### PR TITLE
Refactor libhermit-rs for rust edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 keywords = ["unikernel", "libos"]
 categories = ["os"]
 repository = "https://github.com/hermitcore/libhermit-rs"
+edition = "2018"
 description = """
 RustyHermit - A Rust-based, lightweight unikernel
 """

--- a/src/arch/aarch64/kernel/mod.rs
+++ b/src/arch/aarch64/kernel/mod.rs
@@ -16,14 +16,14 @@ pub mod serial;
 pub mod stubs;
 pub mod systemtime;
 
-use arch::aarch64::kernel::percore::*;
-use arch::aarch64::kernel::serial::SerialPort;
-pub use arch::aarch64::kernel::stubs::*;
-pub use arch::aarch64::kernel::systemtime::get_boot_time;
+use crate::arch::aarch64::kernel::percore::*;
+use crate::arch::aarch64::kernel::serial::SerialPort;
+pub use crate::arch::aarch64::kernel::stubs::*;
+pub use crate::arch::aarch64::kernel::systemtime::get_boot_time;
+use crate::environment;
+use crate::kernel_message_buffer;
+use crate::synch::spinlock::Spinlock;
 use core::ptr;
-use environment;
-use kernel_message_buffer;
-use synch::spinlock::Spinlock;
 
 const SERIAL_PORT_BAUDRATE: u32 = 115200;
 

--- a/src/arch/aarch64/kernel/percore.rs
+++ b/src/arch/aarch64/kernel/percore.rs
@@ -5,8 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::scheduler::PerCoreScheduler;
 use core::ptr;
-use scheduler::PerCoreScheduler;
 
 #[no_mangle]
 pub static mut PERCORE: PerCoreVariables = PerCoreVariables::new(0);

--- a/src/arch/aarch64/kernel/scheduler.rs
+++ b/src/arch/aarch64/kernel/scheduler.rs
@@ -26,12 +26,12 @@
 
 include!(concat!(env!("CARGO_TARGET_DIR"), "/config.rs"));
 
+use crate::arch::aarch64::kernel::percore::*;
+use crate::arch::aarch64::kernel::processor;
+use crate::scheduler::task::{Task, TaskFrame, TaskTLS};
 use alloc::rc::Rc;
-use arch::aarch64::kernel::percore::*;
-use arch::aarch64::kernel::processor;
 use core::cell::RefCell;
 use core::{mem, ptr};
