### PR TITLE
Readme: Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ More details can be found in the [uhyve README](https://github.com/hermitcore/uh
 It is also possible to run RustyHermit within [Qemu](https://www.qemu.org).
 RustyHermit produces 64-bit binaries, but Qemu's x86 emulation cannot boot them directly.
 Therefore, the loader [rusty-loader](https://github.com/hermitcore/rusty-loader) is required to boot the application.
-To build the loader, the assembler [nasm](https://www.nasm.us) are required.
+To build the loader, the assembler [nasm](https://www.nasm.us) is required.
 After the installation, the loader can be build as follows.
 
 ```bash


### PR DESCRIPTION
Change to singular after removing xbuild from Readme in bf6761efa19fcbdfd4e4a40f2461d454aea3d373