### PR TITLE
Cleanup of pci.rs

### DIFF
--- a/src/arch/x86_64/kernel/virtio.rs
+++ b/src/arch/x86_64/kernel/virtio.rs
@@ -14,8 +14,7 @@ use arch::x86_64::kernel::percore::core_scheduler;
 use arch::x86_64::kernel::virtio_fs;
 use arch::x86_64::kernel::virtio_net;
 
-use arch::x86_64::mm::paging::{BasePageSize, PageSize};
-use arch::x86_64::mm::{paging, virtualmem};
+use arch::x86_64::mm::paging;
 
 use alloc::boxed::Box;
 use alloc::rc::Rc;
@@ -771,72 +770,40 @@ pub fn map_virtiocap(
 	};
 	// Since we have verified caplistoffset to be virtio_pci_cap common config, read fields.
 	// TODO: cleanup 'hacky' type conversions
-	let bar: usize = (pci::read_config(bus, device, virtiocapoffset + 4) & 0xFF) as usize; // get offset_of!(virtio_pci_cap, bar)
+	let baridx: u8 = (pci::read_config(bus, device, virtiocapoffset + 4) & 0xFF) as u8; // get offset_of!(virtio_pci_cap, bar)
 	let offset: usize = pci::read_config(bus, device, virtiocapoffset + 8) as usize; // get offset_of!(virtio_pci_cap, offset)
 	let length: usize = pci::read_config(bus, device, virtiocapoffset + 12) as usize; // get offset_of!(virtio_pci_cap, length)
 	debug!(
 		"Found virtio config bar as 0x{:x}, offset 0x{:x}, length 0x{:x}",
-		bar, offset, length
+		baridx, offset, length
 	);
 
-	if (adapter.base_sizes[bar] as usize) < offset + length {
-		error!(
-			"virtio config struct does not fit in bar! Aborting! 0x{:x} < 0x{:x}",
-			adapter.base_sizes[bar],
-			offset + length
-		);
-		return None;
-	}
-
-	// base_addresses from bar are IOBASE?
-	// TODO: do proper memmapped bars in pci.rs
-	let barword = pci::read_config(bus, device, pci::PCI_BAR0_REGISTER + ((bar as u32) << 2));
-	debug!("Found bar{} as 0x{:x}", bar, barword);
-	assert!(barword & 1 == 0, "Not an memory mapped bar!");
-
-	let bartype = (barword >> 1) & 0b11;
-	assert!(bartype == 2, "Not a 64 bit bar!");
-
-	let prefetchable = (barword >> 3) & 1;
-	assert!(prefetchable == 1, "Bar not prefetchable, but 64 bit!");
-
-	let barwordhigh = pci::read_config(
-		bus,
-		device,
-		pci::PCI_BAR0_REGISTER + (((bar + 1) as u32) << 2),
-	);
-	//let barbase = barwordhigh << 33; // creates general protection fault... only when shifting by >=32 though..
-	let barbase: usize = ((barwordhigh as usize) << 32) + (barword & 0xFFFF_FFF0) as usize;
-
-	debug!(
-		"Mapping bar {} at 0x{:x} with length 0x{:x}",
-		bar, barbase, length
-	);
 	// corrosponding setup in eg Qemu @ https://github.com/qemu/qemu/blob/master/hw/virtio/virtio-pci.c#L1590 (virtio_pci_device_plugged)
-	// map 1 page (0x1000?) TODO: map "length"!
-	// for virtio-fs we are "lucky" and each cap is exactly one page (contiguous, but we dont care, map each on its own)
-	let membase = barbase as *mut u8;
-	let capbase = unsafe { membase.offset(offset as isize) as usize };
-	let virtualcapaddr = virtualmem::allocate(BasePageSize::SIZE).unwrap();
-	let mut flags = paging::PageTableEntryFlags::empty();
-	flags.device().writable().execute_disable();
-	paging::map::<BasePageSize>(virtualcapaddr, capbase, 1, flags);
+	if let Some((virtualbaraddr, size)) = adapter.memory_map_bar(baridx, false) {
+		let virtualcapaddr = virtualbaraddr + offset;
 
-	/*
-		let mut slice = unsafe {
-				core::slice::from_raw_parts_mut(membase.offset(offset as isize), length)
-		};
-		info!("{:?}", slice);
-	*/
-	if virtiocaptype == VIRTIO_PCI_CAP_NOTIFY_CFG {
-		let notify_off_multiplier: u32 = pci::read_config(bus, device, virtiocapoffset + 16); // get offset_of!(virtio_pci_notify_cap, notify_off_multiplier)
-		Some((virtualcapaddr, notify_off_multiplier))
+		if size < offset + length {
+			error!(
+				"virtio config struct does not fit in bar! Aborting! 0x{:x} < 0x{:x}",
+				size,
+				offset + length
+			);
+			return None;
+		}
+
+		if virtiocaptype == VIRTIO_PCI_CAP_NOTIFY_CFG {
+			let notify_off_multiplier: u32 = pci::read_config(bus, device, virtiocapoffset + 16); // get offset_of!(virtio_pci_notify_cap, notify_off_multiplier)
+			Some((virtualcapaddr, notify_off_multiplier))
+		} else {
+			Some((virtualcapaddr, 0))
+		}
 	} else {
-		Some((virtualcapaddr, 0))
+		warn!("Could not map virtio-cap-bar!");
+		None
 	}
 }
 
