### PR TITLE
reduce the number of interrupts during a send operation

### DIFF
--- a/src/arch/x86_64/kernel/pci.rs
+++ b/src/arch/x86_64/kernel/pci.rs
@@ -12,9 +12,8 @@ use crate::arch::x86_64::kernel::virtio_fs::VirtioFsDriver;
 use crate::arch::x86_64::kernel::virtio_net::VirtioNetDriver;
 use crate::synch::spinlock::SpinlockIrqSave;
 use crate::x86::io::*;
-use alloc::rc::Rc;
 use alloc::vec::Vec;
-use core::cell::RefCell;
+use core::cell::UnsafeCell;
 use core::convert::TryInto;
 use core::{fmt, u32, u8};
 
@@ -125,8 +124,8 @@ pub struct MemoryBar {
 }
 
 pub enum PciDriver<'a> {
-	VirtioFs(Rc<RefCell<VirtioFsDriver<'a>>>),
-	VirtioNet(Rc<RefCell<VirtioNetDriver<'a>>>),
+	VirtioFs(UnsafeCell<SpinlockIrqSave<VirtioFsDriver<'a>>>),
+	VirtioNet(UnsafeCell<SpinlockIrqSave<VirtioNetDriver<'a>>>),
 }
 
 pub fn register_driver(drv: PciDriver<'static>) {
@@ -134,12 +133,11 @@ pub fn register_driver(drv: PciDriver<'static>) {
 	drivers.push(drv);
 }
 
-pub fn get_network_driver() -> Option<Rc<RefCell<VirtioNetDriver<'static>>>> {
-	let drivers = PCI_DRIVERS.lock();
-	for i in drivers.iter() {
+pub fn get_network_driver() -> Option<&'static SpinlockIrqSave<VirtioNetDriver<'static>>> {
+	for i in PCI_DRIVERS.lock().iter() {
 		match &*i {
 			PciDriver::VirtioNet(nic_driver) => {
-				return Some(nic_driver.clone());
+				return Some(unsafe { &*nic_driver.get() });
 			}
 			_ => {}
 		}

--- a/src/arch/x86_64/kernel/virtio.rs
+++ b/src/arch/x86_64/kernel/virtio.rs
@@ -54,9 +54,11 @@ pub mod consts {
 	pub const VIRTQ_DESC_F_WRITE: u16 = 2; // Buffer is device write-only (instead of read-only)
 	pub const VIRTQ_DESC_F_INDIRECT: u16 = 4; // Buffer contains list of virtq_desc
 
-	// The Guest uses this in flag to advise the Host: don't interrupt me
+	// The guest uses this in flag to advise the host: don't interrupt me
 	// when you consume a buffer.
 	pub const VRING_AVAIL_F_NO_INTERRUPT: u16 = 1;
+	/// Default behaviour, where the guest expects interrupts from the host
+	pub const VRING_AVAIL_F_DEFAULT: u16 = 0;
 }
 
 pub struct Virtq<'a> {
@@ -401,7 +403,7 @@ impl<'a> Virtq<'a> {
 		if value {
 			*vqavail.flags = VRING_AVAIL_F_NO_INTERRUPT;
 		} else {
-			*vqavail.flags = 0;
+			*vqavail.flags = VRING_AVAIL_F_DEFAULT;
 		}
 	}
 

--- a/src/arch/x86_64/kernel/virtio.rs
+++ b/src/arch/x86_64/kernel/virtio.rs
@@ -16,13 +16,11 @@ use crate::arch::x86_64::kernel::virtio_net;
 
 use crate::arch::x86_64::mm::paging;
 use crate::config::VIRTIO_MAX_QUEUE_SIZE;
-use crate::synch::spinlock::SpinlockIrqSave;
 
 use alloc::boxed::Box;
 use alloc::rc::Rc;
 use alloc::vec::Vec;
 use core::cell::RefCell;
-use core::cell::UnsafeCell;
 use core::convert::TryInto;
 use core::sync::atomic::spin_loop_hint;
 use core::sync::atomic::{fence, Ordering};
@@ -830,9 +828,7 @@ pub fn init_virtio_device(adapter: &pci::PciAdapter) {
 						PciNetworkControllerSubclass::EthernetController => {
 							// TODO: proper error handling on driver creation fail
 							let drv = virtio_net::create_virtionet_driver(adapter).unwrap();
-							pci::register_driver(PciDriver::VirtioNet(UnsafeCell::new(
-								SpinlockIrqSave::new(drv),
-							)));
+							pci::register_driver(PciDriver::VirtioNet(drv));
 						}
 						_ => {
 							warn!("Virtio device is NOT supported, skipping!");
@@ -876,7 +872,7 @@ extern "x86-interrupt" fn virtio_irqhandler(_stack_frame: &mut ExceptionStackFra
 	increment_irq_counter((32 + unsafe { VIRTIO_IRQ_NO }).into());
 
 	let check_scheduler = match get_network_driver() {
-		Some(driver) => driver.lock().handle_interrupt(),
+		Some(driver) => driver.borrow_mut().handle_interrupt(),
 		_ => false,
 	};
 

--- a/src/arch/x86_64/kernel/virtio.rs
+++ b/src/arch/x86_64/kernel/virtio.rs
@@ -400,7 +400,7 @@ impl<'a> Virtq<'a> {
 
 	pub fn set_polling_mode(&mut self, value: bool) {
 		let mut vqavail = self.avail.borrow_mut();
-		if value == true {
+		if value {
 			*vqavail.flags = VRING_AVAIL_F_NO_INTERRUPT;
 		} else {
 			*vqavail.flags = 0;

--- a/src/arch/x86_64/kernel/virtio.rs
+++ b/src/arch/x86_64/kernel/virtio.rs
@@ -396,6 +396,15 @@ impl<'a> Virtq<'a> {
 		}
 	}
 
+	pub fn set_polling_mode(&mut self, value: bool) {
+		let mut vqavail = self.avail.borrow_mut();
+		if value == true {
+			*vqavail.flags = VRING_AVAIL_F_NO_INTERRUPT;
+		} else {
+			*vqavail.flags = 0;
+		}
+	}
+
 	pub fn has_packet(&self) -> bool {
 		let vqused = self.used.borrow();
 

--- a/src/arch/x86_64/kernel/virtio.rs
+++ b/src/arch/x86_64/kernel/virtio.rs
@@ -50,6 +50,7 @@ pub mod consts {
 	pub const VIRTIO_F_NOTIFICATION_DATA: u64 = 1 << 38;
 
 	// Descriptor flags
+	pub const VIRTQ_DESC_F_DEFAULT: u16 = 0;
 	pub const VIRTQ_DESC_F_NEXT: u16 = 1; // Buffer continues via next field
 	pub const VIRTQ_DESC_F_WRITE: u16 = 2; // Buffer is device write-only (instead of read-only)
 	pub const VIRTQ_DESC_F_INDIRECT: u16 = 4; // Buffer contains list of virtq_desc

--- a/src/arch/x86_64/kernel/virtio_net.rs
+++ b/src/arch/x86_64/kernel/virtio_net.rs
@@ -377,6 +377,10 @@ impl<'a> VirtioNetDriver<'a> {
 		false
 	}
 
+	pub fn set_polling_mode(&mut self, value: bool) {
+		(self.vqueues.as_deref_mut().unwrap())[0].set_polling_mode(value);
+	}
+
 	pub fn get_mac_address(&self) -> [u8; 6] {
 		self.device_cfg.mac
 	}

--- a/src/arch/x86_64/kernel/virtio_net.rs
+++ b/src/arch/x86_64/kernel/virtio_net.rs
@@ -462,9 +462,7 @@ impl<'a> VirtioNetDriver<'a> {
 	}
 }
 
-pub fn create_virtionet_driver(
-	adapter: &pci::PciAdapter,
-) -> Option<Rc<RefCell<VirtioNetDriver<'static>>>> {
+pub fn create_virtionet_driver(adapter: &pci::PciAdapter) -> Option<VirtioNetDriver<'static>> {
 	// Scan capabilities to get common config, which we need to reset the device and get basic info.
 	// also see https://elixir.bootlin.com/linux/latest/source/drivers/virtio/virtio_pci_modern.c#L581 (virtio_pci_modern_probe)
 	// Read status register
@@ -533,7 +531,7 @@ pub fn create_virtionet_driver(
 	// TODO: also load the other cap types (?).
 
 	// Instanciate driver on heap, so it outlives this function
-	let drv = Rc::new(RefCell::new(VirtioNetDriver {
+	let mut drv = VirtioNetDriver {
 		tx_buffers: Vec::new(),
 		rx_buffers: Vec::new(),
 		common_cfg,
@@ -541,10 +539,10 @@ pub fn create_virtionet_driver(
 		isr_cfg,
 		notify_cfg,
 		vqueues: None,
-	}));
+	};
 
 	trace!("Driver before init: {:?}", drv);
-	drv.borrow_mut().init();
+	drv.init();
 	trace!("Driver after init: {:?}", drv);
 
 	if device_cfg.status & VIRTIO_NET_S_LINK_UP == VIRTIO_NET_S_LINK_UP {
@@ -552,10 +550,7 @@ pub fn create_virtionet_driver(
 	} else {
 		info!("Virtio-Net link is down");
 	}
-	info!(
-		"Virtio-Net status: 0x{:x}",
-		drv.borrow().common_cfg.device_status
-	);
+	info!("Virtio-Net status: 0x{:x}", drv.common_cfg.device_status);
 
 	Some(drv)
 }

--- a/src/arch/x86_64/kernel/virtio_net.rs
+++ b/src/arch/x86_64/kernel/virtio_net.rs
@@ -296,7 +296,7 @@ impl<'a> VirtioNetDriver<'a> {
 					i,
 					addr.try_into().unwrap(),
 					buffer_size,
-					0,
+					VIRTQ_DESC_F_DEFAULT,
 				);
 				vec_buffer.push(buffer);
 			}

--- a/src/collections/mod.rs
+++ b/src/collections/mod.rs
@@ -16,7 +16,7 @@ pub use self::doublylinkedlist::*;
 /// `irqsave` guarantees that the call of the closure
 /// will be not disturbed by an interrupt
 #[inline]
-pub fn irqsave<F, R>(mut f: F) -> R
+pub fn irqsave<F, R>(f: F) -> R
 where
 	F: FnOnce() -> R,
 {

--- a/src/drivers/net/mod.rs
+++ b/src/drivers/net/mod.rs
@@ -5,6 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::arch::irq;
 use crate::arch::kernel::percore::*;
 use crate::scheduler::task::TaskHandle;
 use crate::synch::semaphore::*;
@@ -24,9 +25,13 @@ const POLL_PERIOD: u64 = 20_000;
 fn set_polling_mode(value: bool) {
 	// is the driver already in polling mode?
 	if POLLING.swap(value, Ordering::SeqCst) != value {
+		let irq = irq::nested_disable();
+
 		if let Some(driver) = crate::arch::kernel::pci::get_network_driver() {
-			driver.lock().set_polling_mode(value);
+			driver.borrow_mut().set_polling_mode(value);
 		}
+
+		irq::nested_enable(irq);
 
 		// wakeup network thread to sleep for longer time
 		NET_SEM.release();
@@ -65,9 +70,13 @@ pub fn netwait_and_wakeup(handles: &[usize], millis: Option<u64>) {
 	}
 
 	if reset_nic {
+		let irq = irq::nested_disable();
+
 		if let Some(driver) = crate::arch::kernel::pci::get_network_driver() {
-			driver.lock().set_polling_mode(false);
+			driver.borrow_mut().set_polling_mode(false);
 		}
+
+		irq::nested_enable(irq);
 	} else {
 		NET_SEM.acquire(millis);
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 #![allow(clippy::single_match)]
 #![allow(clippy::cognitive_complexity)]
 #![allow(clippy::forget_copy)]
+#![allow(incomplete_features)]
 #![feature(abi_x86_interrupt)]
 #![feature(allocator_api)]
 #![feature(const_btree_new)]

--- a/src/syscalls/interfaces/mod.rs
+++ b/src/syscalls/interfaces/mod.rs
@@ -17,7 +17,6 @@ use crate::arch;
 use crate::console;
 use crate::environment;
 use crate::errno::*;
-use crate::synch::spinlock::SpinlockIrqSave;
 use crate::syscalls::fs::{self, FilePerms, PosixFile, SeekWhence};
 use crate::util;
 
@@ -26,8 +25,6 @@ pub use self::uhyve::*;
 
 mod generic;
 mod uhyve;
-
-static DRIVER_LOCK: SpinlockIrqSave<()> = SpinlockIrqSave::new(());
 
 const SEEK_SET: i32 = 0;
 const SEEK_CUR: i32 = 1;
@@ -119,65 +116,51 @@ pub trait SyscallInterface: Send + Sync {
 	}
 
 	fn get_mac_address(&self) -> Result<[u8; 6], ()> {
-		let _lock = DRIVER_LOCK.lock();
-
 		match arch::kernel::pci::get_network_driver() {
-			Some(driver) => Ok(driver.borrow().get_mac_address()),
+			Some(driver) => Ok(driver.lock().get_mac_address()),
 			_ => Err(()),
 		}
 	}
 
 	fn get_mtu(&self) -> Result<u16, ()> {
-		let _lock = DRIVER_LOCK.lock();
-
 		match arch::kernel::pci::get_network_driver() {
-			Some(driver) => Ok(driver.borrow().get_mtu()),
+			Some(driver) => Ok(driver.lock().get_mtu()),
 			_ => Err(()),
 		}
 	}
 
 	fn has_packet(&self) -> bool {
-		let _lock = DRIVER_LOCK.lock();
-
 		match arch::kernel::pci::get_network_driver() {
-			Some(driver) => driver.borrow().has_packet(),
+			Some(driver) => driver.lock().has_packet(),
 			_ => false,
 		}
 	}
 
 	fn get_tx_buffer(&self, len: usize) -> Result<(*mut u8, usize), ()> {
-		let _lock = DRIVER_LOCK.lock();
-
 		match arch::kernel::pci::get_network_driver() {
-			Some(driver) => driver.borrow_mut().get_tx_buffer(len),
+			Some(driver) => driver.lock().get_tx_buffer(len),
 			_ => Err(()),
 		}
 	}
 
 	fn send_tx_buffer(&self, handle: usize, len: usize) -> Result<(), ()> {
-		let _lock = DRIVER_LOCK.lock();
-
 		match arch::kernel::pci::get_network_driver() {
-			Some(driver) => driver.borrow_mut().send_tx_buffer(handle, len),
+			Some(driver) => driver.lock().send_tx_buffer(handle, len),
 			_ => Err(()),
 		}
 	}
 
 	fn receive_rx_buffer(&self) -> Result<&'static [u8], ()> {
-		let _lock = DRIVER_LOCK.lock();
-
 		match arch::kernel::pci::get_network_driver() {
-			Some(driver) => driver.borrow().receive_rx_buffer(),
+			Some(driver) => driver.lock().receive_rx_buffer(),
 			_ => Err(()),
 		}
 	}
 
 	fn rx_buffer_consumed(&self) -> Result<(), ()> {
-		let _lock = DRIVER_LOCK.lock();
-
 		match arch::kernel::pci::get_network_driver() {
 			Some(driver) => {
-				driver.borrow_mut().rx_buffer_consumed();
+				driver.lock().rx_buffer_consumed();
 				Ok(())
 			}
 			_ => Err(()),


### PR DESCRIPTION
By transferring a packet to Virtio, the driver will be set in polling mode. In this mode, all Virtio interrupts are disabled. Every 20ms, the driver checks, if the user space is still sending packets. If not, the polling mode will be disabled.