### PR TITLE
Add UTF-8 support to Console

### DIFF
--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -70,5 +70,5 @@ pub use crate::arch::x86_64::kernel::{
 };
 #[cfg(target_arch = "x86_64")]
 pub use crate::arch::x86_64::kernel::{
-	get_processor_count, message_output_init, output_message_byte,
+	get_processor_count, message_output_init, output_message_buf, output_message_byte,
 };

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -277,6 +277,13 @@ pub fn output_message_byte(byte: u8) {
 	}
 }
 
+//#[cfg(not(test))]
+pub fn output_message_buf(buf: &[u8]) {
+	for byte in buf {
+		output_message_byte(*byte);
+	}
+}
+
 /// Real Boot Processor initialization as soon as we have put the first Welcome message on the screen.
 #[cfg(not(test))]
 pub fn boot_processor_init() {

--- a/src/console.rs
+++ b/src/console.rs
@@ -15,18 +15,19 @@ pub struct Console;
 /// A collection of methods that are required to format
 /// a message to HermitCore's console.
 impl fmt::Write for Console {
-	/// Print a single character.
-	fn write_char(&mut self, c: char) -> fmt::Result {
-		arch::output_message_byte(c as u8);
+	/// Print a string of characters.
+	fn write_str(&mut self, s: &str) -> fmt::Result {
+		if s.len() > 0 {
+			let buf = s.as_bytes();
+			arch::output_message_buf(buf);
+		}
+
 		Ok(())
 	}
 
-	/// Print a string of characters.
-	fn write_str(&mut self, s: &str) -> fmt::Result {
-		for character in s.chars() {
-			self.write_char(character).unwrap();
-		}
-		Ok(())
+	/// Print a single character.
+	fn write_char(&mut self, c: char) -> fmt::Result {
+		self.write_str(c.encode_utf8(&mut [0; 4]))
 	}
 }
 


### PR DESCRIPTION
As you can see here: https://github.com/hermitcore/rusty-hermit/pull/31, printing non ascii strings doesn't work on qemu, while it does work on uhyve. I'm not really sure why it works on uhyve, but I guess that the Write traits are probably implemented somewhere else. @stlankes Do you know more about this?

This PR adds support for printing non-ASCII characters to the console.
- Swap order of write_char and write_str to match order of trait
- Implement write_char by calling write_str to match the implementation in the standard library (and support non-ascii characters)
- Add output_message_buf for printing of a buffer.
- Convert str to UTF-8 encoded byte buffer before printing.