### PR TITLE
Implemented virtio device detection

### DIFF
--- a/src/arch/x86_64/kernel/pci.rs
+++ b/src/arch/x86_64/kernel/pci.rs
@@ -198,6 +198,9 @@ pub fn init() {
 			if device_vendor_id != u32::MAX {
 				let device_id = (device_vendor_id >> 16) as u16;
 				let vendor_id = device_vendor_id as u16;
+                if (vendor_id == 0x1AF4) {
+                    info!("Found virtio device with device id {}", device_id);
+                }
 
 				adapters.push(PciAdapter::new(bus, device, vendor_id, device_id));
 			}

--- a/src/arch/x86_64/kernel/pci.rs
+++ b/src/arch/x86_64/kernel/pci.rs
@@ -198,9 +198,9 @@ pub fn init() {
 			if device_vendor_id != u32::MAX {
 				let device_id = (device_vendor_id >> 16) as u16;
 				let vendor_id = device_vendor_id as u16;
-                if (vendor_id == 0x1AF4) {
-                    info!("Found virtio device with device id {}", device_id);
-                }
+				if (vendor_id == 0x1AF4) {
+					info!("Found virtio device with device id {}", device_id);
+				}
 
 				adapters.push(PciAdapter::new(bus, device, vendor_id, device_id));
 			}

--- a/src/drivers/net/uhyve.rs
+++ b/src/drivers/net/uhyve.rs
@@ -16,6 +16,8 @@ use synch;
 use syscalls::sys_sem_post;
 
 #[cfg(target_arch = "x86_64")]
+use arch::x86_64::kernel::pci;
+#[cfg(target_arch = "x86_64")]
 use arch::x86_64::kernel::apic;
 #[cfg(target_arch = "x86_64")]
 use arch::x86_64::kernel::irq::*;
@@ -195,6 +197,17 @@ impl UhyveWrite {
 	pub fn len(&self) -> usize {
 		unsafe { read_volatile(&self.len) }
 	}
+}
+
+fn detect_virtio_device() -> Option<pci::PciAdapter> {
+	for i in 0x100..0x103F {
+		let adapter = pci::get_adapter(0x1AF4, i);
+		match adapter {
+			Some(value) => return adapter,
+			None => {},
+		}
+	}
+	None
 }
 
 pub fn init() -> Result<Box<dyn NetworkInterface>, ()> {

--- a/src/drivers/net/uhyve.rs
+++ b/src/drivers/net/uhyve.rs
@@ -16,8 +16,6 @@ use synch;
 use syscalls::sys_sem_post;
 
 #[cfg(target_arch = "x86_64")]
-use arch::x86_64::kernel::pci;
-#[cfg(target_arch = "x86_64")]
 use arch::x86_64::kernel::apic;
 #[cfg(target_arch = "x86_64")]
 use arch::x86_64::kernel::irq::*;
@@ -197,17 +195,6 @@ impl UhyveWrite {
 	pub fn len(&self) -> usize {
 		unsafe { read_volatile(&self.len) }
 	}
-}
-
-fn detect_virtio_device() -> Option<pci::PciAdapter> {
-	for i in 0x100..0x103F {
-		let adapter = pci::get_adapter(0x1AF4, i);
-		match adapter {
-			Some(value) => return adapter,
-			None => {},
-		}
-	}
-	None
 }
 
 pub fn init() -> Result<Box<dyn NetworkInterface>, ()> {


### PR DESCRIPTION
Redoing this PR since last one was merging the wrong branch.

This PR should solve #17 

When detecting PCI devices, we check if the vendor ID is of RedHat virtio (0x1AF4). This closely matches the C code for virtio device detection.

You can test this by running:

```qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio  -kernel loader/target/$(target)-loader/$(rdir)/hermit-loader -initrd tests/target/$(target)/$(rdir)/rusty_tests -cpu qemu64,apic,fsgsbase,pku,rdtscp,xsave,fxsr -netdev user,id=mynet0 -device virtio-net,netdev=mynet0```

You should see a info log saying "Found virtio device with device id $ID"