### PR TITLE
safer allocation / deallocation of task stacks

### DIFF
--- a/src/arch/x86_64/kernel/scheduler.rs
+++ b/src/arch/x86_64/kernel/scheduler.rs
@@ -343,11 +343,10 @@ impl TaskFrame for Task {
 	fn create_stack_frame(&mut self, func: extern "C" fn(usize), arg: usize) {
 		// Check if the task (process or thread) uses Thread-Local-Storage.
 		let tls_size = environment::get_tls_memsz();
-		self.tls = if tls_size > 0 {
-			Some(TaskTLS::new(tls_size))
-		} else {
-			None
-		};
+		// check is TLS is already allocated
+		if self.tls.is_none() && tls_size > 0 {
+			self.tls = Some(TaskTLS::new(tls_size))
+		}
 
 		unsafe {
 			// Set a marker for debugging at the very top.


### PR DESCRIPTION
- store task (instead of the task id) in the finished task queue
- it delays the release of the task (and its stacks) until the context switch has been completed
- create TLS only if TLS isn't already initialized