### PR TITLE
remove dependency to lazy_static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,14 +26,6 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,7 +145,6 @@ name = "rusty-hermit"
 version = "0.3.30"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "multiboot 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -173,11 +164,6 @@ dependencies = [
 [[package]]
 name = "semver-parser"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "spin"
-version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -211,7 +197,6 @@ dependencies = [
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum cc 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)" = "404b1fe4f65288577753b17e3b36a04596ee784493ec249bf81c7f2d2acd751c"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum multiboot 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "745e351d4f128ea9e266fe2dd04a1bd7349c60441d45ec8677520bae08e25d43"
 "checksum num 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
@@ -227,7 +212,6 @@ dependencies = [
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum syn 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)" = "1425de3c33b0941002740a420b1a906a350b88d08b82b2c8a01035a3f9447bac"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum x86 0.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2786ac694ed572ab5d2bbcd9e188805dba26b3501973dd69718914fb3d4a5a69"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ acpi = []
 bitflags = "1.2"
 #cfg-if = "0.1"
 #byteorder = { version = "1.0", default-features = false }
-lazy_static = { version = "1.4.0", default-features = false, features = ["spin_no_std"] }
 num-derive = "0.3"
 
 [dependencies.num]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
 #![allow(clippy::forget_copy)]
 #![feature(abi_x86_interrupt)]
 #![feature(allocator_api)]
+#![feature(const_btree_new)]
 #![feature(const_fn)]
 #![feature(lang_items)]
 #![feature(linkage)]
@@ -51,8 +52,6 @@ extern crate multiboot;
 extern crate x86;
 #[macro_use]
 extern crate log;
-#[macro_use]
-extern crate lazy_static;
 extern crate num;
 #[macro_use]
 extern crate num_derive;

--- a/src/syscalls/fs.rs
+++ b/src/syscalls/fs.rs
@@ -51,9 +51,7 @@ TODO:
 */
 
 // TODO: lazy static could be replaced with explicit init on OS boot.
-lazy_static! {
-	pub static ref FILESYSTEM: Spinlock<Filesystem> = Spinlock::new(Filesystem::new());
-}
+pub static FILESYSTEM: Spinlock<Filesystem> = Spinlock::new(Filesystem::new());
 
 pub struct Filesystem {
 	// Keep track of mount-points
@@ -64,7 +62,7 @@ pub struct Filesystem {
 }
 
 impl Filesystem {
-	pub fn new() -> Self {
+	pub const fn new() -> Self {
 		Self {
 			mounts: BTreeMap::new(),
 			files: BTreeMap::new(),


### PR DESCRIPTION
- requires PR rust-lang/rust#71839
- consequently, the latest nightly compiler has to be used