### PR TITLE
Remove check for uhyve in PCI

### DIFF
--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -232,10 +232,12 @@ pub fn boot_processor_init() {
 	processor::print_information();
 	systemtime::init();
 
-	if environment::is_single_kernel() && !environment::is_uhyve() {
+	if environment::is_single_kernel() {
 		pci::init();
 		pci::print_information();
-		acpi::init();
+		if !environment::is_uhyve() {
+			acpi::init();
+		}
 	}
 
 	apic::init();


### PR DESCRIPTION
This PR is necessary for [this issue](https://github.com/hermitcore/uhyve/issues/1) with [this PR](https://github.com/hermitcore/uhyve/pull/2) to run as it removes the requirement for the running environment to not be uhyve. 