### PR TITLE
CI: Test libhermit-rs on uhyve with rusty-demo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,54 @@
+language: rust
+rust:
+  - nightly
+os: linux
+dist: bionic
+cache:
+  cargo: true # This caches $HOME/.cargo and $TRAVIS_BUILD_DIR/target (The latter is not used here)
+
+before_install:
+  - sudo apt-get install -y qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils
+  - sudo adduser $USER libvirt
+  - sudo adduser $USER kvm
+  - cargo install cargo-download
+  - rustup component add rust-src
+  - rustup component add llvm-tools-preview
+  - cargo install uhyve
+install:
+  - ls -l
+  - if [ -d "$HOME/tmp_libhermit-rs" ]; then rm -rf $HOME/tmp_libhermit-rs; fi
+  - mkdir $HOME/tmp_libhermit-rs
+  - shopt -s dotglob nullglob && mv ./* $HOME/tmp_libhermit-rs
+  # If for some reason target exists (due to a bad cache) then delete it.
+  - if [ -d "$HOME/tmp_libhermit-rs/target" ]; then rm -rf $HOME/tmp_libhermit-rs/target; fi
+  - git clone https://github.com/hermitcore/rusty-hermit.git
+  - cd rusty-hermit
+  - git checkout devel
+  - echo "rusty-hermit at commit $(git rev-parse HEAD)"
+  # Ensure that libhermit-rs is empty - This shouldn't be necessary since we don't initialize the submodules
+  # But let's do it anyway to be safe
+  - if [ -d "$TRAVIS_BUILD_DIR/rusty-hermit/libhermit-rs" ]; then rm -rf $TRAVIS_BUILD_DIR/rusty-hermit/libhermit-rs; fi
+  - mkdir $TRAVIS_BUILD_DIR/rusty-hermit/libhermit-rs
+  - shopt -s dotglob nullglob && mv $HOME/tmp_libhermit-rs/* $TRAVIS_BUILD_DIR/rusty-hermit/libhermit-rs/.
+  - ls -l --all libhermit-rs
+  - rustc --version
+  - cargo --version
+  - uhyve --version
+jobs:
+  include:
+    - stage: Test
+      name: "Test Debug build"
+      script:
+        - cd $TRAVIS_BUILD_DIR/rusty-hermit
+        - cargo build -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit
+        # used to get terminal with new groups permissions while preserving own user
+        - sudo -E sudo -u $USER -E bash -c "HERMIT_VERBOSE=1 $HOME/.cargo/bin/uhyve target/x86_64-unknown-hermit/debug/rusty_demo"
+        - sudo -E sudo -u $USER -E bash -c "HERMIT_VERBOSE=1 HERMIT_CPUS=2 $HOME/.cargo/bin/uhyve target/x86_64-unknown-hermit/debug/rusty_demo"
+
+    - name: "Test Release Build"
+      script:
+        - cd $TRAVIS_BUILD_DIR/rusty-hermit
+        - cargo build -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit --release
+        - sudo -E sudo -u $USER -E bash -c "HERMIT_VERBOSE=1 $HOME/.cargo/bin/uhyve target/x86_64-unknown-hermit/release/rusty_demo"
+        - sudo -E sudo -u $USER -E bash -c "HERMIT_VERBOSE=1 HERMIT_CPUS=2 $HOME/.cargo/bin/uhyve target/x86_64-unknown-hermit/release/rusty_demo"
+


### PR DESCRIPTION
This commits adds testing of `libhermit-rs` for pushes and PRs. Both debug and release builds are tested with 1 and 2 cores each.
Tests are done via the rusty-hermit demo in rusty-hermit. rusty-hermit is cloned and checked out to the devel branch. The demo is then compiled with the version of libhermit-rs that triggered the build and not the version specified as a submodule in rusty-hermit.

rusty-hermit including libhermit-rs is compiled fresh every time, but cargo dependencies such as uhyve and cargo-download are cached to speed up build time