### PR TITLE
remove obsolete init function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,6 @@ fn boot_processor_main() -> ! {
 	);
 
 	arch::boot_processor_init();
-	scheduler::init();
 	scheduler::add_current_core();
 
 	if environment::is_single_kernel() && !environment::is_uhyve() {

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -504,8 +504,6 @@ fn get_tid() -> TaskId {
 	}
 }
 
-pub fn init() {}
-
 #[inline]
 pub fn abort() {
 	core_scheduler().exit(-1);


### PR DESCRIPTION
scheduler::init has nothing to do and can be removed