### PR TITLE
Log: Add option to set LevelFilter at compile time

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -34,7 +34,18 @@ impl log::Log for KernelLogger {
 
 pub fn init() {
 	set_logger(&KernelLogger).expect("Can't initialize logger");
-	set_max_level(LevelFilter::Info);
+	// Determines LevelFilter at compile time
+	let log_level: Option<&'static str> = option_env!("HERMIT_LOG_LEVEL_FILTER");
+	let max_level: LevelFilter = match log_level {
+		Some("Error") => LevelFilter::Error,
+		Some("Debug") => LevelFilter::Debug,
+		Some("Off") => LevelFilter::Off,
+		Some("Trace") => LevelFilter::Trace,
+		Some("Warn") => LevelFilter::Warn,
+		Some("Info") => LevelFilter::Info,
+		_ => LevelFilter::Info,
+	};
+	set_max_level(max_level);
 }
 
 macro_rules! infoheader {


### PR DESCRIPTION
Adds support to change the LevelFilter of the logger at compile time via enviroment variable `HERMIT_LOG_LEVEL_FILTER`. 
If the Environment variable is not set, or the name doesn't match, then `LevelFilter::Info` is used by default, which is the same as it was before.
The name of the Environment variable is arbitrary of course, so feel free to suggest other names.
