### PR TITLE
CI: Remove cargo download step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,8 +57,6 @@ jobs:
       - name: Cargo Test libhermit-rs
         run: cargo test
         working-directory: libhermit-rs
-      - name: Install cargo-download
-        run: cargo install cargo-download
       - name: Install qemu/nasm (apt)
         run: sudo apt-get update --fix-missing && sudo apt-get install qemu-system-x86 nasm
         if: ${{ matrix.os == 'ubuntu-latest' }}


### PR DESCRIPTION
Since we aren't downloading from cargo.io cargo download isn't actually needed in this workflow, so it doesn't have to be installed.