### PR TITLE
CI: Run rusty-hermit demo tests on PRs to libhermit-rs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@ name: Test
 
 on:
   push:
-    branches:
-      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,12 +103,14 @@ jobs:
       - name: Test dev version (smp)
         run:
           qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/debug/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand
+        timeout-minutes: 20  
       - name: Test release version
         run:
           qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand
       - name: Test release version (smp)
         run:
           qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand
+        timeout-minutes: 20  
 
 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,17 +33,17 @@ jobs:
 
 
     steps:
-    - uses: hecrj/setup-rust-action@v1.3.1
-      with: 
-         rust-version: ${{ matrix.rust }}
-         components: ${{ matrix.components || '' }}
-         targets: ${{ matrix.targets || '' }}
-    - uses: actions/checkout@v1
-      with:
-         submodules: true
-    - name: Check Cargo availability
-      run: cargo --version
-    - name: Build
-      run:
-         cargo test
+      - uses: hecrj/setup-rust-action@v1.3.1
+        with:
+          rust-version: ${{ matrix.rust }}
+          components: ${{ matrix.components || '' }}
+          targets: ${{ matrix.targets || '' }}
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+      - name: Check Cargo availability
+        run: cargo --version
+      - name: Build
+        run:
+          cargo test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
             targets: 'x86_64-pc-windows-msvc'
           - os: ubuntu-latest
             rust: 'nightly'
-            components: 'rust-src'
+            components: 'rust-src, llvm-tools-preview'
             targets: 'x86_64-unknown-linux-gnu'
 
 
@@ -38,12 +38,60 @@ jobs:
           rust-version: ${{ matrix.rust }}
           components: ${{ matrix.components || '' }}
           targets: ${{ matrix.targets || '' }}
-      - uses: actions/checkout@v1
+      - name: Checkout rusty-hermit devel
+        uses: actions/checkout@v2
         with:
-          submodules: true
+          repository: 'hermitcore/rusty-hermit'
+          ref: 'devel'
+          submodules: 'true'
+      - name: Remove submodule libhermit-rs
+        run: rm -r libhermit-rs
+        if: ${{ ( matrix.os == 'macOS-latest' ) || ( matrix.os == 'ubuntu-latest' ) }}
+      - name: Remove submodule libhermit-rs (windows)
+        run: git rm -r libhermit-rs
+        if: ${{ matrix.os == 'windows-latest' }}
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: 'libhermit-rs'
       - name: Check Cargo availability
         run: cargo --version
-      - name: Build
+      - name: Cargo Test libhermit-rs
+        run: cargo test
+        working-directory: libhermit-rs
+      - name: Install cargo-download
+        run: cargo install cargo-download
+      - name: Install xbuild
+        run: cargo install cargo-xbuild
+      - name: Install qemu/nasm
+        run: sudo apt-get update --fix-missing && sudo apt-get install qemu-system-x86 nasm
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+      - name: Building dev version
         run:
-          cargo test
+          cargo build -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit
+      - name: Building release version
+        run:
+          cargo build -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit --release
+      - name: Build loader
+        run:
+          cd loader && make
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+      - name: Test dev version
+        run:
+          qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/debug/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+      - name: Test dev version (smp)
+        run:
+          qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/debug/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+      - name: Test release version
+        run:
+          qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+      - name: Test release version (smp)
+        run:
+          qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+
+
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,11 +20,11 @@ jobs:
         include:
           - os: macOS-latest
             rust: 'nightly'
-            components: 'rust-src'
+            components: 'rust-src, llvm-tools-preview'
             targets: 'x86_64-apple-darwin'
           - os: windows-latest
             rust: 'nightly'
-            components: 'rust-src'
+            components: 'rust-src, llvm-tools-preview'
             targets: 'x86_64-pc-windows-msvc'
           - os: ubuntu-latest
             rust: 'nightly'
@@ -61,37 +61,54 @@ jobs:
         working-directory: libhermit-rs
       - name: Install cargo-download
         run: cargo install cargo-download
-      - name: Install xbuild
-        run: cargo install cargo-xbuild
-      - name: Install qemu/nasm
+      - name: Install qemu/nasm (apt)
         run: sudo apt-get update --fix-missing && sudo apt-get install qemu-system-x86 nasm
         if: ${{ matrix.os == 'ubuntu-latest' }}
+      # Note: The add-path must be kept in sync with the version of binutils installed by homebrew
+      - name: Install qemu/nasm/binutils (macos)
+        run: |
+          brew update && brew install qemu nasm binutils
+          echo "::add-path::/usr/local/Cellar/binutils/2.34/bin/"
+        if: ${{ matrix.os == 'macOS-latest' }}
+      - name: Install qemu/nasm (windows)
+        run: |
+          choco install qemu nasm
+          echo "::add-path::C:\Program Files\NASM"
+          echo "::add-path::C:\Program Files\qemu"
+        if: ${{ matrix.os == 'windows-latest' }}
       - name: Building dev version
         run:
           cargo build -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit
       - name: Building release version
         run:
           cargo build -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit --release
-      - name: Build loader
-        run:
-          cd loader && make
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+      - name: Build loader (unix)
+        working-directory: loader
+        run: make
+        if: ${{ ( matrix.os == 'macOS-latest' ) || ( matrix.os == 'ubuntu-latest' ) }}
+      # Workaround since makefile doesn't work when using powershell
+      - name: Build loader (windows)
+        working-directory: loader
+        run: |
+          cargo build -Z build-std=core,alloc --target x86_64-unknown-hermit-loader.json
+          $VAR_RUSTC_SYSROOT = (rustc --print sysroot)
+          echo "Sysroot - $VAR_RUSTC_SYSROOT"
+          $LLVM_OBJCOPY = ((Get-ChildItem -Path $VAR_RUSTC_SYSROOT -Include llvm-objcopy.exe -File -Recurse -ErrorAction SilentlyContinue)).Fullname
+          echo "LLVM Objcopy - $LLVM_OBJCOPY"
+          Invoke-Expression "$LLVM_OBJCOPY --strip-debug -O elf32-i386 target/x86_64-unknown-hermit-loader/debug/rusty-loader"
+        if: ${{ matrix.os == 'windows-latest' }}
       - name: Test dev version
         run:
           qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/debug/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand
-        if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Test dev version (smp)
         run:
           qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/debug/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand
-        if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Test release version
         run:
           qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand
-        if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Test release version (smp)
         run:
           qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand
-        if: ${{ matrix.os == 'ubuntu-latest' }}
 
 
 


### PR DESCRIPTION
Update: This PR is ready for review.


I think the rusty-hermit demo should be run here as a test. Right now we only check if PRs compile and do a quick cargo test. Checking if the rusty-hermit demo is able to run succesfully improves the testing situation.

Changes: 
- Run the rusty-hermit demo (see rusty-hermit repo) on PRs and all pushes 
- Add support for running the demo with qemu on windows and macOS ~~( SMP doesn't work consistently, but thats a different issue - https://github.com/hermitcore/rusty-hermit/issues/12~~ issue solved with 34114700c13a8c34808a5cfd699dd1e20b7796bc)
- ~~Workaround build failing by using old nightly (see also https://github.com/hermitcore/rusty-hermit/issues/7~~ This was fixed by disabling lto in rusty-hemit)