### PR TITLE
Safety: Mark __sys_realloc and __sys_free as unsafe

### DIFF
--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -6,6 +6,24 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::drivers::net::*;
+use crate::environment;
+#[cfg(feature = "newlib")]
+use crate::synch::spinlock::SpinlockIrqSave;
+use crate::syscalls::interfaces::SyscallInterface;
+#[cfg(not(test))]
+use crate::{__sys_free, __sys_malloc, __sys_realloc};
+
+pub use self::condvar::*;
+pub use self::processor::*;
+pub use self::random::*;
+pub use self::recmutex::*;
+pub use self::semaphore::*;
+pub use self::spinlock::*;
+pub use self::system::*;
+pub use self::tasks::*;
+pub use self::timer::*;
+
 mod condvar;
 pub mod fs;
 mod interfaces;
@@ -19,24 +37,6 @@ mod spinlock;
 mod system;
 mod tasks;
 mod timer;
-
-pub use self::condvar::*;
-pub use self::processor::*;
-pub use self::random::*;
-pub use self::recmutex::*;
-pub use self::semaphore::*;
-pub use self::spinlock::*;
-pub use self::system::*;
-pub use self::tasks::*;
-pub use self::timer::*;
-#[cfg(not(test))]
-use crate::{__sys_free, __sys_malloc, __sys_realloc};
-
-use crate::drivers::net::*;
-use crate::environment;
-#[cfg(feature = "newlib")]
-use crate::synch::spinlock::SpinlockIrqSave;
-use crate::syscalls::interfaces::SyscallInterface;
 
 #[cfg(feature = "newlib")]
 const LWIP_FD_BIT: i32 = 1 << 30;
@@ -74,13 +74,13 @@ pub extern "C" fn sys_malloc(size: usize, align: usize) -> *mut u8 {
 #[cfg(not(test))]
 #[no_mangle]
 pub extern "C" fn sys_realloc(ptr: *mut u8, size: usize, align: usize, new_size: usize) -> *mut u8 {
-	__sys_realloc(ptr, size, align, new_size)
+	unsafe { __sys_realloc(ptr, size, align, new_size) }
 }
 
 #[cfg(not(test))]
 #[no_mangle]
 pub extern "C" fn sys_free(ptr: *mut u8, size: usize, align: usize) {
-	__sys_free(ptr, size, align)
+	unsafe { __sys_free(ptr, size, align) }
 }
 
 pub fn get_application_parameters() -> (i32, *const *const u8, *const *const u8) {


### PR DESCRIPTION
This PR adresses the Safety of the internal `malloc`, `free` and `realloc` functions. 
# __sys_realloc, __sys_free and __sys_malloc
- Add Errors section to docs
- Check if parameters (size > 0, generated layout) are valid and warn/return an error if this is not the case

# __sys_realloc, __sys_free
- Mark as **unsafe** 
- Add detailed Safety section (relevant sections taken from the internally used unsafe functions)
- Suggestion: Maybe we could add some structure that tracks the pointers created/destroyed with malloc/realloc and free? If we did that, I think we could make them safe again, but this would cause a performance overhead. Comments?

# uhyve::get_application_parameters()
- make internal block unsafe and add Todos and Fixmes since this still needs some work!
- Suggestion: I would personally like to change the whole signature of the trait and return some structure which is not so close to c. Specifically I'd prefer to use Option or Result, to be able to signal Errors and some rust structure instead of `argc` and raw pointers. Comments on this are welcome.

# syscalls
- wrap the now unsafe function calls in unsafe. Since the wrapper function is extern "C", which is also unsafe for any caller, this should be fine.
- I didn't add docs here. I would assume the write place would be to add docs for this would be in the hermit-abi crate, since that is where the declaration is. Any comments?
