### PR TITLE
introduce a new interface for smoltcp

### DIFF
--- a/src/arch/x86_64/kernel/virtio_net.rs
+++ b/src/arch/x86_64/kernel/virtio_net.rs
@@ -366,14 +366,10 @@ impl<'a> VirtioNetDriver<'a> {
 	pub fn handle_interrupt(&mut self) -> bool {
 		let isr_status = *(self.isr_cfg);
 		if (isr_status & 0x1) == 0x1 {
-			//self.check_used_elements();
+			// handle incoming packets
+			netwakeup();
 
-			if self.has_packet() {
-				// handle incoming packets
-				netwakeup();
-
-				return true;
-			}
+			return true;
 		}
 
 		false

--- a/src/drivers/net/mod.rs
+++ b/src/drivers/net/mod.rs
@@ -5,25 +5,91 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::synch::semaphore::*;
+#[cfg(feature = "newlib")]
+pub use self::newlib::{netwait, netwakeup};
+#[cfg(not(feature = "newlib"))]
+pub use self::nonewlib::{netwait, netwait_and_wakeup, netwakeup};
 
-static NET_SEM: Semaphore = Semaphore::new(0);
+#[cfg(feature = "newlib")]
+mod newlib {
+	use crate::synch::semaphore::*;
 
-pub fn netwakeup() {
-	NET_SEM.release();
+	static NET_SEM: Semaphore = Semaphore::new(0);
+
+	pub fn netwakeup() {
+		NET_SEM.release();
+	}
+
+	pub fn netwait(millis: Option<u64>) {
+		match millis {
+			Some(ms) => {
+				if ms > 0 {
+					NET_SEM.acquire(Some(ms));
+				} else {
+					NET_SEM.try_acquire();
+				}
+			}
+			_ => {
+				NET_SEM.acquire(None);
+			}
+		};
+	}
 }
 
-pub fn netwait(millis: Option<u64>) {
-	match millis {
-		Some(ms) => {
-			if ms > 0 {
-				NET_SEM.acquire(Some(ms));
-			} else {
-				NET_SEM.try_acquire();
+#[cfg(not(feature = "newlib"))]
+mod nonewlib {
+	use crate::arch::kernel::percore::*;
+	use crate::scheduler::task::TaskHandle;
+	use crate::synch::semaphore::*;
+	use crate::synch::spinlock::SpinlockIrqSave;
+	use alloc::collections::BTreeMap;
+
+	static NET_SEM: Semaphore = Semaphore::new(0);
+	static NIC_QUEUE: SpinlockIrqSave<BTreeMap<usize, TaskHandle>> =
+		SpinlockIrqSave::new(BTreeMap::new());
+
+	pub fn netwakeup() {
+		NET_SEM.release();
+	}
+
+	pub fn netwait_and_wakeup(handles: &[usize], millis: Option<u64>) {
+		{
+			let mut guard = NIC_QUEUE.lock();
+
+			for i in handles {
+				if let Some(task) = guard.remove(i) {
+					core_scheduler().custom_wakeup(task);
+				}
 			}
 		}
-		_ => {
-			NET_SEM.acquire(None);
+
+		NET_SEM.acquire(millis);
+	}
+
+	pub fn netwait(handle: usize, millis: Option<u64>) {
+		let wakeup_time = match millis {
+			Some(ms) => Some(crate::arch::processor::get_timer_ticks() + ms * 1000),
+			_ => None,
+		};
+		let mut guard = NIC_QUEUE.lock();
+		let core_scheduler = core_scheduler();
+
+		// Block the current task and add it to the wakeup queue.
+		core_scheduler.block_current_task(wakeup_time);
+		guard.insert(handle, core_scheduler.get_current_task_handle());
+
+		// release lock
+		drop(guard);
+
+		// Switch to the next task.
+		core_scheduler.reschedule();
+
+		// if the timer is expired, we have still the task in the btreemap
+		// => remove it from the btreemap
+		if millis.is_some() {
+			let mut guard = NIC_QUEUE.lock();
+
+			guard.remove(&handle);
 		}
-	};
+	}
 }

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -266,6 +266,12 @@ impl PerCoreScheduler {
 	}
 
 	#[inline]
+	pub fn get_current_task_prio(&self) -> Priority {
+		let _ = AvoidInterrupts::new();
+		self.current_task.borrow().prio
+	}
+
+	#[inline]
 	pub fn get_current_task_wakeup_reason(&self) -> WakeupReason {
 		let _ = AvoidInterrupts::new();
 		self.current_task.borrow_mut().last_wakeup_reason

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -141,22 +141,20 @@ pub fn sys_rx_buffer_consumed() -> Result<(), ()> {
 	kernel_function!(__sys_rx_buffer_consumed())
 }
 
-#[cfg(not(feature = "newlib"))]
-#[no_mangle]
-pub fn sys_netwakeup() {
-	kernel_function!(netwakeup());
-}
-
-pub fn __sys_netwait(millis: Option<u64>) {
-	if !unsafe { SYS.has_packet() } {
-		netwait(millis)
-	}
+fn __sys_netwait(handle: usize, millis: Option<u64>) {
+	netwait(handle, millis)
 }
 
 #[cfg(not(feature = "newlib"))]
 #[no_mangle]
-pub fn sys_netwait(millis: Option<u64>) {
-	kernel_function!(__sys_netwait(millis));
+pub fn sys_netwait(handle: usize, millis: Option<u64>) {
+	kernel_function!(__sys_netwait(handle, millis));
+}
+
+#[cfg(not(feature = "newlib"))]
+#[no_mangle]
+pub fn sys_netwait_and_wakeup(handles: &[usize], millis: Option<u64>) {
+	kernel_function!(netwait_and_wakeup(handles, millis));
 }
 
 pub fn __sys_shutdown(arg: i32) -> ! {


### PR DESCRIPTION
- network thread is able to wakeup directly the blocked threads
- reduce the number of context switches