-use scheduler::task::{Task, TaskFrame, TaskTLS};
 
 extern "C" {
 	static tls_start: u8;

--- a/src/arch/aarch64/kernel/serial.rs
+++ b/src/arch/aarch64/kernel/serial.rs
@@ -24,12 +24,12 @@ impl SerialPort {
 		// LF newline characters need to be extended to CRLF over a real serial port.
 		if byte == b'\n' {
 			unsafe {
-				volatile_store(port, b'\r');
+				std::ptr::write_volatile(port, b'\r');
 			}
 		}
 
 		unsafe {
-			volatile_store(port, byte);
+			std::ptr::write_volatile(port, byte);
 		}
 	}
 

--- a/src/arch/aarch64/kernel/systemtime.rs
+++ b/src/arch/aarch64/kernel/systemtime.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use environment;
+use crate::environment;
 
 extern "C" {
 	static mut boot_gtod: u64;

--- a/src/arch/aarch64/mm/paging.rs
+++ b/src/arch/aarch64/mm/paging.rs
@@ -5,14 +5,14 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch::aarch64::kernel::percore::*;
-use arch::aarch64::kernel::processor;
-use arch::aarch64::mm::physicalmem;
-use arch::aarch64::mm::virtualmem;
+use crate::arch::aarch64::kernel::percore::*;
+use crate::arch::aarch64::kernel::processor;
+use crate::arch::aarch64::mm::physicalmem;
+use crate::arch::aarch64::mm::virtualmem;
+use crate::mm;
+use crate::scheduler;
 use core::marker::PhantomData;
 use core::{fmt, ptr, usize};
-use mm;
-use scheduler;
 
 extern "C" {
 	#[linkage = "extern_weak"]

--- a/src/arch/aarch64/mm/physicalmem.rs
+++ b/src/arch/aarch64/mm/physicalmem.rs
@@ -5,11 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch::aarch64::mm::paging::{BasePageSize, PageSize};
-use collections::Node;
-use mm;
-use mm::freelist::{FreeList, FreeListEntry};
-use mm::{MM_LOCK, POOL};
+use crate::arch::aarch64::mm::paging::{BasePageSize, PageSize};
+use crate::collections::Node;
+use crate::mm;
+use crate::mm::freelist::{FreeList, FreeListEntry};
+use crate::mm::{MM_LOCK, POOL};
 
 extern "C" {
 	static limit: usize;

--- a/src/arch/aarch64/mm/virtualmem.rs
+++ b/src/arch/aarch64/mm/virtualmem.rs
@@ -5,11 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch::aarch64::mm::paging::{BasePageSize, PageSize};
-use collections::Node;
-use mm;
-use mm::freelist::{FreeList, FreeListEntry};
-use mm::{MM_LOCK, POOL};
+use crate::arch::aarch64::mm::paging::{BasePageSize, PageSize};
+use crate::collections::Node;
+use crate::mm;
+use crate::mm::freelist::{FreeList, FreeListEntry};
+use crate::mm::{MM_LOCK, POOL};
 
 static mut KERNEL_FREE_LIST: FreeList = FreeList::new();
 

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -15,58 +15,60 @@ pub mod x86_64;
 
 // Export our platform-specific modules.
 #[cfg(target_arch = "aarch64")]
-pub use arch::aarch64::*;
+pub use crate::arch::aarch64::*;
 
 #[cfg(target_arch = "aarch64")]
-pub use arch::aarch64::kernel::stubs::{set_oneshot_timer, switch, wakeup_core};
+pub use crate::arch::aarch64::kernel::stubs::{set_oneshot_timer, switch, wakeup_core};
 
 #[cfg(target_arch = "aarch64")]
-pub use arch::aarch64::kernel::{
+pub use crate::arch::aarch64::kernel::{
 	application_processor_init, boot_application_processors, boot_processor_init,
 	get_processor_count, message_output_init, output_message_byte,
 };
 
 #[cfg(target_arch = "aarch64")]
-use arch::aarch64::kernel::percore::core_scheduler;
+use crate::arch::aarch64::kernel::percore::core_scheduler;
 
 #[cfg(target_arch = "aarch64")]
-pub use arch::aarch64::kernel::percore;
+pub use crate::arch::aarch64::kernel::percore;
 
 #[cfg(target_arch = "aarch64")]
-pub use arch::aarch64::kernel::scheduler;
+pub use crate::arch::aarch64::kernel::scheduler;
 
 #[cfg(target_arch = "aarch64")]
-pub use arch::aarch64::kernel::processor;
+pub use crate::arch::aarch64::kernel::processor;
 
 #[cfg(target_arch = "aarch64")]
-pub use arch::aarch64::kernel::irq;
+pub use crate::arch::aarch64::kernel::irq;
 
 #[cfg(target_arch = "aarch64")]
-pub use arch::aarch64::kernel::systemtime::get_boot_time;
+pub use crate::arch::aarch64::kernel::systemtime::get_boot_time;
 
 #[cfg(target_arch = "x86_64")]
-pub use arch::x86_64::*;
+pub use crate::arch::x86_64::*;
 
 #[cfg(target_arch = "x86_64")]
-pub use arch::x86_64::kernel::apic::{set_oneshot_timer, wakeup_core};
+pub use crate::arch::x86_64::kernel::apic::{set_oneshot_timer, wakeup_core};
 #[cfg(target_arch = "x86_64")]
-pub use arch::x86_64::kernel::gdt::set_current_kernel_stack;
+pub use crate::arch::x86_64::kernel::gdt::set_current_kernel_stack;
 #[cfg(target_arch = "x86_64")]
-pub use arch::x86_64::kernel::irq;
+pub use crate::arch::x86_64::kernel::irq;
 #[cfg(target_arch = "x86_64")]
-pub use arch::x86_64::kernel::percore;
+pub use crate::arch::x86_64::kernel::percore;
 #[cfg(target_arch = "x86_64")]
-pub use arch::x86_64::kernel::processor;
+pub use crate::arch::x86_64::kernel::processor;
 #[cfg(target_arch = "x86_64")]
-pub use arch::x86_64::kernel::scheduler;
+pub use crate::arch::x86_64::kernel::scheduler;
 #[cfg(target_arch = "x86_64")]
-pub use arch::x86_64::kernel::switch::switch;
+pub use crate::arch::x86_64::kernel::switch::switch;
 #[cfg(target_arch = "x86_64")]
-pub use arch::x86_64::kernel::systemtime::get_boot_time;
+pub use crate::arch::x86_64::kernel::systemtime::get_boot_time;
 #[cfg(not(test))]
 #[cfg(target_arch = "x86_64")]
-pub use arch::x86_64::kernel::{
+pub use crate::arch::x86_64::kernel::{
 	application_processor_init, boot_application_processors, boot_processor_init,
 };
 #[cfg(target_arch = "x86_64")]
-pub use arch::x86_64::kernel::{get_processor_count, message_output_init, output_message_byte};
+pub use crate::arch::x86_64::kernel::{
+	get_processor_count, message_output_init, output_message_byte,
+};

--- a/src/arch/x86_64/kernel/acpi.rs
+++ b/src/arch/x86_64/kernel/acpi.rs
@@ -5,11 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch::x86_64::mm::paging;
-use arch::x86_64::mm::paging::{BasePageSize, PageSize, PageTableEntryFlags};
-use arch::x86_64::mm::virtualmem;
+use crate::arch::x86_64::mm::paging::{BasePageSize, PageSize, PageTableEntryFlags};
+use crate::arch::x86_64::mm::{paging, virtualmem};
+use crate::x86::io::*;
 use core::{mem, slice, str};
-use x86::io::*;
 
 /// Memory at this physical address is supposed to contain a pointer to the Extended BIOS Data Area (EBDA).
 const EBDA_PTR_LOCATION: usize = 0x0000_040E;

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -5,31 +5,26 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::arch;
+#[cfg(feature = "acpi")]
+use crate::arch::x86_64::kernel::acpi;
+#[cfg(not(test))]
+use crate::arch::x86_64::kernel::smp_boot_code::SMP_BOOT_CODE;
+use crate::arch::x86_64::mm::paging::{BasePageSize, PageSize, PageTableEntryFlags};
+use crate::arch::x86_64::mm::{paging, virtualmem};
+use crate::config::*;
+use crate::environment;
+use crate::mm;
+use crate::scheduler;
+use crate::scheduler::CoreId;
+use crate::x86::controlregs::*;
+use crate::x86::msr::*;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use arch;
-#[cfg(feature = "acpi")]
-use arch::x86_64::kernel::acpi;
-use arch::x86_64::kernel::idt;
-use arch::x86_64::kernel::irq;
-use arch::x86_64::kernel::percore::*;
-use arch::x86_64::kernel::processor;
-#[cfg(not(test))]
-use arch::x86_64::kernel::smp_boot_code::SMP_BOOT_CODE;
-use arch::x86_64::kernel::BOOT_INFO;
-use arch::x86_64::mm::paging;
-use arch::x86_64::mm::paging::{BasePageSize, PageSize, PageTableEntryFlags};
-use arch::x86_64::mm::virtualmem;
-use config::*;
+use arch::x86_64::kernel::{idt, irq, percore::*, processor, BOOT_INFO};
 use core::convert::TryInto;
 use core::sync::atomic::spin_loop_hint;
 use core::{cmp, fmt, mem, ptr, u32};
-use environment;
-use mm;
-use scheduler;
-use scheduler::CoreId;
-use x86::controlregs::*;
-use x86::msr::*;
 
 const APIC_ICR2: usize = 0x0310;
 

--- a/src/arch/x86_64/kernel/fuse.rs
+++ b/src/arch/x86_64/kernel/fuse.rs
@@ -5,12 +5,12 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::syscalls::fs::{FileError, FilePerms, PosixFile, PosixFileSystem, SeekWhence};
 use alloc::boxed::Box;
 use alloc::rc::Rc;
 use alloc::vec::Vec;
 use core::cell::RefCell;
 use core::{fmt, u32, u8};
-use syscalls::fs::{FileError, FilePerms, PosixFile, PosixFileSystem, SeekWhence};
 
 // response out layout eg @ https://github.com/zargony/fuse-rs/blob/bf6d1cf03f3277e35b580f3c7b9999255d72ecf3/src/ll/request.rs#L44
 // op in/out sizes/layout: https://github.com/hanwen/go-fuse/blob/204b45dba899dfa147235c255908236d5fde2d32/fuse/opcode.go#L439

--- a/src/arch/x86_64/kernel/gdt.rs
+++ b/src/arch/x86_64/kernel/gdt.rs
@@ -6,17 +6,17 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::arch::x86_64::kernel::percore::*;
+use crate::arch::x86_64::kernel::BOOT_INFO;
+use crate::config::*;
+use crate::x86::bits64::segmentation::*;
+use crate::x86::bits64::task::*;
+use crate::x86::dtables::{self, DescriptorTablePointer};
+use crate::x86::segmentation::*;
+use crate::x86::task::*;
+use crate::x86::Ring;
 use alloc::boxed::Box;
-use arch::x86_64::kernel::percore::*;
-use arch::x86_64::kernel::BOOT_INFO;
-use config::*;
 use core::mem;
-use x86::bits64::segmentation::*;
-use x86::bits64::task::*;
-use x86::dtables::{self, DescriptorTablePointer};
-use x86::segmentation::*;
-use x86::task::*;
-use x86::Ring;
 
 pub const GDT_NULL: u16 = 0;
 pub const GDT_KERNEL_CODE: u16 = 1;
@@ -44,7 +44,7 @@ struct Gdt {
 pub fn init() {
 	unsafe {
 		// Dynamically allocate memory for the GDT.
-		GDT = ::mm::allocate(mem::size_of::<Gdt>(), false) as *mut Gdt;
+		GDT = crate::mm::allocate(mem::size_of::<Gdt>(), false) as *mut Gdt;
 
 		// The NULL descriptor is always the first entry.
 		(*GDT).entries[GDT_NULL as usize] = Descriptor::NULL;
@@ -96,7 +96,7 @@ pub fn add_current_core() {
 	// Allocate all ISTs for this core.
 	// Every task later gets its own IST1, so the IST1 allocated here is only used by the Idle task.
 	for i in 0..IST_ENTRIES {
-		let ist = ::mm::allocate(KERNEL_STACK_SIZE, true);
+		let ist = crate::mm::allocate(KERNEL_STACK_SIZE, true);
 		boxed_tss.ist[i] = (ist + KERNEL_STACK_SIZE - 0x10) as u64;
 	}
 

--- a/src/arch/x86_64/kernel/idt.rs
+++ b/src/arch/x86_64/kernel/idt.rs
@@ -84,7 +84,7 @@ impl IdtEntry {
 			base_lo: ((handler.as_usize() as u64) & 0xFFFF) as u16,
 			base_hi: handler.as_usize() as u64 >> 16,
 			selector: gdt_code_selector,
-			ist_index: ist_index,
+			ist_index,
 			flags: dpl as u8 | ty.pack() | (1 << 7),
 			reserved1: 0,
 		}

--- a/src/arch/x86_64/kernel/idt.rs
+++ b/src/arch/x86_64/kernel/idt.rs
@@ -8,12 +8,12 @@
 
 #![allow(dead_code)]
 
-use arch::x86_64::kernel::gdt;
+use crate::arch::x86_64::kernel::gdt;
+use crate::x86::bits64::paging::VAddr;
+use crate::x86::dtables::{self, DescriptorTablePointer};
+use crate::x86::segmentation::{SegmentSelector, SystemDescriptorTypes64};
+use crate::x86::Ring;
 use core::sync::atomic::{AtomicBool, Ordering};
-use x86::bits64::paging::VAddr;
-use x86::dtables::{self, DescriptorTablePointer};
-use x86::segmentation::{SegmentSelector, SystemDescriptorTypes64};
-use x86::Ring;
 
 /// An interrupt gate descriptor.
 ///

--- a/src/arch/x86_64/kernel/irq.rs
+++ b/src/arch/x86_64/kernel/irq.rs
@@ -6,14 +6,14 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch::x86_64::kernel::apic;
-use arch::x86_64::kernel::idt;
-use arch::x86_64::kernel::percore::*;
-use arch::x86_64::kernel::processor;
-use arch::x86_64::mm::paging;
+use crate::arch::x86_64::kernel::apic;
+use crate::arch::x86_64::kernel::idt;
+use crate::arch::x86_64::kernel::percore::*;
+use crate::arch::x86_64::kernel::processor;
+use crate::arch::x86_64::mm::paging;
+use crate::scheduler;
+use crate::x86::bits64::rflags;
 use core::fmt;
-use scheduler;
-use x86::bits64::rflags;
 
 // Derived from Philipp Oppermann's blog
 // => https://github.com/phil-opp/blog_os/blob/master/src/interrupts/mod.rs

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -35,14 +35,14 @@ pub mod virtio;
 pub mod virtio_fs;
 pub mod virtio_net;
 
-use arch::x86_64::kernel::percore::*;
-use arch::x86_64::kernel::serial::SerialPort;
+use crate::arch::x86_64::kernel::percore::*;
+use crate::arch::x86_64::kernel::serial::SerialPort;
 
+use crate::environment;
+use crate::kernel_message_buffer;
 #[cfg(feature = "newlib")]
 use core::slice;
 use core::{intrinsics, ptr};
-use environment;
-use kernel_message_buffer;
 
 const SERIAL_PORT_BAUDRATE: u32 = 115_200;
 
@@ -288,8 +288,8 @@ pub fn boot_processor_init() {
 		vga::init();
 	}
 
-	::mm::init();
-	::mm::print_information();
+	crate::mm::init();
+	crate::mm::print_information();
 	environment::init();
 	gdt::init();
 	gdt::add_current_core();

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -94,11 +94,7 @@ static mut COM1: SerialPort = SerialPort::new(0x3f8);
 pub fn has_ipdevice() -> bool {
 	let ip = unsafe { core::ptr::read_volatile(&(*BOOT_INFO).hcip) };
 
-	if ip[0] == 255 && ip[1] == 255 && ip[2] == 255 && ip[3] == 255 {
-		false
-	} else {
-		true
-	}
+	!(ip[0] == 255 && ip[1] == 255 && ip[2] == 255 && ip[3] == 255)
 }
 
 #[cfg(not(feature = "newlib"))]

--- a/src/arch/x86_64/kernel/pci.rs
+++ b/src/arch/x86_64/kernel/pci.rs
@@ -249,7 +249,7 @@ fn parse_bars(bus: u8, device: u8, vendor_id: u16, device_id: u16) -> Vec<PciBar
 		}
 	}
 
-	return bars;
+	bars
 }
 
 impl PciAdapter {
@@ -274,10 +274,10 @@ impl PciAdapter {
 		let interrupt_info = read_config(bus, device, PCI_INTERRUPT_REGISTER);
 
 		Some(Self {
-			bus: bus,
-			device: device,
-			vendor_id: vendor_id,
-			device_id: device_id,
+			bus,
+			device,
+			vendor_id,
+			device_id,
 			class_id: (class_ids >> 24) as u8,
 			subclass_id: (class_ids >> 16) as u8,
 			programming_interface_id: (class_ids >> 8) as u8,
@@ -294,33 +294,33 @@ impl PciAdapter {
 
 	/// Returns the bar at bar-register baridx.
 	pub fn get_bar(&self, baridx: u8) -> Option<PciBar> {
-		for bar in &self.base_addresses {
-			match bar {
-				PciBar::IO(bar) => {
-					if bar.index == baridx {
-						return Some(PciBar::IO(*bar));
+		for pci_bar in &self.base_addresses {
+			match pci_bar {
+				PciBar::IO(pci_bar) => {
+					if pci_bar.index == baridx {
+						return Some(PciBar::IO(*pci_bar));
 					}
 				}
-				PciBar::Memory(bar) => {
-					if bar.index == baridx {
-						return Some(PciBar::Memory(*bar));
+				PciBar::Memory(pci_bar) => {
+					if pci_bar.index == baridx {
+						return Some(PciBar::Memory(*pci_bar));
 					}
 				}
 			}
 		}
-		return None;
+		None
 	}
 
 	/// Memory maps pci bar with specified index to identical location in virtual memory.
 	/// no_cache determines if we set the `Cache Disable` flag in the page-table-entry.
 	/// Returns (virtual-pointer, size) if successful, else None (if bar non-existent or IOSpace)
 	pub fn memory_map_bar(&self, index: u8, no_cache: bool) -> Option<(usize, usize)> {
-		let bar = match self.get_bar(index) {
+		let pci_bar = match self.get_bar(index) {
 			Some(PciBar::IO(_)) => {
 				warn!("Cannot map IOBar!");
 				return None;
 			}
-			Some(PciBar::Memory(bar)) => bar,
+			Some(PciBar::Memory(mem_bar)) => mem_bar,
 			None => {
 				warn!("Memory bar not found!");
 				return None;
@@ -329,32 +329,32 @@ impl PciAdapter {
 
 		debug!(
 			"Mapping bar {} at 0x{:x} with length 0x{:x}",
-			index, bar.addr, bar.size
+			index, pci_bar.addr, pci_bar.size
 		);
 
-		if bar.width != 64 {
+		if pci_bar.width != 64 {
 			warn!("Currently only mapping of 64 bit bars is supported!");
 			return None;
 		}
-		if !bar.prefetchable {
+		if !pci_bar.prefetchable {
 			warn!("Currently only mapping of prefetchable bars is supported!")
 		}
 
 		// Since the bios/bootloader manages the physical address space, the address got from the bar is unique and not overlapping.
 		// We therefore do not need to reserve any additional memory in our kernel.
 		// Map bar into RW^X virtual memory
-		let physical_address = bar.addr;
-		let virtual_address = ::mm::map(physical_address, bar.size, true, false, no_cache);
+		let physical_address = pci_bar.addr;
+		let virtual_address = ::mm::map(physical_address, pci_bar.size, true, false, no_cache);
 
-		Some((virtual_address, bar.size))
+		Some((virtual_address, pci_bar.size))
 	}
 }
 
 impl fmt::Display for PciBar {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		let (typ, addr, size) = match self {
-			PciBar::IO(bar) => ("IOBar", bar.addr as usize, bar.size as usize),
-			PciBar::Memory(bar) => ("MemoryBar", bar.addr, bar.size),
+			PciBar::IO(io_bar) => ("IOBar", io_bar.addr as usize, io_bar.size as usize),
+			PciBar::Memory(mem_bar) => ("MemoryBar", mem_bar.addr, mem_bar.size),
 		};
 		write!(f, "{}: 0x{:x} (size 0x{:x})", typ, addr, size)?;
 
@@ -417,8 +417,8 @@ impl fmt::Display for PciAdapter {
 			write!(f, ", IRQ {}", self.irq)?;
 		}
 
-		for bar in &self.base_addresses {
-			write!(f, ", {}", bar)?;
+		for pci_bar in &self.base_addresses {
+			write!(f, ", {}", pci_bar)?;
 		}
 
 		Ok(())

--- a/src/arch/x86_64/kernel/pci.rs
+++ b/src/arch/x86_64/kernel/pci.rs
@@ -6,17 +6,17 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::arch::x86_64::kernel::pci_ids::{CLASSES, VENDORS};
+use crate::arch::x86_64::kernel::virtio;
+use crate::arch::x86_64::kernel::virtio_fs::VirtioFsDriver;
+use crate::arch::x86_64::kernel::virtio_net::VirtioNetDriver;
+use crate::synch::spinlock::SpinlockIrqSave;
+use crate::x86::io::*;
 use alloc::rc::Rc;
 use alloc::vec::Vec;
-use arch::x86_64::kernel::pci_ids::{CLASSES, VENDORS};
-use arch::x86_64::kernel::virtio;
-use arch::x86_64::kernel::virtio_fs::VirtioFsDriver;
-use arch::x86_64::kernel::virtio_net::VirtioNetDriver;
 use core::cell::RefCell;
 use core::convert::TryInto;
 use core::{fmt, u32, u8};
-use synch::spinlock::SpinlockIrqSave;
-use x86::io::*;
 
 // TODO: should these be pub? currently needed since used in virtio.rs maybe use getter methods to be more flexible.
 pub const PCI_MAX_BUS_NUMBER: u8 = 32;
@@ -344,7 +344,7 @@ impl PciAdapter {
 		// We therefore do not need to reserve any additional memory in our kernel.
 		// Map bar into RW^X virtual memory
 		let physical_address = pci_bar.addr;
-		let virtual_address = ::mm::map(physical_address, pci_bar.size, true, false, no_cache);
+		let virtual_address = crate::mm::map(physical_address, pci_bar.size, true, false, no_cache);
 
 		Some((virtual_address, pci_bar.size))
 	}

--- a/src/arch/x86_64/kernel/percore.rs
+++ b/src/arch/x86_64/kernel/percore.rs
@@ -5,11 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch::x86_64::kernel::BOOT_INFO;
+use crate::arch::x86_64::kernel::BOOT_INFO;
+use crate::scheduler::{CoreId, PerCoreScheduler};
+use crate::x86::bits64::task::TaskStateSegment;
+use crate::x86::msr::*;
 use core::ptr;
-use scheduler::{CoreId, PerCoreScheduler};
-use x86::bits64::task::TaskStateSegment;
-use x86::msr::*;
 
 pub static mut PERCORE: PerCoreVariables = PerCoreVariables::new(0);
 
@@ -60,7 +60,7 @@ impl<T> PerCoreVariable<T> {
 
 // Treat all per-core variables as 64-bit variables by default. This is true for u64, usize, pointers.
 // Implement the PerCoreVariableMethods trait functions using 64-bit memory moves.
-// The functions are implemented as default functions, which can be overriden in specialized implementations of the trait.
+// The functions are implemented as default functions, which can be overridden in specialized implementations of the trait.
 impl<T> PerCoreVariableMethods<T> for PerCoreVariable<T> {
 	#[inline]
 	default unsafe fn get(&self) -> T {

--- a/src/arch/x86_64/kernel/pic.rs
+++ b/src/arch/x86_64/kernel/pic.rs
@@ -5,9 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch::x86_64::kernel::idt;
-use arch::x86_64::kernel::irq::ExceptionStackFrame;
-use x86::io::*;
+use crate::arch::x86_64::kernel::idt;
+use crate::arch::x86_64::kernel::irq::ExceptionStackFrame;
+use crate::x86::io::*;
 
 const PIC1_COMMAND_PORT: u16 = 0x20;
 const PIC1_DATA_PORT: u16 = 0x21;

--- a/src/arch/x86_64/kernel/pit.rs
+++ b/src/arch/x86_64/kernel/pit.rs
@@ -8,8 +8,8 @@
 
 #![allow(dead_code)]
 
-use arch::x86_64::kernel::pic;
-use x86::io::*;
+use crate::arch::x86_64::kernel::pic;
+use crate::x86::io::*;
 
 const PIT_CLOCK: u64 = 1_193_182;
 pub const PIT_INTERRUPT_NUMBER: u8 = pic::PIC1_INTERRUPT_OFFSET + 0;

--- a/src/arch/x86_64/kernel/processor.rs
+++ b/src/arch/x86_64/kernel/processor.rs
@@ -420,10 +420,10 @@ impl CpuFrequency {
 	}
 
 	unsafe fn detect(&mut self) {
-		let mut cpuid = CpuId::new();
+		let cpuid = CpuId::new();
 		self.detect_from_cpuid(&cpuid)
-			.or_else(|_e| self.detect_from_cpuid_tsc_info(&mut cpuid))
-			.or_else(|_e| self.detect_from_cpuid_hypervisor_info(&mut cpuid))
+			.or_else(|_e| self.detect_from_cpuid_tsc_info(&cpuid))
+			.or_else(|_e| self.detect_from_cpuid_hypervisor_info(&cpuid))
 			.or_else(|_e| self.detect_from_hypervisor())
 			//.or_else(|_e| self.detect_from_cmdline())
 			.or_else(|_e| self.detect_from_cpuid_brand_string(&cpuid))

--- a/src/arch/x86_64/kernel/processor.rs
+++ b/src/arch/x86_64/kernel/processor.rs
@@ -9,19 +9,15 @@
 #![allow(dead_code)]
 
 #[cfg(feature = "acpi")]
-use arch::x86_64::kernel::acpi;
-use arch::x86_64::kernel::idt;
-use arch::x86_64::kernel::irq;
-use arch::x86_64::kernel::pic;
-use arch::x86_64::kernel::pit;
-use arch::x86_64::kernel::BOOT_INFO;
+use crate::arch::x86_64::kernel::acpi;
+use crate::arch::x86_64::kernel::{idt, irq, pic, pit, BOOT_INFO};
+use crate::environment;
+use crate::x86::controlregs::*;
+use crate::x86::cpuid::*;
+use crate::x86::msr::*;
+use crate::x86::time::*;
 use core::sync::atomic::spin_loop_hint;
 use core::{fmt, u32};
-use environment;
-use x86::controlregs::*;
-use x86::cpuid::*;
-use x86::msr::*;
-use x86::time::*;
 
 const IA32_MISC_ENABLE_ENHANCED_SPEEDSTEP: u64 = 1 << 16;
 const IA32_MISC_ENABLE_SPEEDSTEP_LOCK: u64 = 1 << 20;

--- a/src/arch/x86_64/kernel/scheduler.rs
+++ b/src/arch/x86_64/kernel/scheduler.rs
@@ -137,9 +137,9 @@ impl TaskStacks {
 		}
 
 		TaskStacks::Common(CommonStack {
-			virt_addr: virt_addr,
-			phys_addr: phys_addr,
-			total_size: total_size,
+			virt_addr,
+			phys_addr,
+			total_size,
 		})
 	}
 
@@ -151,8 +151,8 @@ impl TaskStacks {
 		debug!("IST0 is located at {:#X}", ist0);
 
 		TaskStacks::Boot(BootStack {
-			stack: stack,
-			ist0: ist0,
+			stack,
+			ist0,
 		})
 	}
 

--- a/src/arch/x86_64/kernel/scheduler.rs
+++ b/src/arch/x86_64/kernel/scheduler.rs
@@ -8,16 +8,16 @@
 
 //! Architecture dependent interface to initialize a task
 
-use arch::x86_64::kernel::apic;
-use arch::x86_64::kernel::idt;
-use arch::x86_64::kernel::irq;
-use arch::x86_64::kernel::percore::*;
-use arch::x86_64::mm::paging::{BasePageSize, PageSize, PageTableEntryFlags};
-use config::*;
+use crate::arch::x86_64::kernel::apic;
+use crate::arch::x86_64::kernel::idt;
+use crate::arch::x86_64::kernel::irq;
+use crate::arch::x86_64::kernel::percore::*;
+use crate::arch::x86_64::mm::paging::{BasePageSize, PageSize, PageTableEntryFlags};
+use crate::config::*;
+use crate::environment;
+use crate::mm;
+use crate::scheduler::task::{Task, TaskFrame};
 use core::{mem, ptr};
-use environment;
-use mm;
-use scheduler::task::{Task, TaskFrame};
 
 #[repr(C, packed)]
 struct State {
@@ -88,9 +88,9 @@ impl TaskStacks {
 			align_up!(size, BasePageSize::SIZE)
 		};
 		let total_size = user_stack_size + DEFAULT_STACK_SIZE + KERNEL_STACK_SIZE;
-		let virt_addr = ::arch::mm::virtualmem::allocate(total_size + 4 * BasePageSize::SIZE)
+		let virt_addr = crate::arch::mm::virtualmem::allocate(total_size + 4 * BasePageSize::SIZE)
 			.expect("Failed to allocate Virtual Memory for TaskStacks");
-		let phys_addr = ::arch::mm::physicalmem::allocate(total_size)
+		let phys_addr = crate::arch::mm::physicalmem::allocate(total_size)
 			.expect("Failed to allocate Physical Memory for TaskStacks");
 
 		debug!(
@@ -103,7 +103,7 @@ impl TaskStacks {
 		flags.normal().writable().execute_disable();
 
 		// map IST0 into the address space
-		::arch::mm::paging::map::<BasePageSize>(
+		crate::arch::mm::paging::map::<BasePageSize>(
 			virt_addr + BasePageSize::SIZE,
 			phys_addr,
 			KERNEL_STACK_SIZE / BasePageSize::SIZE,
@@ -111,7 +111,7 @@ impl TaskStacks {
 		);
 
 		// map kernel stack into the address space
-		::arch::mm::paging::map::<BasePageSize>(
+		crate::arch::mm::paging::map::<BasePageSize>(
 			virt_addr + KERNEL_STACK_SIZE + 2 * BasePageSize::SIZE,
 			phys_addr + KERNEL_STACK_SIZE,
 			DEFAULT_STACK_SIZE / BasePageSize::SIZE,
@@ -119,7 +119,7 @@ impl TaskStacks {
 		);
 
 		// map user stack into the address space
-		::arch::mm::paging::map::<BasePageSize>(
+		crate::arch::mm::paging::map::<BasePageSize>(
 			virt_addr + KERNEL_STACK_SIZE + DEFAULT_STACK_SIZE + 3 * BasePageSize::SIZE,
 			phys_addr + KERNEL_STACK_SIZE + DEFAULT_STACK_SIZE,
 			user_stack_size / BasePageSize::SIZE,
@@ -150,10 +150,7 @@ impl TaskStacks {
 		let ist0 = tss.ist[0] as usize + 0x10 - KERNEL_STACK_SIZE;
 		debug!("IST0 is located at {:#X}", ist0);
 
-		TaskStacks::Boot(BootStack {
-			stack,
-			ist0,
-		})
+		TaskStacks::Boot(BootStack { stack, ist0 })
 	}
 
 	pub fn get_user_stack_size(&self) -> usize {
@@ -214,15 +211,15 @@ impl Drop for TaskStacks {
 					stacks.total_size >> 10,
 				);
 
-				::arch::mm::paging::unmap::<BasePageSize>(
+				crate::arch::mm::paging::unmap::<BasePageSize>(
 					stacks.virt_addr,
 					stacks.total_size / BasePageSize::SIZE + 4,
 				);
-				::arch::mm::virtualmem::deallocate(
+				crate::arch::mm::virtualmem::deallocate(
 					stacks.virt_addr,
 					stacks.total_size + 4 * BasePageSize::SIZE,
 				);
-				::arch::mm::physicalmem::deallocate(stacks.phys_addr, stacks.total_size);
+				crate::arch::mm::physicalmem::deallocate(stacks.phys_addr, stacks.total_size);
 			}
 		}
 	}
@@ -255,7 +252,7 @@ impl TaskTLS {
 		// We allocate in BasePageSize granularity, so we don't have to manually impose an
 		// additional alignment for TLS variables.
 		let memory_size = align_up!(tls_allocation_size, BasePageSize::SIZE);
-		let ptr = ::mm::allocate(memory_size, true);
+		let ptr = crate::mm::allocate(memory_size, true);
 
 		// The tls_pointer is the address to the end of the TLS area requested by the task.
 		let tls_pointer = ptr + align_up!(tls_size, 32);

--- a/src/arch/x86_64/kernel/serial.rs
+++ b/src/arch/x86_64/kernel/serial.rs
@@ -5,9 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::environment;
+use crate::x86::io::*;
 use core::sync::atomic::spin_loop_hint;
-use environment;
-use x86::io::*;
 
 const UART_TX: u16 = 0;
 const UART_IER: u16 = 1;
@@ -33,9 +33,7 @@ pub struct SerialPort {
 
 impl SerialPort {
 	pub const fn new(port_address: u16) -> Self {
-		Self {
-			port_address,
-		}
+		Self { port_address }
 	}
 
 	fn read_from_register(&self, register: u16) -> u8 {

--- a/src/arch/x86_64/kernel/serial.rs
+++ b/src/arch/x86_64/kernel/serial.rs
@@ -34,7 +34,7 @@ pub struct SerialPort {
 impl SerialPort {
 	pub const fn new(port_address: u16) -> Self {
 		Self {
-			port_address: port_address,
+			port_address,
 		}
 	}
 

--- a/src/arch/x86_64/kernel/start.rs
+++ b/src/arch/x86_64/kernel/start.rs
@@ -5,11 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use application_processor_main;
-use arch::x86_64::kernel::{BootInfo, BOOT_INFO};
-use boot_processor_main;
-use config::KERNEL_STACK_SIZE;
-use x86::controlregs::*;
+use crate::application_processor_main;
+use crate::arch::x86_64::kernel::{BootInfo, BOOT_INFO};
+use crate::boot_processor_main;
+use crate::config::KERNEL_STACK_SIZE;
+use crate::x86::controlregs::*;
 
 pub unsafe fn cr0_enable_caching() {
 	let mut cr0 = cr0();

--- a/src/arch/x86_64/kernel/systemtime.rs
+++ b/src/arch/x86_64/kernel/systemtime.rs
@@ -5,11 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch::x86_64::kernel::irq;
-use arch::x86_64::kernel::processor;
-use arch::x86_64::kernel::BOOT_INFO;
+use crate::arch::x86_64::kernel::irq;
+use crate::arch::x86_64::kernel::processor;
+use crate::arch::x86_64::kernel::BOOT_INFO;
+use crate::environment;
 use core::sync::atomic::spin_loop_hint;
-use environment;
 use x86::io::*;
 
 const CMOS_COMMAND_PORT: u16 = 0x70;

--- a/src/arch/x86_64/kernel/vga.rs
+++ b/src/arch/x86_64/kernel/vga.rs
@@ -5,8 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch::x86_64::mm::paging;
-use arch::x86_64::mm::paging::{BasePageSize, PageTableEntryFlags};
+use crate::arch::x86_64::mm::paging;
+use crate::arch::x86_64::mm::paging::{BasePageSize, PageTableEntryFlags};
 use x86::shared::io::*;
 
 const CRT_CONTROLLER_ADDRESS_PORT: u16 = 0x3D4;

--- a/src/arch/x86_64/kernel/virtio.rs
+++ b/src/arch/x86_64/kernel/virtio.rs
@@ -5,21 +5,21 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch::x86_64::kernel::apic;
-use arch::x86_64::kernel::irq::*;
-use arch::x86_64::kernel::pci::{
+use crate::arch::x86_64::kernel::apic;
+use crate::arch::x86_64::kernel::irq::*;
+use crate::arch::x86_64::kernel::pci::{
 	self, get_network_driver, PciAdapter, PciClassCode, PciDriver, PciNetworkControllerSubclass,
 };
-use arch::x86_64::kernel::percore::core_scheduler;
-use arch::x86_64::kernel::virtio_fs;
-use arch::x86_64::kernel::virtio_net;
+use crate::arch::x86_64::kernel::percore::core_scheduler;
+use crate::arch::x86_64::kernel::virtio_fs;
+use crate::arch::x86_64::kernel::virtio_net;
 
-use arch::x86_64::mm::paging;
+use crate::arch::x86_64::mm::paging;
+use crate::config::VIRTIO_MAX_QUEUE_SIZE;
 
 use alloc::boxed::Box;
 use alloc::rc::Rc;
 use alloc::vec::Vec;
-use config::VIRTIO_MAX_QUEUE_SIZE;
 use core::cell::RefCell;
 use core::convert::TryInto;
 use core::sync::atomic::spin_loop_hint;

--- a/src/arch/x86_64/kernel/virtio.rs
+++ b/src/arch/x86_64/kernel/virtio.rs
@@ -196,7 +196,7 @@ impl<'a> Virtq<'a> {
 			notify_cfg.get_notify_addr(common_cfg.queue_notify_off as u32),
 		);
 
-		return Some(vq);
+		Some(vq)
 	}
 
 	fn notify_device(&mut self) {
@@ -636,8 +636,8 @@ impl<'a> VirtqUsed<'a> {
 
 		fence(Ordering::SeqCst);
 
-		assert!(usedelem.id == chain.0.first().unwrap().index as u32);
-		return true;
+		assert_eq!(usedelem.id, chain.0.first().unwrap().index as u32);
+		true
 
 		// current version cannot fail.
 		//false

--- a/src/arch/x86_64/kernel/virtio_fs.rs
+++ b/src/arch/x86_64/kernel/virtio_fs.rs
@@ -5,13 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch::x86_64::kernel::fuse::{self, FuseInterface};
-use arch::x86_64::kernel::pci;
-use arch::x86_64::kernel::virtio::{
+use crate::arch::x86_64::kernel::fuse::{self, FuseInterface};
+use crate::arch::x86_64::kernel::pci;
+use crate::arch::x86_64::kernel::virtio::{
 	self, consts::*, virtio_pci_common_cfg, VirtioNotification, Virtq,
 };
-use syscalls::fs;
-use util;
+use crate::syscalls::fs;
+use crate::util;
 
 use alloc::boxed::Box;
 use alloc::rc::Rc;

--- a/src/arch/x86_64/kernel/virtio_net.rs
+++ b/src/arch/x86_64/kernel/virtio_net.rs
@@ -180,7 +180,7 @@ impl RxBuffer {
 		let addr = ::mm::allocate(sz, true);
 
 		Self {
-			addr: addr,
+			addr,
 			len: sz,
 		}
 	}
@@ -206,7 +206,7 @@ impl TxBuffer {
 		let addr = ::mm::allocate(sz, true);
 
 		Self {
-			addr: addr,
+			addr,
 			len: sz,
 			in_use: false,
 		}
@@ -382,7 +382,7 @@ impl<'a> VirtioNetDriver<'a> {
 		let mut buffers = &mut self.tx_buffers;
 
 		// do we have free buffers?
-		if buffers.iter().position(|b| b.in_use == false).is_none() {
+		if buffers.iter().position(|b| !b.in_use ).is_none() {
 			// if not, check if we are able to free used elements
 			self.check_used_elements();
 		}
@@ -391,7 +391,7 @@ impl<'a> VirtioNetDriver<'a> {
 		let index = index as usize;
 
 		let mut buffers = &mut self.tx_buffers;
-		if buffers[index].in_use == false {
+		if !buffers[index].in_use {
 			buffers[index].in_use = true;
 			let header = buffers[index].addr as *mut virtio_net_hdr;
 			unsafe {

--- a/src/arch/x86_64/mm/paging.rs
+++ b/src/arch/x86_64/mm/paging.rs
@@ -282,7 +282,7 @@ impl<S: PageSize> Page<S> {
 		assert!(first.virtual_address <= last.virtual_address);
 		PageIter {
 			current: first,
-			last: last,
+			last,
 		}
 	}
 
@@ -635,7 +635,7 @@ pub fn virtual_to_physical(virtual_address: usize) -> usize {
 	};
 
 	for i in (0..3).rev() {
-		page_bits = page_bits - PAGE_MAP_BITS;
+		page_bits -= PAGE_MAP_BITS;
 
 		let vpn = (virtual_address >> page_bits) as isize;
 		let ptr = SELF[i] as *const usize;

--- a/src/arch/x86_64/mm/paging.rs
+++ b/src/arch/x86_64/mm/paging.rs
@@ -7,20 +7,20 @@
 
 #![allow(dead_code)]
 
-use arch::x86_64::kernel::apic;
-use arch::x86_64::kernel::get_mbinfo;
-use arch::x86_64::kernel::irq;
+use crate::arch::x86_64::kernel::apic;
+use crate::arch::x86_64::kernel::get_mbinfo;
+use crate::arch::x86_64::kernel::irq;
 //use arch::x86_64::kernel::is_uhyve;
-use arch::x86_64::kernel::processor;
-use arch::x86_64::mm::paddr_to_slice;
-use arch::x86_64::mm::physicalmem;
+use crate::arch::x86_64::kernel::processor;
+use crate::arch::x86_64::mm::paddr_to_slice;
+use crate::arch::x86_64::mm::physicalmem;
+use crate::environment;
+use crate::mm;
+use crate::scheduler;
 use core::marker::PhantomData;
 use core::mem;
 use core::ptr;
-use environment;
-use mm;
 use multiboot::Multiboot;
-use scheduler;
 use x86::controlregs;
 use x86::irq::PageFaultError;
 
@@ -149,23 +149,26 @@ impl PageTableEntry {
 		if flags.contains(PageTableEntryFlags::HUGE_PAGE) {
 			// HUGE_PAGE may indicate a 2 MiB or 1 GiB page.
 			// We don't know this here, so we can only verify that at least the offset bits for a 2 MiB page are zero.
-			assert!(
-				physical_address % LargePageSize::SIZE == 0,
+			assert_eq!(
+				physical_address % LargePageSize::SIZE,
+				0,
 				"Physical address is not on a 2 MiB page boundary (physical_address = {:#X})",
 				physical_address
 			);
 		} else {
 			// Verify that the offset bits for a 4 KiB page are zero.
-			assert!(
-				physical_address % BasePageSize::SIZE == 0,
+			assert_eq!(
+				physical_address % BasePageSize::SIZE,
+				0,
 				"Physical address is not on a 4 KiB page boundary (physical_address = {:#X})",
 				physical_address
 			);
 		}
 
 		// Verify that the physical address does not exceed the CPU's physical address width.
-		assert!(
-			physical_address >> processor::get_physical_address_bits() == 0,
+		assert_eq!(
+			physical_address >> processor::get_physical_address_bits(),
+			0,
 			"Physical address exceeds CPU's physical address width (physical_address = {:#X})",
 			physical_address
 		);

--- a/src/arch/x86_64/mm/physicalmem.rs
+++ b/src/arch/x86_64/mm/physicalmem.rs
@@ -5,15 +5,15 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch::x86_64::kernel::{get_limit, get_mbinfo};
-use arch::x86_64::mm::paddr_to_slice;
-use arch::x86_64::mm::paging::{BasePageSize, PageSize};
-use collections::Node;
+use crate::arch::x86_64::kernel::{get_limit, get_mbinfo};
+use crate::arch::x86_64::mm::paddr_to_slice;
+use crate::arch::x86_64::mm::paging::{BasePageSize, PageSize};
+use crate::collections::Node;
+use crate::mm;
+use crate::mm::freelist::{FreeList, FreeListEntry};
+use crate::synch::spinlock::*;
 use core::sync::atomic::{AtomicUsize, Ordering};
-use mm;
-use mm::freelist::{FreeList, FreeListEntry};
 use multiboot::{MemoryType, Multiboot};
-use synch::spinlock::*;
 
 static PHYSICAL_FREE_LIST: SpinlockIrqSave<FreeList> = SpinlockIrqSave::new(FreeList::new());
 static TOTAL_MEMORY: AtomicUsize = AtomicUsize::new(0);

--- a/src/arch/x86_64/mm/virtualmem.rs
+++ b/src/arch/x86_64/mm/virtualmem.rs
@@ -5,11 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch::x86_64::mm::paging::{BasePageSize, PageSize};
-use collections::Node;
-use mm;
-use mm::freelist::{FreeList, FreeListEntry};
-use synch::spinlock::*;
+use crate::arch::x86_64::mm::paging::{BasePageSize, PageSize};
+use crate::collections::Node;
+use crate::mm;
+use crate::mm::freelist::{FreeList, FreeListEntry};
+use crate::synch::spinlock::*;
 
 static KERNEL_FREE_LIST: SpinlockIrqSave<FreeList> = SpinlockIrqSave::new(FreeList::new());
 
@@ -23,8 +23,9 @@ pub fn init() {
 
 pub fn allocate(size: usize) -> Result<usize, ()> {
 	assert!(size > 0);
-	assert!(
-		size % BasePageSize::SIZE == 0,
+	assert_eq!(
+		size % BasePageSize::SIZE,
+		0,
 		"Size {:#X} is not a multiple of {:#X}",
 		size,
 		BasePageSize::SIZE
@@ -36,14 +37,16 @@ pub fn allocate(size: usize) -> Result<usize, ()> {
 pub fn allocate_aligned(size: usize, alignment: usize) -> Result<usize, ()> {
 	assert!(size > 0);
 	assert!(alignment > 0);
-	assert!(
-		size % alignment == 0,
+	assert_eq!(
+		size % alignment,
+		0,
 		"Size {:#X} is not a multiple of the given alignment {:#X}",
 		size,
 		alignment
 	);
-	assert!(
-		alignment % BasePageSize::SIZE == 0,
+	assert_eq!(
+		alignment % BasePageSize::SIZE,
+		0,
 		"Alignment {:#X} is not a multiple of {:#X}",
 		alignment,
 		BasePageSize::SIZE
@@ -63,15 +66,17 @@ pub fn deallocate(virtual_address: usize, size: usize) {
 		"Virtual address {:#X} is not < kernel_heap_end()",
 		virtual_address
 	);
-	assert!(
-		virtual_address % BasePageSize::SIZE == 0,
+	assert_eq!(
+		virtual_address % BasePageSize::SIZE,
+		0,
 		"Virtual address {:#X} is not a multiple of {:#X}",
 		virtual_address,
 		BasePageSize::SIZE
 	);
 	assert!(size > 0);
-	assert!(
-		size % BasePageSize::SIZE == 0,
+	assert_eq!(
+		size % BasePageSize::SIZE,
+		0,
 		"Size {:#X} is not a multiple of {:#X}",
 		size,
 		BasePageSize::SIZE
@@ -91,15 +96,17 @@ pub fn reserve(virtual_address: usize, size: usize) {
 		"Virtual address {:#X} is not < kernel_heap_end()",
 		virtual_address
 	);
-	assert!(
-		virtual_address % BasePageSize::SIZE == 0,
+	assert_eq!(
+		virtual_address % BasePageSize::SIZE,
+		0,
 		"Virtual address {:#X} is not a multiple of {:#X}",
 		virtual_address,
 		BasePageSize::SIZE
 	);
 	assert!(size > 0);
-	assert!(
-		size % BasePageSize::SIZE == 0,
+	assert_eq!(
+		size % BasePageSize::SIZE,
+		0,
 		"Size {:#X} is not a multiple of {:#X}",
 		size,
 		BasePageSize::SIZE

--- a/src/collections/doublylinkedlist.rs
+++ b/src/collections/doublylinkedlist.rs
@@ -29,7 +29,7 @@ pub struct Node<T> {
 impl<T> Node<T> {
 	pub fn new(value: T) -> Rc<RefCell<Self>> {
 		Rc::new(RefCell::new(Self {
-			value: value,
+			value,
 			prev: None,
 			next: None,
 		}))

--- a/src/collections/mod.rs
+++ b/src/collections/mod.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch::irq;
+use crate::arch::irq;
 
 mod doublylinkedlist;
 

--- a/src/collections/refcell.rs
+++ b/src/collections/refcell.rs
@@ -12,7 +12,7 @@
 //! By borrowing the reference, interrupts are automatically disabled to support
 //! the usage within an interrupt handler.
 
-use arch::kernel::irq;
+use crate::arch::kernel::irq;
 use core::cell;
 use core::ops::{Deref, DerefMut};
 

--- a/src/console.rs
+++ b/src/console.rs
@@ -6,9 +6,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch;
+use crate::arch;
+use crate::synch::spinlock::SpinlockIrqSave;
 use core::fmt;
-use synch::spinlock::SpinlockIrqSave;
 
 pub struct Console;
 

--- a/src/drivers/net/mod.rs
+++ b/src/drivers/net/mod.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use synch::semaphore::*;
+use crate::synch::semaphore::*;
 
 static NET_SEM: Semaphore = Semaphore::new(0);
 
@@ -17,7 +17,7 @@ pub fn netwait(millis: Option<u64>) {
 	match millis {
 		Some(ms) => {
 			if ms > 0 {
-				let delay = Some(::arch::processor::get_timer_ticks() + ms * 1000);
+				let delay = Some(crate::arch::processor::get_timer_ticks() + ms * 1000);
 				NET_SEM.acquire(delay);
 			} else {
 				NET_SEM.try_acquire();

--- a/src/drivers/net/rtl8139.rs
+++ b/src/drivers/net/rtl8139.rs
@@ -19,14 +19,14 @@ use smoltcp::phy::{self, Device, DeviceCapabilities};
 use smoltcp::time::Instant;
 use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr, Ipv4Address};
 
-use arch::x86_64::kernel::apic;
-use arch::x86_64::kernel::irq::*;
-use arch::x86_64::kernel::pci;
-use arch::x86_64::kernel::percore::core_scheduler;
-use arch::x86_64::mm::paging::virt_to_phys;
-use drivers::net::{networkd, NETWORK_TASK_ID, NET_SEM};
-use scheduler;
-use x86::io::*;
+use crate::arch::x86_64::kernel::apic;
+use crate::arch::x86_64::kernel::irq::*;
+use crate::arch::x86_64::kernel::pci;
+use crate::arch::x86_64::kernel::percore::core_scheduler;
+use crate::arch::x86_64::mm::paging::virt_to_phys;
+use crate::drivers::net::{networkd, NETWORK_TASK_ID, NET_SEM};
+use crate::scheduler;
+use crate::x86::io::*;
 
 /// size of the receive buffer
 const RX_BUF_LEN: usize = 8192;

--- a/src/drivers/net/uhyve.rs
+++ b/src/drivers/net/uhyve.rs
@@ -4,19 +4,18 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
-
+use crate::arch::irq;
+use crate::drivers::net::NetworkInterface;
 use alloc::boxed::Box;
-use arch::irq;
-use drivers::net::NetworkInterface;
 
 #[cfg(target_arch = "x86_64")]
-use arch::x86_64::kernel::irq::*;
+use crate::arch::x86_64::kernel::irq::*;
 #[cfg(target_arch = "x86_64")]
-use arch::x86_64::kernel::uhyve_get_ip;
+use crate::arch::x86_64::kernel::uhyve_get_ip;
 #[cfg(target_arch = "x86_64")]
-use arch::x86_64::mm::paging::virt_to_phys;
+use crate::arch::x86_64::mm::paging::virt_to_phys;
 #[cfg(target_arch = "x86_64")]
-use x86::io::*;
+use crate::x86::io::*;
 
 const UHYVE_IRQ_NET: u32 = 11;
 const UHYVE_PORT_NETINFO: u16 = 0x600;

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -10,7 +10,7 @@
 //! command-line parameters.
 
 #[cfg(target_arch = "x86_64")]
-pub use arch::x86_64::kernel::{
+pub use crate::arch::x86_64::kernel::{
 	get_base_address, get_cmdline, get_cmdsize, get_image_size, get_tls_filesz, get_tls_memsz,
 	get_tls_start, is_single_kernel, is_uhyve,
 };
@@ -20,10 +20,10 @@ pub use arch::aarch64::kernel::{
 	get_base_address, get_cmdline, get_cmdsize, get_image_size, is_single_kernel, is_uhyve,
 };
 
+use crate::util;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::{slice, str};
-use util;
 
 static mut COMMAND_LINE_CPU_FREQUENCY: u16 = 0;
 static mut IS_PROXY: bool = false;
@@ -71,7 +71,6 @@ unsafe fn parse_command_line() {
 			}
 		};
 	}
-
 }
 
 /// Returns the cmdline argument passed in after "--"

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -46,35 +46,32 @@ unsafe fn parse_command_line() {
 	debug!("Got cmdline tokens as {:?}", tokens);
 
 	let mut tokeniter = tokens.into_iter();
-	loop {
-		if let Some(token) = tokeniter.next() {
-			match token.as_str() {
-				"-freq" => {
-					let mhz_str = tokeniter.next().expect("Invalid -freq command line");
-					COMMAND_LINE_CPU_FREQUENCY = mhz_str
-						.parse()
-						.expect("Could not parse -freq command line as number");
-				}
-				"-proxy" => {
-					IS_PROXY = true;
-				}
-				"--" => {
-					// Collect remaining arguments as applications argv
-					COMMAND_LINE_APPLICATION = Some(tokeniter.collect());
-					break;
-				}
-				_ if COMMAND_LINE_PATH.is_none() => {
-					// Qemu passes in the kernel path (rusty-loader) as first argument
-					COMMAND_LINE_PATH = Some(token)
-				}
-				_ => {
-					warn!("Unknown cmdline option: {} [{}]", token, cmdline_str);
-				}
-			};
-		} else {
-			break;
-		}
+	while let Some(token) = tokeniter.next() {
+		match token.as_str() {
+			"-freq" => {
+				let mhz_str = tokeniter.next().expect("Invalid -freq command line");
+				COMMAND_LINE_CPU_FREQUENCY = mhz_str
+					.parse()
+					.expect("Could not parse -freq command line as number");
+			}
+			"-proxy" => {
+				IS_PROXY = true;
+			}
+			"--" => {
+				// Collect remaining arguments as applications argv
+				COMMAND_LINE_APPLICATION = Some(tokeniter.collect());
+				break;
+			}
+			_ if COMMAND_LINE_PATH.is_none() => {
+				// Qemu passes in the kernel path (rusty-loader) as first argument
+				COMMAND_LINE_PATH = Some(token)
+			}
+			_ => {
+				warn!("Unknown cmdline option: {} [{}]", token, cmdline_str);
+			}
+		};
 	}
+
 }
 
 /// Returns the cmdline argument passed in after "--"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,9 +81,9 @@ mod synch;
 mod syscalls;
 mod util;
 
-pub use arch::*;
-pub use config::*;
-pub use syscalls::*;
+pub use crate::arch::*;
+pub use crate::config::*;
+pub use crate::syscalls::*;
 
 use alloc::alloc::Layout;
 use arch::percore::*;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -31,6 +31,7 @@ macro_rules! print {
 
 /// Print formatted text to our console, followed by a newline.
 macro_rules! println {
+    () => (print!("\n"));
 	($($arg:tt)+) => (print!("{}\n", format_args!($($arg)+)));
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -37,7 +37,7 @@ macro_rules! println {
 
 macro_rules! switch_to_kernel {
 	() => {
-		::arch::irq::disable();
+		crate::arch::irq::disable();
 		#[allow(unused)]
 		unsafe {
 			let user_stack_pointer;
@@ -48,32 +48,32 @@ macro_rules! switch_to_kernel {
 			);
 			core_scheduler().set_current_user_stack(user_stack_pointer);
 		}
-		::arch::irq::enable();
+		crate::arch::irq::enable();
 	}
 }
 
 macro_rules! switch_to_user {
 	() => {
-		use arch::kernel::percore::*;
+		use crate::arch::kernel::percore::*;
 
-		::arch::irq::disable();
+		crate::arch::irq::disable();
 		let user_stack_pointer = core_scheduler().get_current_user_stack();
 		#[allow(unused)]
 		unsafe {
 			// Switch to the user stack
 			llvm_asm!("mov $0, %rsp" :: "r"(user_stack_pointer) :: "volatile");
 		}
-		::arch::irq::enable();
+		crate::arch::irq::enable();
 	}
 }
 
 macro_rules! kernel_function {
 	($f:ident($($x:tt)*)) => {{
-		use arch::kernel::percore::*;
+		use crate::arch::kernel::percore::*;
 
 		#[allow(unused)]
 		unsafe {
-			::arch::irq::disable();
+			crate::arch::irq::disable();
 			let user_stack_pointer;
 			// Store the user stack pointer and switch to the kernel stack
 			llvm_asm!(
@@ -83,17 +83,17 @@ macro_rules! kernel_function {
 				:: "volatile"
 			);
 			core_scheduler().set_current_user_stack(user_stack_pointer);
-			::arch::irq::enable();
+			crate::arch::irq::enable();
 
 			let ret = $f($($x)*);
 
-			::arch::irq::disable();
+			crate::arch::irq::disable();
 			// Switch to the user stack
 			llvm_asm!("mov $0, %rsp"
 				:: "r"(core_scheduler().get_current_user_stack())
 				:: "volatile"
 			);
-			::arch::irq::enable();
+			crate::arch::irq::enable();
 
 			ret
 		}

--- a/src/mm/allocator.rs
+++ b/src/mm/allocator.rs
@@ -7,13 +7,13 @@
 
 #![allow(dead_code)]
 
+use crate::mm::hole::{Hole, HoleList};
+use crate::mm::kernel_end_address;
+use crate::synch::spinlock::*;
 use core::alloc::{AllocErr, AllocInit, AllocRef, GlobalAlloc, Layout, MemoryBlock};
 use core::ops::Deref;
 use core::ptr::NonNull;
 use core::{mem, ptr};
-use mm::hole::{Hole, HoleList};
-use mm::kernel_end_address;
-use synch::spinlock::*;
 
 /// Size of the preallocated space for the Bootstrap Allocator.
 const BOOTSTRAP_HEAP_SIZE: usize = 4096;

--- a/src/mm/freelist.rs
+++ b/src/mm/freelist.rs
@@ -5,8 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::collections::{DoublyLinkedList, Node};
 use alloc::rc::Rc;
-use collections::{DoublyLinkedList, Node};
 use core::cell::RefCell;
 
 pub struct FreeListEntry {
@@ -16,10 +16,7 @@ pub struct FreeListEntry {
 
 impl FreeListEntry {
 	pub const fn new(start: usize, end: usize) -> Self {
-		FreeListEntry {
-			start,
-			end,
-		}
+		FreeListEntry { start, end }
 	}
 }
 
@@ -256,15 +253,15 @@ fn allocate() {
 	freelist.list.push(entry);
 	let addr = freelist.allocate(0x1000);
 
-	assert!(addr.unwrap() != 0x1000);
+	assert_ne!(addr.unwrap(), 0x1000);
 	for node in freelist.list.iter() {
-		assert!(node.borrow_mut().value.start != 0x2000);
-		assert!(node.borrow_mut().value.end != 0x10000);
+		assert_ne!(node.borrow_mut().value.start, 0x2000);
+		assert_ne!(node.borrow_mut().value.end, 0x10000);
 	}
 
 	let addr = freelist.allocate_aligned(0x1000, 0x2000);
 	for node in freelist.list.iter() {
-		assert!(node.borrow_mut().value.start % 0x2000 != 0);
+		assert_ne!(node.borrow_mut().value.start % 0x2000, 0);
 	}
 }
 
@@ -281,7 +278,7 @@ fn deallocate() {
 	freelist.deallocate(addr.unwrap(), 0x1000);
 
 	for node in freelist.list.iter() {
-		assert!(node.borrow_mut().value.start != 0x1000);
-		assert!(node.borrow_mut().value.end != 0x10000);
+		assert_ne!(node.borrow_mut().value.start, 0x1000);
+		assert_ne!(node.borrow_mut().value.end, 0x10000);
 	}
 }

--- a/src/mm/freelist.rs
+++ b/src/mm/freelist.rs
@@ -17,8 +17,8 @@ pub struct FreeListEntry {
 impl FreeListEntry {
 	pub const fn new(start: usize, end: usize) -> Self {
 		FreeListEntry {
-			start: start,
-			end: end,
+			start,
+			end,
 		}
 	}
 }
@@ -59,7 +59,7 @@ impl FreeList {
 			} else if region_size == size {
 				// We have found a region that has exactly the requested size.
 				// Return the address to the beginning of that region and move the node into the pool for deletion or reuse.
-				self.list.remove(node.clone());
+				self.list.remove(node);
 				return Ok(region_start);
 			}
 		}
@@ -83,7 +83,7 @@ impl FreeList {
 		if region_start == address && region_end == end {
 			// We found free space that has exactly the address and size of the block we want to allocate.
 			// Remove it.
-			self.list.remove(node.clone());
+			self.list.remove(node);
 			return true;
 		} else if region_start < address && region_end == end {
 			// We found free space in which the block we want to allocate lies right-aligned.
@@ -185,7 +185,7 @@ impl FreeList {
 						// It can reunite, so let the current region span over the reunited region and move the duplicate node
 						// into the pool for deletion or reuse.
 						node.borrow_mut().value.end = next_region_end;
-						self.list.remove(next_node.clone());
+						self.list.remove(next_node);
 						return;
 					}
 				}

--- a/src/mm/hole.rs
+++ b/src/mm/hole.rs
@@ -27,7 +27,7 @@ impl HoleList {
 	/// creates a hole at the given `hole_addr`. This can cause undefined behavior if this address
 	/// is invalid or if memory from the `[hole_addr, hole_addr+size) range is used somewhere else.
 	pub unsafe fn new(hole_addr: usize, hole_size: usize) -> HoleList {
-		assert!(size_of::<Hole>() == Self::min_size());
+		assert_eq!(size_of::<Hole>(), Self::min_size());
 
 		let ptr = hole_addr as *mut Hole;
 		ptr.write(Hole::new(hole_size, None));

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -292,7 +292,7 @@ pub fn map(
 pub fn unmap(virtual_address: usize, sz: usize) {
 	let size = align_up!(sz, BasePageSize::SIZE);
 
-	if let Some(_) = arch::mm::paging::get_page_table_entry::<BasePageSize>(virtual_address) {
+	if arch::mm::paging::get_page_table_entry::<BasePageSize>(virtual_address).is_some() {
 		arch::mm::paging::unmap::<BasePageSize>(virtual_address, size / BasePageSize::SIZE);
 		arch::mm::virtualmem::deallocate(virtual_address, size);
 	} else {

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -11,14 +11,16 @@ mod hole;
 #[cfg(test)]
 mod test;
 
-use arch;
-use arch::mm::paging::{BasePageSize, HugePageSize, LargePageSize, PageSize, PageTableEntryFlags};
-use arch::mm::physicalmem::total_memory_size;
+use crate::arch;
+use crate::arch::mm::paging::{
+	BasePageSize, HugePageSize, LargePageSize, PageSize, PageTableEntryFlags,
+};
+use crate::arch::mm::physicalmem::total_memory_size;
 #[cfg(feature = "newlib")]
-use arch::mm::virtualmem::kernel_heap_end;
+use crate::arch::mm::virtualmem::kernel_heap_end;
+use crate::environment;
 use core::mem;
 use core::sync::atomic::spin_loop_hint;
-use environment;
 
 /// Physical and virtual address of the first 2 MiB page that maps the kernel.
 /// Can be easily accessed through kernel_start_address()
@@ -185,7 +187,7 @@ pub fn init() {
 
 		unsafe {
 			HEAP_START_ADDRESS = virt_addr;
-			::ALLOCATOR.lock().init(virt_addr, virt_size);
+			crate::ALLOCATOR.lock().init(virt_addr, virt_size);
 		}
 
 		map_addr = virt_addr + counter;

--- a/src/mm/test.rs
+++ b/src/mm/test.rs
@@ -10,16 +10,16 @@ use core::alloc::Layout;
 use std::mem::{align_of, size_of};
 use std::prelude::v1::*;
 
-use mm::allocator::*;
-use mm::hole::*;
+use crate::mm::allocator::*;
+use crate::mm::hole::*;
 
 fn new_heap() -> Heap {
 	const HEAP_SIZE: usize = 1000;
 	let heap_space = Box::into_raw(Box::new([0u8; HEAP_SIZE]));
 
 	let heap = unsafe { Heap::new(heap_space as usize, HEAP_SIZE) };
-	assert!(heap.bottom() == heap_space as usize);
-	assert!(heap.size() == HEAP_SIZE);
+	assert_eq!(heap.bottom(), heap_space as usize);
+	assert_eq!(heap.size(), HEAP_SIZE);
 	heap
 }
 
@@ -29,8 +29,8 @@ fn new_max_heap() -> Heap {
 	let heap_space = Box::into_raw(Box::new([0u8; HEAP_SIZE_MAX]));
 
 	let heap = unsafe { Heap::new(heap_space as usize, HEAP_SIZE) };
-	assert!(heap.bottom() == heap_space as usize);
-	assert!(heap.size() == HEAP_SIZE);
+	assert_eq!(heap.bottom(), heap_space as usize);
+	assert_eq!(heap.size(), HEAP_SIZE);
 	heap
 }
 
@@ -62,7 +62,7 @@ fn allocate_double_usize() {
 	let addr = heap.allocate_first_fit(layout.unwrap());
 	assert!(addr.is_ok());
 	let addr = addr.unwrap().0.as_ptr() as usize;
-	assert!(addr == heap.bottom());
+	assert_eq!(addr, heap.bottom());
 	let (hole_addr, hole_size) = heap.holes.first_hole().expect("ERROR: no hole left");
 
 	// note: the smallest allocation granularity is 64 byte

--- a/src/runtime_glue.rs
+++ b/src/runtime_glue.rs
@@ -30,7 +30,7 @@ fn panic(info: &PanicInfo) -> ! {
 		print!("{}", message);
 	}
 
-	println!("");
+	println!();
 
 	if run_on_hypervisor() {
 		__sys_shutdown(1);

--- a/src/runtime_glue.rs
+++ b/src/runtime_glue.rs
@@ -9,11 +9,10 @@
 //! Minor functions that Rust really expects to be defined by the compiler,
 //! but which we need to provide manually because we're on bare metal.
 
+use crate::arch::kernel::processor::run_on_hypervisor;
+use crate::{__sys_shutdown, arch};
 use alloc::alloc::Layout;
-use arch;
-use arch::kernel::processor::run_on_hypervisor;
 use core::panic::PanicInfo;
-use syscalls::__sys_shutdown;
 
 // see https://users.rust-lang.org/t/psa-breaking-change-panic-fmt-language-item-removed-in-favor-of-panic-implementation/17875
 #[cfg(not(test))]

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -8,19 +8,19 @@
 
 pub mod task;
 
+use crate::arch;
+use crate::arch::irq;
+use crate::arch::percore::*;
+use crate::arch::switch;
+use crate::collections::AvoidInterrupts;
+use crate::config::*;
+use crate::scheduler::task::*;
+use crate::synch::spinlock::*;
 use alloc::boxed::Box;
 use alloc::collections::{BTreeMap, VecDeque};
 use alloc::rc::Rc;
-use arch;
-use arch::irq;
-use arch::percore::*;
-use arch::switch;
-use collections::AvoidInterrupts;
-use config::*;
 use core::cell::RefCell;
 use core::sync::atomic::{AtomicU32, Ordering};
-use scheduler::task::*;
-use synch::spinlock::*;
 
 /// Time slice of a task in microseconds.
 /// When this time has elapsed and the scheduler is called, it may switch to another ready task.

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -99,10 +99,10 @@ impl PerCoreScheduler {
 			NO_TASKS.fetch_add(1, Ordering::SeqCst);
 
 			if core_id != core_scheduler().core_id {
-				input_locked.new_tasks.push_back(task.clone());
+				input_locked.new_tasks.push_back(task);
 				true
 			} else {
-				core_scheduler().ready_queue.push(task.clone());
+				core_scheduler().ready_queue.push(task);
 				false
 			}
 		};
@@ -126,8 +126,9 @@ impl PerCoreScheduler {
 
 			// Get the current task.
 			let mut current_task_borrowed = self.current_task.borrow_mut();
-			assert!(
-				current_task_borrowed.status != TaskStatus::TaskIdle,
+			assert_ne!(
+				current_task_borrowed.status,
+				TaskStatus::TaskIdle,
 				"Trying to terminate the idle task"
 			);
 
@@ -182,10 +183,10 @@ impl PerCoreScheduler {
 			TASKS.lock().insert(tid, VecDeque::with_capacity(1));
 			NO_TASKS.fetch_add(1, Ordering::SeqCst);
 			if core_id != core_scheduler().core_id {
-				input_locked.new_tasks.push_back(clone_task.clone());
+				input_locked.new_tasks.push_back(clone_task);
 				true
 			} else {
-				core_scheduler().ready_queue.push(clone_task.clone());
+				core_scheduler().ready_queue.push(clone_task);
 				false
 			}
 		};
@@ -526,7 +527,7 @@ pub fn add_current_core() {
 		core_id, tid
 	);
 	let boxed_scheduler = Box::new(PerCoreScheduler {
-		core_id: core_id,
+		core_id,
 		current_task: idle_task.clone(),
 		idle_task: idle_task.clone(),
 		fpu_owner: idle_task,

--- a/src/scheduler/task.rs
+++ b/src/scheduler/task.rs
@@ -6,17 +6,17 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::arch;
+use crate::arch::percore::*;
+use crate::arch::processor::msb;
+use crate::arch::scheduler::{TaskStacks, TaskTLS};
+use crate::collections::{DoublyLinkedList, Node};
+use crate::scheduler::CoreId;
 use alloc::collections::VecDeque;
 use alloc::rc::Rc;
-use arch;
-use arch::percore::*;
-use arch::processor::msb;
-use arch::scheduler::{TaskStacks, TaskTLS};
-use collections::{DoublyLinkedList, Node};
 use core::cell::RefCell;
 use core::convert::TryInto;
 use core::fmt;
-use scheduler::CoreId;
 
 /// The status of the task - used for scheduling
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -141,7 +141,7 @@ impl TaskHandlePriorityQueue {
 		let i = task.priority.into() as usize;
 		//assert!(i < NO_PRIORITIES, "Priority {} is too high", i);
 
-		self.prio_bitmap |= 1 << i;
+		self.prio_bitmap |= (1 << i) as u64;
 		if let Some(queue) = &mut self.queues[i] {
 			queue.push_back(task);
 		} else {

--- a/src/scheduler/task.rs
+++ b/src/scheduler/task.rs
@@ -98,9 +98,9 @@ pub struct TaskHandle {
 impl TaskHandle {
 	pub fn new(id: TaskId, priority: Priority, core_id: CoreId) -> Self {
 		Self {
-			id: id,
-			priority: priority,
-			core_id: core_id,
+			id,
+			priority,
+			core_id,
 		}
 	}
 
@@ -271,7 +271,7 @@ impl PriorityTaskQueue {
 		let i = task.borrow().prio.into() as usize;
 		//assert!(i < NO_PRIORITIES, "Priority {} is too high", i);
 
-		self.prio_bitmap |= 1 << i;
+		self.prio_bitmap |= (1 << i) as u64;
 		match self.queues[i].tail {
 			None => {
 				// first element in the queue
@@ -291,7 +291,7 @@ impl PriorityTaskQueue {
 			}
 		}
 
-		self.queues[i].tail = Some(task.clone());
+		self.queues[i].tail = Some(task);
 	}
 
 	fn pop_from_queue(&mut self, queue_index: usize) -> Option<Rc<RefCell<Task>>> {
@@ -413,7 +413,7 @@ impl Task {
 			last_stack_pointer: 0,
 			user_stack_pointer: 0,
 			last_fpu_state: arch::processor::FPUState::new(),
-			core_id: core_id,
+			core_id,
 			stacks: TaskStacks::new(stack_size),
 			next: None,
 			prev: None,
@@ -434,7 +434,7 @@ impl Task {
 			last_stack_pointer: 0,
 			user_stack_pointer: 0,
 			last_fpu_state: arch::processor::FPUState::new(),
-			core_id: core_id,
+			core_id,
 			stacks: TaskStacks::from_boot_stacks(),
 			next: None,
 			prev: None,
@@ -455,7 +455,7 @@ impl Task {
 			last_stack_pointer: 0,
 			user_stack_pointer: 0,
 			last_fpu_state: arch::processor::FPUState::new(),
-			core_id: core_id,
+			core_id,
 			stacks: task.stacks.clone(),
 			next: None,
 			prev: None,
@@ -525,18 +525,16 @@ impl BlockedTaskQueue {
 			let mut borrowed = task.borrow_mut();
 			debug!("Blocking task {}", borrowed.id);
 
-			assert!(
-				borrowed.status == TaskStatus::TaskRunning,
+			assert_eq!(
+				borrowed.status,
+				TaskStatus::TaskRunning,
 				"Trying to block task {} which is not running",
 				borrowed.id
 			);
 			borrowed.status = TaskStatus::TaskBlocked;
 		}
 
-		let new_node = Node::new(BlockedTask {
-			task: task,
-			wakeup_time: wakeup_time,
-		});
+		let new_node = Node::new(BlockedTask { task, wakeup_time });
 
 		// Shall the task automatically be woken up after a certain time?
 		if let Some(wt) = wakeup_time {

--- a/src/synch/recmutex.rs
+++ b/src/synch/recmutex.rs
@@ -5,9 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch::percore::*;
-use scheduler::task::{TaskHandlePriorityQueue, TaskId};
-use synch::spinlock::Spinlock;
+use crate::arch::percore::*;
+use crate::scheduler::task::{TaskHandlePriorityQueue, TaskId};
+use crate::synch::spinlock::Spinlock;
 
 struct RecursiveMutexState {
 	current_tid: Option<TaskId>,

--- a/src/synch/semaphore.rs
+++ b/src/synch/semaphore.rs
@@ -6,9 +6,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch::percore::*;
-use scheduler::task::{TaskHandlePriorityQueue, WakeupReason};
-use synch::spinlock::SpinlockIrqSave;
+use crate::arch::percore::*;
+use crate::scheduler::task::{TaskHandlePriorityQueue, WakeupReason};
+use crate::synch::spinlock::SpinlockIrqSave;
 
 struct SemaphoreState {
 	/// Resource available count

--- a/src/synch/semaphore.rs
+++ b/src/synch/semaphore.rs
@@ -62,7 +62,7 @@ impl Semaphore {
 	pub const fn new(count: isize) -> Self {
 		Self {
 			state: SpinlockIrqSave::new(SemaphoreState {
-				count: count,
+				count,
 				queue: TaskHandlePriorityQueue::new(),
 			}),
 		}

--- a/src/synch/spinlock.rs
+++ b/src/synch/spinlock.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch::irq;
+use crate::arch::irq;
 use core::cell::UnsafeCell;
 use core::fmt;
 use core::marker::Sync;

--- a/src/syscalls/condvar.rs
+++ b/src/syscalls/condvar.rs
@@ -8,10 +8,10 @@
 // The implementation is inspired by Andrew D. Birrell's paper
 // "Implementing Condition Variables with Semaphores"
 
+use crate::synch::semaphore::Semaphore;
 use alloc::boxed::Box;
 use core::mem;
 use core::sync::atomic::{AtomicIsize, Ordering};
-use synch::semaphore::Semaphore;
 
 struct CondQueue {
 	counter: AtomicIsize,

--- a/src/syscalls/fs.rs
+++ b/src/syscalls/fs.rs
@@ -5,12 +5,12 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::synch::spinlock::Spinlock;
 use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
-use synch::spinlock::Spinlock;
 
 /*
 Design:

--- a/src/syscalls/fs.rs
+++ b/src/syscalls/fs.rs
@@ -98,11 +98,11 @@ impl Filesystem {
 		path: &'b str,
 	) -> Result<(&'a Box<dyn PosixFileSystem>, &'b str), FileError> {
 		// assert start with / (no pwd relative!), split path at /, look first element. Determine backing fs. If non existent, -ENOENT
-		if !path.starts_with("/") {
+		if !path.starts_with('/') {
 			warn!("Relative paths not allowed!");
 			return Err(FileError::ENOENT());
 		}
-		let mut pathsplit = path.splitn(3, "/");
+		let mut pathsplit = path.splitn(3, '/');
 		pathsplit.next(); // always empty, since first char is /
 		let mount = pathsplit.next().unwrap();
 		let internal_path = pathsplit.next().unwrap(); //TODO: this can fail from userspace, eg when passing "/test"
@@ -114,7 +114,7 @@ impl Filesystem {
 				"Trying to open file on non-existing mount point '{}'!",
 				mount
 			);
-			return Err(FileError::ENOENT());
+			Err(FileError::ENOENT())
 		}
 	}
 
@@ -147,7 +147,7 @@ impl Filesystem {
 	/// Create new backing-fs at mountpoint mntpath
 	pub fn mount(&mut self, mntpath: &str, mntobj: Box<dyn PosixFileSystem>) -> Result<(), ()> {
 		info!("Mounting {}", mntpath);
-		if mntpath.contains("/") {
+		if mntpath.contains('/') {
 			warn!(
 				"Trying to mount at '{}', but slashes in name are not supported!",
 				mntpath

--- a/src/syscalls/interfaces/generic.rs
+++ b/src/syscalls/interfaces/generic.rs
@@ -6,7 +6,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use syscalls::interfaces::SyscallInterface;
+use crate::syscalls::interfaces::SyscallInterface;
 
 // The generic interface simply uses all default implementations of the
 // SyscallInterface trait.

--- a/src/syscalls/interfaces/mod.rs
+++ b/src/syscalls/interfaces/mod.rs
@@ -12,19 +12,19 @@ mod uhyve;
 
 pub use self::generic::*;
 pub use self::uhyve::*;
+use crate::arch;
+use crate::console;
+use crate::environment;
+use crate::errno::*;
+use crate::synch::spinlock::SpinlockIrqSave;
+use crate::util;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use arch;
-use console;
 use core::convert::{TryFrom, TryInto};
 use core::fmt::Write;
 use core::{isize, ptr, slice, str};
-use environment;
-use errno::*;
-use synch::spinlock::SpinlockIrqSave;
-use util;
 
-use syscalls::fs::{self, FilePerms, PosixFile, SeekWhence};
+use crate::syscalls::fs::{self, FilePerms, PosixFile, SeekWhence};
 
 static DRIVER_LOCK: SpinlockIrqSave<()> = SpinlockIrqSave::new(());
 

--- a/src/syscalls/interfaces/mod.rs
+++ b/src/syscalls/interfaces/mod.rs
@@ -175,7 +175,10 @@ pub trait SyscallInterface: Send + Sync {
 		let _lock = DRIVER_LOCK.lock();
 
 		match arch::kernel::pci::get_network_driver() {
-			Some(driver) => Ok(driver.borrow_mut().rx_buffer_consumed()),
+			Some(driver) => {
+				driver.borrow_mut().rx_buffer_consumed();
+				Ok(())
+			}
 			_ => Err(()),
 		}
 	}
@@ -231,7 +234,7 @@ pub trait SyscallInterface: Send + Sync {
 
 		let mut fs = fs::FILESYSTEM.lock();
 		fs.close(fd as u64);
-		return 0;
+		0
 	}
 
 	#[cfg(not(target_arch = "x86_64"))]

--- a/src/syscalls/interfaces/uhyve.rs
+++ b/src/syscalls/interfaces/uhyve.rs
@@ -5,14 +5,14 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch;
-use arch::mm::paging;
+use crate::arch;
+use crate::arch::mm::paging;
+use crate::syscalls::interfaces::SyscallInterface;
+#[cfg(feature = "newlib")]
+use crate::syscalls::lwip::sys_lwip_get_errno;
+#[cfg(feature = "newlib")]
+use crate::syscalls::{LWIP_FD_BIT, LWIP_LOCK};
 use core::{mem, ptr, slice};
-use syscalls::interfaces::SyscallInterface;
-#[cfg(feature = "newlib")]
-use syscalls::lwip::sys_lwip_get_errno;
-#[cfg(feature = "newlib")]
-use syscalls::{LWIP_FD_BIT, LWIP_LOCK};
 
 #[cfg(target_arch = "x86_64")]
 use x86::io::*;
@@ -166,11 +166,7 @@ struct SysWrite {
 
 impl SysWrite {
 	fn new(fd: i32, buf: *const u8, len: usize) -> SysWrite {
-		SysWrite {
-			fd,
-			buf,
-			len,
-		}
+		SysWrite { fd, buf, len }
 	}
 }
 
@@ -183,11 +179,7 @@ struct SysLseek {
 
 impl SysLseek {
 	fn new(fd: i32, offset: isize, whence: i32) -> SysLseek {
-		SysLseek {
-			fd,
-			offset,
-			whence,
-		}
+		SysLseek { fd, offset, whence }
 	}
 }
 
@@ -221,18 +213,18 @@ impl SyscallInterface for Uhyve {
 		uhyve_send(UHYVE_PORT_CMDSIZE, &mut syscmdsize);
 
 		// create array to receive all arguments
-		let argv_raw = ::__sys_malloc(
+		let argv_raw = crate::__sys_malloc(
 			syscmdsize.argc as usize * mem::size_of::<*const u8>(),
 			mem::size_of::<*const u8>(),
 		) as *mut *const u8;
-		let argv_phy_raw = ::__sys_malloc(
+		let argv_phy_raw = crate::__sys_malloc(
 			syscmdsize.argc as usize * mem::size_of::<*const u8>(),
 			mem::size_of::<*const u8>(),
 		) as *mut *const u8;
 		let argv = unsafe { slice::from_raw_parts_mut(argv_raw, syscmdsize.argc as usize) };
 		let argv_phy = unsafe { slice::from_raw_parts_mut(argv_phy_raw, syscmdsize.argc as usize) };
 		for i in 0..syscmdsize.argc as usize {
-			argv[i] = ::__sys_malloc(
+			argv[i] = crate::__sys_malloc(
 				syscmdsize.argsz[i] as usize * mem::size_of::<*const u8>(),
 				1,
 			);
@@ -240,11 +232,11 @@ impl SyscallInterface for Uhyve {
 		}
 
 		// create array to receive the environment
-		let env_raw = ::__sys_malloc(
+		let env_raw = crate::__sys_malloc(
 			(syscmdsize.envc + 1) as usize * mem::size_of::<*const u8>(),
 			mem::size_of::<*const u8>(),
 		) as *mut *const u8;
-		let env_phy_raw = ::__sys_malloc(
+		let env_phy_raw = crate::__sys_malloc(
 			(syscmdsize.envc + 1) as usize * mem::size_of::<*const u8>(),
 			mem::size_of::<*const u8>(),
 		) as *mut *const u8;
@@ -252,7 +244,7 @@ impl SyscallInterface for Uhyve {
 		let env_phy =
 			unsafe { slice::from_raw_parts_mut(env_phy_raw, (syscmdsize.envc + 1) as usize) };
 		for i in 0..syscmdsize.envc as usize {
-			env[i] = ::__sys_malloc(
+			env[i] = crate::__sys_malloc(
 				syscmdsize.envsz[i] as usize * mem::size_of::<*const u8>(),
 				1,
 			);
@@ -266,12 +258,12 @@ impl SyscallInterface for Uhyve {
 		uhyve_send(UHYVE_PORT_CMDVAL, &mut syscmdval);
 
 		// free temporary array
-		::__sys_free(
+		crate::__sys_free(
 			argv_phy_raw as *mut u8,
 			syscmdsize.argc as usize * mem::size_of::<*const u8>(),
 			mem::size_of::<*const u8>(),
 		);
-		::__sys_free(
+		crate::__sys_free(
 			env_phy_raw as *mut u8,
 			(syscmdsize.envc + 1) as usize * mem::size_of::<*const u8>(),
 			mem::size_of::<*const u8>(),

--- a/src/syscalls/interfaces/uhyve.rs
+++ b/src/syscalls/interfaces/uhyve.rs
@@ -88,7 +88,7 @@ struct SysExit {
 
 impl SysExit {
 	fn new(arg: i32) -> SysExit {
-		SysExit { arg: arg }
+		SysExit { arg }
 	}
 }
 
@@ -119,8 +119,8 @@ impl SysOpen {
 	fn new(name: *const u8, flags: i32, mode: i32) -> SysOpen {
 		SysOpen {
 			name: paging::virtual_to_physical(name as usize) as *const u8,
-			flags: flags,
-			mode: mode,
+			flags,
+			mode,
 			ret: -1,
 		}
 	}
@@ -149,9 +149,9 @@ struct SysRead {
 impl SysRead {
 	fn new(fd: i32, buf: *const u8, len: usize) -> SysRead {
 		SysRead {
-			fd: fd,
-			buf: buf,
-			len: len,
+			fd,
+			buf,
+			len,
 			ret: -1,
 		}
 	}
@@ -167,9 +167,9 @@ struct SysWrite {
 impl SysWrite {
 	fn new(fd: i32, buf: *const u8, len: usize) -> SysWrite {
 		SysWrite {
-			fd: fd,
-			buf: buf,
-			len: len,
+			fd,
+			buf,
+			len,
 		}
 	}
 }
@@ -184,9 +184,9 @@ struct SysLseek {
 impl SysLseek {
 	fn new(fd: i32, offset: isize, whence: i32) -> SysLseek {
 		SysLseek {
-			fd: fd,
-			offset: offset,
-			whence: whence,
+			fd,
+			offset,
+			whence,
 		}
 	}
 }

--- a/src/syscalls/lwip.rs
+++ b/src/syscalls/lwip.rs
@@ -5,10 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch;
-use arch::percore::*;
-use console;
-use synch::spinlock::SpinlockIrqSaveGuard;
+use crate::arch;
+use crate::arch::percore::*;
+use crate::console;
+use crate::synch::spinlock::SpinlockIrqSaveGuard;
 
 /// Enables lwIP's printf to print a whole string without being interrupted by
 /// a message from the kernel.

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -148,7 +148,7 @@ pub fn sys_netwakeup() {
 }
 
 pub fn __sys_netwait(millis: Option<u64>) {
-	if unsafe { SYS.has_packet() } == false {
+	if !unsafe { SYS.has_packet() } {
 		netwait(millis)
 	}
 }

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -32,11 +32,11 @@ pub use self::timer::*;
 #[cfg(not(test))]
 use crate::{__sys_free, __sys_malloc, __sys_realloc};
 
-use drivers::net::*;
-use environment;
+use crate::drivers::net::*;
+use crate::environment;
 #[cfg(feature = "newlib")]
-use synch::spinlock::SpinlockIrqSave;
-use syscalls::interfaces::SyscallInterface;
+use crate::synch::spinlock::SpinlockIrqSave;
+use crate::syscalls::interfaces::SyscallInterface;
 
 #[cfg(feature = "newlib")]
 const LWIP_FD_BIT: i32 = 1 << 30;

--- a/src/syscalls/processor.rs
+++ b/src/syscalls/processor.rs
@@ -5,11 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch;
+use crate::arch::get_processor_count;
 use core::convert::TryInto;
 
 fn __sys_get_processor_count() -> usize {
-	arch::get_processor_count().try_into().unwrap()
+	get_processor_count().try_into().unwrap()
 }
 
 /** Returns the number of processors currently online. */
@@ -19,7 +19,7 @@ pub extern "C" fn sys_get_processor_count() -> usize {
 }
 
 fn __sys_get_processor_frequency() -> u16 {
-	arch::processor::get_frequency()
+	crate::arch::processor::get_frequency()
 }
 
 /** Returns the processor frequency in MHz. */

--- a/src/syscalls/random.rs
+++ b/src/syscalls/random.rs
@@ -5,8 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch;
-use synch::spinlock::Spinlock;
+use crate::arch;
+use crate::synch::spinlock::Spinlock;
 
 static PARK_MILLER_LEHMER_SEED: Spinlock<u32> = Spinlock::new(0);
 

--- a/src/syscalls/recmutex.rs
+++ b/src/syscalls/recmutex.rs
@@ -5,9 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::errno::*;
+use crate::synch::recmutex::RecursiveMutex;
 use alloc::boxed::Box;
-use errno::*;
-use synch::recmutex::RecursiveMutex;
 
 fn __sys_recmutex_init(recmutex: *mut *mut RecursiveMutex) -> i32 {
 	if recmutex.is_null() {

--- a/src/syscalls/semaphore.rs
+++ b/src/syscalls/semaphore.rs
@@ -5,10 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::arch;
+use crate::errno::*;
+use crate::synch::semaphore::Semaphore;
 use alloc::boxed::Box;
-use arch;
-use errno::*;
-use synch::semaphore::Semaphore;
 
 fn __sys_sem_init(sem: *mut *mut Semaphore, value: u32) -> i32 {
 	if sem.is_null() {

--- a/src/syscalls/spinlock.rs
+++ b/src/syscalls/spinlock.rs
@@ -5,9 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::errno::*;
+use crate::synch::spinlock::*;
 use alloc::boxed::Box;
-use errno::*;
-use synch::spinlock::*;
 
 pub struct SpinlockContainer<'a> {
 	lock: Spinlock<()>,

--- a/src/syscalls/system.rs
+++ b/src/syscalls/system.rs
@@ -21,10 +21,10 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use arch;
+use crate::arch;
 
 fn __sys_getpagesize() -> i32 {
-	arch::mm::paging::get_application_page_size() as i32
+	arch::x86_64::mm::paging::get_application_page_size() as i32
 }
 
 #[no_mangle]

--- a/src/syscalls/tasks.rs
+++ b/src/syscalls/tasks.rs
@@ -4,23 +4,22 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
-
-use arch;
-use arch::kernel::get_processor_count;
-use arch::percore::*;
-use config::USER_STACK_SIZE;
+use crate::arch;
+use crate::arch::kernel::get_processor_count;
+use crate::arch::percore::*;
+use crate::config::USER_STACK_SIZE;
+use crate::errno::*;
+#[cfg(feature = "newlib")]
+use crate::mm::{task_heap_end, task_heap_start};
+use crate::scheduler;
+use crate::scheduler::task::{Priority, TaskId};
+use crate::syscalls;
+use crate::syscalls::timer::timespec;
 use core::convert::TryInto;
 use core::isize;
 #[cfg(feature = "newlib")]
 use core::sync::atomic::AtomicUsize;
 use core::sync::atomic::{AtomicU32, Ordering};
-use errno::*;
-#[cfg(feature = "newlib")]
-use mm::{task_heap_end, task_heap_start};
-use scheduler;
-use scheduler::task::{Priority, TaskId};
-use syscalls;
-use syscalls::timer::timespec;
 
 #[cfg(feature = "newlib")]
 pub type SignalHandler = extern "C" fn(i32);
@@ -67,7 +66,7 @@ pub extern "C" fn sys_exit(arg: i32) -> ! {
 
 fn __sys_thread_exit(arg: i32) -> ! {
 	debug!("Exit thread with error code {}!", arg);
-	core_scheduler().exit(arg);
+	core_scheduler().exit(arg)
 }
 
 #[no_mangle]

--- a/src/syscalls/timer.rs
+++ b/src/syscalls/timer.rs
@@ -5,9 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch;
-use errno::*;
-use syscalls::__sys_usleep;
+use crate::arch;
+use crate::errno::*;
+use crate::syscalls::__sys_usleep;
 
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -32,15 +32,15 @@ pub fn c_strbuflen(c_strbuf: &[u8]) -> usize {
 	c_strbuf
 		.iter()
 		.position(|&s| s == 0)
-		.unwrap_or(c_strbuf.len())
+		.unwrap_or_else(|| c_strbuf.len())
 }
 
-/// Converts (optional null terminated) c string buffer into onwed rust utf8 string.
+/// Converts (optional null terminated) c string buffer into owned rust utf8 string.
 /// Is safe, since input buffer has fixed length
 /// TODO: panics if not utf8. return error
 pub fn c_buf_to_str(c_strbuf: &[u8]) -> &str {
 	let len = c_strbuflen(c_strbuf);
-	core::str::from_utf8(&c_strbuf[0..len]).unwrap().into()
+	core::str::from_utf8(&c_strbuf[0..len]).unwrap()
 }
 
 /// Splits a string at delimiter, except when its quoted with " or '. Useful for cmdline arguments.
@@ -55,7 +55,7 @@ pub fn tokenize(cmdline: &str, delimiter: char) -> Vec<String> {
 		if let Some(c) = chars.next() {
 			match c {
 				_ if c == delimiter => {
-					if current_token.len() > 0 {
+					if !current_token.is_empty() {
 						tokens.push(current_token.clone());
 						current_token.clear();
 					}
@@ -71,13 +71,13 @@ pub fn tokenize(cmdline: &str, delimiter: char) -> Vec<String> {
 				}
 			};
 		} else {
-			if current_token.len() > 0 {
+			if !current_token.is_empty() {
 				tokens.push(current_token);
 			}
 			break;
 		}
 	}
-	return tokens;
+	tokens
 }
 
 /// Very simple unquote function for a string with unknown end. Used in conjunction with tokenize for parsing argument lists.


### PR DESCRIPTION
This PR consists of two commits. The first addresses various Clippy warning.
Pinging @tlambertz: I changed occurences of `bar` into `pci_bar` or `mem_bar`, since clippy warned that bar is a black listed identifier. Please have a look and tell me if I accidentally broke something, or you want to suggest a different name.

The second commit is to compile the library with rust edition 2018. It mostly adds `crate::`. 

Please have a special look at places with `use x86` since i was unsure if this refers to the external crate or the `crate::x86`. In places where my IDE could resolve the import `use crate:x86::xxx` I chose that, otherwise I left it as `use x86:xxx`

Other than that this should be pretty straightforward.