-pub fn init_virtio_device(adapter: pci::PciAdapter) {
+pub fn init_virtio_device(adapter: &pci::PciAdapter) {
 	// TODO: 2.3.1: Loop until get_config_generation static, since it might change mid-read
 
 	match adapter.device_id {

--- a/src/arch/x86_64/kernel/virtio.rs
+++ b/src/arch/x86_64/kernel/virtio.rs
@@ -779,7 +779,7 @@ pub fn map_virtiocap(
 	);
 
 	// corrosponding setup in eg Qemu @ https://github.com/qemu/qemu/blob/master/hw/virtio/virtio-pci.c#L1590 (virtio_pci_device_plugged)
-	if let Some((virtualbaraddr, size)) = adapter.memory_map_bar(baridx, false) {
+	if let Some((virtualbaraddr, size)) = adapter.memory_map_bar(baridx, true) {
 		let virtualcapaddr = virtualbaraddr + offset;
 
 		if size < offset + length {

--- a/src/arch/x86_64/kernel/virtio_fs.rs
+++ b/src/arch/x86_64/kernel/virtio_fs.rs
@@ -237,7 +237,7 @@ impl FuseInterface for VirtioFsDriver<'_> {
 }
 
 pub fn create_virtiofs_driver(
-	adapter: pci::PciAdapter,
+	adapter: &pci::PciAdapter,
 ) -> Option<Rc<RefCell<VirtioFsDriver<'static>>>> {
 	// Scan capabilities to get common config, which we need to reset the device and get basic info.
 	// also see https://elixir.bootlin.com/linux/latest/source/drivers/virtio/virtio_pci_modern.c#L581 (virtio_pci_modern_probe)
@@ -257,7 +257,7 @@ pub fn create_virtiofs_driver(
 
 	// get common config mapped, cast to virtio_pci_common_cfg
 	let common_cfg =
-		match virtio::map_virtiocap(bus, device, &adapter, caplist, VIRTIO_PCI_CAP_COMMON_CFG) {
+		match virtio::map_virtiocap(bus, device, adapter, caplist, VIRTIO_PCI_CAP_COMMON_CFG) {
 			Some((cap_common_raw, _)) => unsafe {
 				&mut *(cap_common_raw as *mut virtio_pci_common_cfg)
 			},
@@ -268,7 +268,7 @@ pub fn create_virtiofs_driver(
 		};
 	// get device config mapped, cast to virtio_fs_config
 	let device_cfg =
-		match virtio::map_virtiocap(bus, device, &adapter, caplist, VIRTIO_PCI_CAP_DEVICE_CFG) {
+		match virtio::map_virtiocap(bus, device, adapter, caplist, VIRTIO_PCI_CAP_DEVICE_CFG) {
 			Some((cap_device_raw, _)) => unsafe { &mut *(cap_device_raw as *mut virtio_fs_config) },
 			None => {
 				error!("Could not find VIRTIO_PCI_CAP_DEVICE_CFG. Aborting!");
@@ -277,7 +277,7 @@ pub fn create_virtiofs_driver(
 		};
 	// get device notifications mapped
 	let (notification_ptr, notify_off_multiplier) =
-		match virtio::map_virtiocap(bus, device, &adapter, caplist, VIRTIO_PCI_CAP_NOTIFY_CFG) {
+		match virtio::map_virtiocap(bus, device, adapter, caplist, VIRTIO_PCI_CAP_NOTIFY_CFG) {
 			Some((cap_notification_raw, notify_off_multiplier)) => {
 				(
 					cap_notification_raw as *mut u16, // unsafe { core::slice::from_raw_parts_mut::<u16>(...)}

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -31,7 +31,6 @@ pub use self::tasks::*;
 pub use self::timer::*;
 #[cfg(not(test))]
 use crate::{__sys_free, __sys_malloc, __sys_realloc};
-use arch::kernel::pci::find_adapter;
 
 use drivers::net::*;
 use environment;
@@ -82,15 +81,6 @@ pub extern "C" fn sys_realloc(ptr: *mut u8, size: usize, align: usize, new_size:
 #[no_mangle]
 pub extern "C" fn sys_free(ptr: *mut u8, size: usize, align: usize) {
 	__sys_free(ptr, size, align)
-}
-
-#[no_mangle]
-pub fn sys_pci_find_adapter(
-	vendor_id: u16,
-	class_id: u8,
-	subclass_id: u8,
-) -> Option<([u32; 6], u8)> {
-	kernel_function!(find_adapter(vendor_id, class_id, subclass_id))
 }
 
 pub fn get_application_parameters() -> (i32, *const *const u8, *const *const u8) {


### PR DESCRIPTION
I have refactored pci.rs a bit. Changes:

- handle both IOSpace and 32/64-bit Memory BARs
- add generic function to mm: map(), which maps a physical buffer to a newly allocated virtual address range, used for mmaping memory bars
- add function to memory map the PCI memory bars
- check pci device header-type to ensure we don't read/write garbage, warn on multifunction devices
- remove sys_pci_find_adapter, since it is not used anywhere
    - I am unsure of its original purpose, since I did not find any reference in newlib/hermit-abi. Does it have a current / planned future use?

Previously, virtio mapped the pci bars with the `Cache Disable` page-flag set. Since @stlankes introduced memory barriers, this should no longer be needed.

I have not tested these changes with virtio-net, only virtio-fs. Is there an easy way to also test virtio-net?

As an improvement we could potentially cache the result of `memory_map_bar`, but since virtual address space is huge I feel this is a non-issue. Currently virtio will map a bar of size ~5kb up to 5 times, since its capabilities are all next to each other in the same bar, but mapped separately.