### PR TITLE
Added rust-toolchain file pointing to nightly.

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
This is useful for all of us not living on nightly as default.