### PR TITLE
Readme: Fix build instructions for Qemu

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ After the installation of [xbuild](https://github.com/rust-osdev/cargo-xbuild), 
 ```bash
 $ git clone https://github.com/hermitcore/rusty-loader.git
 $ cd rusty-loader
-$ cargo xbuild --target x86_64-unknown-hermit-loader.json
+$ make
 ```
 
 Afterwards, the loader is stored in `target/x86_64-unknown-hermit-loader/debug/` as `rusty-loader`.


### PR DESCRIPTION
Use make to be consistent with the gitlab pipeline.
Without the objcpy after building the loader, qemu fails at startup.

I initially wanted to create the pull request for the devel branch, but the Readme at the devel branch seems to be outdated. 