### PR TITLE
Scheduler: Improve Error message when Memory allocation fails

### DIFF
--- a/src/arch/x86_64/kernel/scheduler.rs
+++ b/src/arch/x86_64/kernel/scheduler.rs
@@ -88,9 +88,10 @@ impl TaskStacks {
 			align_up!(size, BasePageSize::SIZE)
 		};
 		let total_size = user_stack_size + DEFAULT_STACK_SIZE + KERNEL_STACK_SIZE;
-		let virt_addr =
-			::arch::mm::virtualmem::allocate(total_size + 4 * BasePageSize::SIZE).unwrap();
-		let phys_addr = ::arch::mm::physicalmem::allocate(total_size).unwrap();
+		let virt_addr = ::arch::mm::virtualmem::allocate(total_size + 4 * BasePageSize::SIZE)
+			.expect("Failed to allocate Virtual Memory for TaskStacks");
+		let phys_addr = ::arch::mm::physicalmem::allocate(total_size)
+			.expect("Failed to allocate Physical Memory for TaskStacks");
 
 		debug!(
 			"Create stacks at {:#X} with a size of {} KB",


### PR DESCRIPTION
This commit aims to improve the Error message when panicing after Allocation of Memory for the TaskStacks has failed. This should make it clearer to a User, that increasing the amount of memory the Machine has will solve this problem. 
The current panic message is `thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ()', src\arch\x86_64\kernel\scheduler.rs:92:25` which doesn't say much without looking at the Code.

Since `expect` is basically `unwrap` with a custom Error message, this shouldn't have any performance implications.