### PR TITLE
Add new kernel-command-line option for setting argv

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ $ qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio  -kernel path_to_
 
 It is important to enable the processor features _fsgsbase_ and _rdtscp_ because it is a prerequisite to boot RustyHermit.
 
+You can provide arguments to the application via the kernel commandline, which you can set with qemu's `-append` option. Since both the kernel and the application can have parameters, they are separated with `--`:
+
+```bash
+qemu-system-x86_64 ... -append "kernel-arguments -- application-arguments"
+```
+
 #### Using virtio-fs
 
 The Kernel has rudimentary support for the virtio-fs shared file system. Currently only files, no folders are supported. To use it, you have to run a virtio-fs daemon and start qemu as described in [Standalone virtio-fs usage](https://virtio-fs.gitlab.io/howto-qemu.html):

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -21,12 +21,13 @@ pub use arch::aarch64::kernel::{
 };
 
 use alloc::string::String;
+use alloc::vec::Vec;
 use core::{slice, str};
 use util;
 
 static mut COMMAND_LINE_CPU_FREQUENCY: u16 = 0;
 static mut IS_PROXY: bool = false;
-static mut COMMAND_LINE_APPLICATION: Option<String> = None;
+static mut COMMAND_LINE_APPLICATION: Option<Vec<String>> = None;
 static mut COMMAND_LINE_PATH: Option<String> = None;
 
 unsafe fn parse_command_line() {
@@ -57,9 +58,10 @@ unsafe fn parse_command_line() {
 				"-proxy" => {
 					IS_PROXY = true;
 				}
-				"-args" => {
-					let argv = tokeniter.next().expect("Invalid -args command line");
-					COMMAND_LINE_APPLICATION = Some(argv);
+				"--" => {
+					// Collect remaining arguments as applications argv
+					COMMAND_LINE_APPLICATION = Some(tokeniter.collect());
+					break;
 				}
 				_ if COMMAND_LINE_PATH.is_none() => {
 					// Qemu passes in the kernel path (rusty-loader) as first argument
@@ -75,8 +77,8 @@ unsafe fn parse_command_line() {
 	}
 }
 
-/// Returns the cmdline argument passed in with "-args"
-pub fn get_command_line_argv() -> Option<&'static str> {
+/// Returns the cmdline argument passed in after "--"
+pub fn get_command_line_argv() -> Option<&'static [String]> {
 	unsafe { COMMAND_LINE_APPLICATION.as_deref() }
 }
 

--- a/src/syscalls/interfaces/mod.rs
+++ b/src/syscalls/interfaces/mod.rs
@@ -98,11 +98,9 @@ pub trait SyscallInterface: Send + Sync {
 		argv.push(name);
 
 		if let Some(args) = environment::get_command_line_argv() {
-			let tokens = util::tokenize(args, ' ');
-			debug!("Parsed argv as: {:?}", tokens);
-			for mut t in tokens {
-				t.push('\0');
-				let ptr = Box::leak(t.into_boxed_str()).as_ptr();
+			debug!("Setting argv as: {:?}", args);
+			for a in args {
+				let ptr = Box::leak(format!("{}\0", a).into_boxed_str()).as_ptr();
 				argv.push(ptr);
 			}
 		}

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,6 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use alloc::string::String;
+use alloc::vec::Vec;
 
 /// Gets length of null terminated c string.
 /// UNSAFE. Caller has to assert that string is null terminated!
@@ -40,4 +41,76 @@ pub fn c_strbuflen(c_strbuf: &[u8]) -> usize {
 pub fn c_buf_to_str(c_strbuf: &[u8]) -> &str {
 	let len = c_strbuflen(c_strbuf);
 	core::str::from_utf8(&c_strbuf[0..len]).unwrap().into()
+}
+
+/// Splits a string at delimiter, except when its quoted with " or '. Useful for cmdline arguments.
+/// Returns a vector of the split arguments, unquoted and unescaped.
+pub fn tokenize(cmdline: &str, delimiter: char) -> Vec<String> {
+	let mut current_token = String::with_capacity(cmdline.len());
+	let mut chars = cmdline.chars();
+	let mut tokens: Vec<String> = Vec::new();
+
+	loop {
+		// We have to use loop instead of for, since we advance the iterator in the loop during unquoting
+		if let Some(c) = chars.next() {
+			match c {
+				_ if c == delimiter => {
+					if current_token.len() > 0 {
+						tokens.push(current_token.clone());
+						current_token.clear();
+					}
+				}
+				'"' | '\'' => {
+					// Begin quoted string. Unquote will advance iterator!
+					if let Ok(val) = unquote(c, &mut chars) {
+						current_token.push_str(&val);
+					}
+				}
+				_ => {
+					current_token.push(c);
+				}
+			};
+		} else {
+			if current_token.len() > 0 {
+				tokens.push(current_token);
+			}
+			break;
+		}
+	}
+	return tokens;
+}
+
+/// Very simple unquote function for a string with unknown end. Used in conjunction with tokenize for parsing argument lists.
+/// String is assumed to be ending with delimiter, but not starting, since the tokenize() already consumed the starting delimiter from the iterator.
+/// Delimiter and a few common chars such as newline can be escaped with `\`
+pub fn unquote(
+	delimiter: char,
+	chars: &mut impl Iterator<Item = char>,
+) -> Result<String, &'static str> {
+	let mut in_escape = false;
+	let mut unquoted = String::with_capacity(255); // Avoid too many reallocs
+
+	for x in chars {
+		if in_escape {
+			in_escape = false;
+			unquoted.push(match x {
+				'"' => '"',
+				'\'' => '\'',
+				'n' => '\n',
+				'r' => '\r',
+				't' => '\t',
+				'\\' => '\\',
+				_ if x == delimiter => delimiter,
+				_ => return Err("Invalid escape char!"),
+			});
+		} else if x == '\\' {
+			in_escape = true;
+		} else if x == delimiter {
+			// We reached the end of the quoted-string
+			return Ok(unquoted);
+		} else {
+			unquoted.push(x);
+		}
+	}
+	Err("Missing end-quote!")
 }


### PR DESCRIPTION
I was annoyed with having to recompile my benchmark each time I wanted to change some options, so I implemented a new kernel-command-line option to set argv/c.

Previously, there were only `-freq` and `-proxy`, both set some kernel-internal stuff.

This pull request adds a new option `-args`. Since I did not want it to clash with any existing (or future) options which might get introduced, I wrote a simple "tokenizer" which can handle splitting strings at spaces while respecting quoted strings.

Exampe cmdline:
```
qemu-system-x86_64 -cpu qemu64,fsgsbase,rdtscp,xsave,fxsr,+x2apic -enable-kvm \
 -display none -smp 1 -m 1G -serial stdio -kernel LOADER -initrd APP \
 -append "-args '-a -b --opt \"some string\"'"

--> argv = ["{name}", "-a", "-b", "--opt", "some string"]
```

If you want to have a `"` inside an argument, the escaping is a bit awkward since we have a string in a string in a string. Consider calling bash-like `rusty-demo "test\" string" -v`. Starting the kernel with qemu we need to escape as follows:
- bash: `qemu-system-x86_64 .... -append "... -args '\"test\\\\\" string\" -v'"`
- qemu `argv[-2:-1]`: `[-append, ... -args '"test\\" string" -v']`
- libhermit kernel-cmdline tokens: `[..., -args, "test\" string" -v]`
- rusty-demo argv = `[test" string, -v]` 

I am not sure if uhyve currently supports setting the command line, I just had a quick look and it seems it is not supported there.
