### PR TITLE
separate virtual from physical addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cc"
-version = "1.0.54"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -66,7 +66,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -111,7 +111,7 @@ name = "proc-macro2"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -124,11 +124,11 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "8.1.0"
+version = "8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -168,17 +168,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "1.0.31"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -188,14 +188,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bit_field 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "raw-cpuid 8.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "raw-cpuid 8.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum bit_field 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a165d606cf084741d4ac3a28fb6e9b1eb0bd31f6cd999098cfddb0b2ab381dc0"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-"checksum cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)" = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
+"checksum cc 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)" = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum multiboot 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "745e351d4f128ea9e266fe2dd04a1bd7349c60441d45ec8677520bae08e25d43"
@@ -208,10 +208,10 @@ dependencies = [
 "checksum num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 "checksum proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
 "checksum quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
-"checksum raw-cpuid 8.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5ab01b333691cd32fa882476c0fd735e98a85bf080853728936210562d0cdca6"
+"checksum raw-cpuid 8.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0cee2c7710d96f9f90f56824fca5438b301dc0fb49ece4cf9dfa044e54067e10"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum syn 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
-"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum syn 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
+"checksum unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 "checksum x86 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c146cbc47471e076987378c159a7aa8fa434680c6fbddca59fe6f40f1591c819"

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -71,8 +71,8 @@ const SMP_BOOT_CODE_OFFSET_BOOTINFO: usize = 0x10;
 
 const X2APIC_ENABLE: u64 = 1 << 10;
 
-static mut LOCAL_APIC_ADDRESS: VirtAddr = VirtAddr(0);
-static mut IOAPIC_ADDRESS: VirtAddr = VirtAddr(0);
+static mut LOCAL_APIC_ADDRESS: VirtAddr = VirtAddr::zero();
+static mut IOAPIC_ADDRESS: VirtAddr = VirtAddr::zero();
 
 /// Stores the Local APIC IDs of all CPUs. The index equals the Core ID.
 /// Both numbers often match, but don't need to (e.g. when a core has been disabled).

--- a/src/arch/x86_64/kernel/irq.rs
+++ b/src/arch/x86_64/kernel/irq.rs
@@ -203,7 +203,7 @@ pub extern "C" fn irq_install_handler(irq_number: u32, handler: usize) {
 }
 
 pub fn add_irq_name(irq_number: u32, name: &'static str) {
-	debug!("Install handler for interrupt {}", irq_number);
+	debug!("Register name \"{}\"  for interrupt {}", name, irq_number);
 	IRQ_NAMES.lock().insert(32 + irq_number, name.to_string());
 }
 

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -35,6 +35,7 @@ pub mod virtio;
 pub mod virtio_fs;
 pub mod virtio_net;
 
+use crate::arch::mm::VirtAddr;
 use crate::arch::x86_64::kernel::irq::{get_irq_name, IrqStatistics};
 use crate::arch::x86_64::kernel::percore::*;
 use crate::arch::x86_64::kernel::serial::SerialPort;
@@ -166,8 +167,8 @@ pub unsafe extern "C" fn sys_uhyve_get_mask(mask: *mut u8) {
 	switch_to_user!();
 }
 
-pub fn get_base_address() -> usize {
-	unsafe { core::ptr::read_volatile(&(*BOOT_INFO).base) as usize }
+pub fn get_base_address() -> VirtAddr {
+	unsafe { VirtAddr(core::ptr::read_volatile(&(*BOOT_INFO).base)) }
 }
 
 pub fn get_image_size() -> usize {
@@ -178,8 +179,8 @@ pub fn get_limit() -> usize {
 	unsafe { core::ptr::read_volatile(&(*BOOT_INFO).limit) as usize }
 }
 
-pub fn get_tls_start() -> usize {
-	unsafe { core::ptr::read_volatile(&(*BOOT_INFO).tls_start) as usize }
+pub fn get_tls_start() -> VirtAddr {
+	unsafe { VirtAddr(core::ptr::read_volatile(&(*BOOT_INFO).tls_start)) }
 }
 
 pub fn get_tls_filesz() -> usize {
@@ -190,8 +191,8 @@ pub fn get_tls_memsz() -> usize {
 	unsafe { core::ptr::read_volatile(&(*BOOT_INFO).tls_memsz) as usize }
 }
 
-pub fn get_mbinfo() -> usize {
-	unsafe { core::ptr::read_volatile(&(*BOOT_INFO).mb_info) as usize }
+pub fn get_mbinfo() -> VirtAddr {
+	unsafe { VirtAddr(core::ptr::read_volatile(&(*BOOT_INFO).mb_info)) }
 }
 
 pub fn get_processor_count() -> u32 {
@@ -216,8 +217,8 @@ pub fn get_cmdsize() -> usize {
 	unsafe { core::ptr::read_volatile(&(*BOOT_INFO).cmdsize) as usize }
 }
 
-pub fn get_cmdline() -> usize {
-	unsafe { core::ptr::read_volatile(&(*BOOT_INFO).cmdline) as usize }
+pub fn get_cmdline() -> VirtAddr {
+	unsafe { VirtAddr(core::ptr::read_volatile(&(*BOOT_INFO).cmdline)) }
 }
 
 /// Earliest initialization function called by the Boot Processor.

--- a/src/arch/x86_64/kernel/virtio.rs
+++ b/src/arch/x86_64/kernel/virtio.rs
@@ -873,7 +873,7 @@ static mut VIRTIO_IRQ_NO: u8 = 0;
 
 #[cfg(target_arch = "x86_64")]
 extern "x86-interrupt" fn virtio_irqhandler(_stack_frame: &mut ExceptionStackFrame) {
-	info!("Receive virtio interrupt");
+	debug!("Receive virtio interrupt");
 	apic::eoi();
 	increment_irq_counter((32 + unsafe { VIRTIO_IRQ_NO }).into());
 

--- a/src/arch/x86_64/kernel/virtio_fs.rs
+++ b/src/arch/x86_64/kernel/virtio_fs.rs
@@ -259,7 +259,7 @@ pub fn create_virtiofs_driver(
 	let common_cfg =
 		match virtio::map_virtiocap(bus, device, adapter, caplist, VIRTIO_PCI_CAP_COMMON_CFG) {
 			Some((cap_common_raw, _)) => unsafe {
-				&mut *(cap_common_raw as *mut virtio_pci_common_cfg)
+				&mut *(cap_common_raw.as_mut_ptr::<virtio_pci_common_cfg>())
 			},
 			None => {
 				error!("Could not find VIRTIO_PCI_CAP_COMMON_CFG. Aborting!");
@@ -269,7 +269,9 @@ pub fn create_virtiofs_driver(
 	// get device config mapped, cast to virtio_fs_config
 	let device_cfg =
 		match virtio::map_virtiocap(bus, device, adapter, caplist, VIRTIO_PCI_CAP_DEVICE_CFG) {
-			Some((cap_device_raw, _)) => unsafe { &mut *(cap_device_raw as *mut virtio_fs_config) },
+			Some((cap_device_raw, _)) => unsafe {
+				&mut *(cap_device_raw.as_mut_ptr::<virtio_fs_config>())
+			},
 			None => {
 				error!("Could not find VIRTIO_PCI_CAP_DEVICE_CFG. Aborting!");
 				return None;
@@ -280,7 +282,7 @@ pub fn create_virtiofs_driver(
 		match virtio::map_virtiocap(bus, device, adapter, caplist, VIRTIO_PCI_CAP_NOTIFY_CFG) {
 			Some((cap_notification_raw, notify_off_multiplier)) => {
 				(
-					cap_notification_raw as *mut u16, // unsafe { core::slice::from_raw_parts_mut::<u16>(...)}
+					cap_notification_raw.as_mut_ptr::<u16>(), // unsafe { core::slice::from_raw_parts_mut::<u16>(...)}
 					notify_off_multiplier,
 				)
 			}

--- a/src/arch/x86_64/kernel/virtio_net.rs
+++ b/src/arch/x86_64/kernel/virtio_net.rs
@@ -276,12 +276,7 @@ impl<'a> VirtioNetDriver<'a> {
 			for i in 0..vqsize {
 				let buffer = RxBuffer::new(buffer_size);
 				let addr = buffer.addr;
-				vqueues[VIRTIO_NET_RX_QUEUE].add_buffer(
-					i,
-					addr,
-					buffer_size,
-					VIRTQ_DESC_F_WRITE,
-				);
+				vqueues[VIRTIO_NET_RX_QUEUE].add_buffer(i, addr, buffer_size, VIRTQ_DESC_F_WRITE);
 				vec_buffer.push(buffer);
 			}
 		}
@@ -292,12 +287,7 @@ impl<'a> VirtioNetDriver<'a> {
 			for i in 0..vqsize {
 				let buffer = TxBuffer::new(buffer_size);
 				let addr = buffer.addr;
-				vqueues[VIRTIO_NET_TX_QUEUE].add_buffer(
-					i,
-					addr,
-					buffer_size,
-					VIRTQ_DESC_F_DEFAULT,
-				);
+				vqueues[VIRTIO_NET_TX_QUEUE].add_buffer(i, addr, buffer_size, VIRTQ_DESC_F_DEFAULT);
 				vec_buffer.push(buffer);
 			}
 		}

--- a/src/arch/x86_64/mm/mod.rs
+++ b/src/arch/x86_64/mm/mod.rs
@@ -13,6 +13,9 @@ pub use self::paging::init_page_tables;
 use core::mem;
 use core::slice;
 
+pub use x86::bits64::paging::PAddr as PhysAddr;
+pub use x86::bits64::paging::VAddr as VirtAddr;
+
 fn paddr_to_slice<'a>(p: multiboot::PAddr, sz: usize) -> Option<&'a [u8]> {
 	unsafe {
 		let ptr = mem::transmute(p);

--- a/src/arch/x86_64/mm/paging.rs
+++ b/src/arch/x86_64/mm/paging.rs
@@ -732,8 +732,8 @@ pub fn init_page_tables() {
 
 			// make sure that only the required areas are mapped
 			let start = pde
-				+ ((mm::kernel_end_address().as_usize() >> (PAGE_MAP_BITS + PAGE_BITS)) * mem::size_of::<u64>())
-				as u64;
+				+ ((mm::kernel_end_address().as_usize() >> (PAGE_MAP_BITS + PAGE_BITS))
+					* mem::size_of::<u64>()) as u64;
 			let size = (512 - (mm::kernel_end_address().as_usize() >> (PAGE_MAP_BITS + PAGE_BITS)))
 				* mem::size_of::<u64>();
 

--- a/src/arch/x86_64/mm/paging.rs
+++ b/src/arch/x86_64/mm/paging.rs
@@ -513,7 +513,7 @@ where
 				// Mark all entries as unused in the newly created table.
 				let subtable = self.subtable::<S>(page);
 				for entry in subtable.entries.iter_mut() {
-					entry.physical_address_and_flags = PhysAddr(0u64);
+					entry.physical_address_and_flags = PhysAddr::zero();
 				}
 			}
 
@@ -653,7 +653,7 @@ pub fn virtual_to_physical(virtual_address: VirtAddr) -> PhysAddr {
 			let off = virtual_address.as_u64()
 				& !(((!0u64) << page_bits) & !PageTableEntryFlags::EXECUTE_DISABLE.bits());
 			let phys =
-				entry & (((!064) << page_bits) & !PageTableEntryFlags::EXECUTE_DISABLE.bits());
+				entry & (((!0u64) << page_bits) & !PageTableEntryFlags::EXECUTE_DISABLE.bits());
 
 			return PhysAddr(off | phys);
 		}
@@ -701,7 +701,7 @@ pub fn identity_map(start_address: PhysAddr, end_address: PhysAddr) {
 	let first_page = Page::<BasePageSize>::including_address(VirtAddr(start_address.as_u64()));
 	let last_page = Page::<BasePageSize>::including_address(VirtAddr(end_address.as_u64()));
 	assert!(
-		last_page.address() < VirtAddr(mm::kernel_start_address().as_u64()),
+		last_page.address() < mm::kernel_start_address(),
 		"Address {:#X} to be identity-mapped is not below Kernel start address",
 		last_page.address()
 	);

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -37,7 +37,7 @@ unsafe fn parse_command_line() {
 	}
 
 	// Convert the command-line into a Rust string slice.
-	let cmdline = get_cmdline() as *const u8;
+	let cmdline = get_cmdline().as_ptr::<u8>();
 	let slice = slice::from_raw_parts(cmdline, cmdsize);
 	let cmdline_str = str::from_utf8_unchecked(slice);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@
 #![feature(panic_info_message)]
 #![feature(specialization)]
 #![feature(naked_functions)]
+#![feature(nonnull_slice_from_raw_parts)]
 #![feature(core_intrinsics)]
 #![feature(alloc_error_handler)]
 #![allow(unused_macros)]

--- a/src/mm/allocator.rs
+++ b/src/mm/allocator.rs
@@ -116,7 +116,7 @@ impl Heap {
 		// It would only increase the management burden and we wouldn't save
 		// any significant amounts of memory.
 		// So check if this is a pointer allocated by the System Allocator.
-		if address >= kernel_end_address() {
+		if address >= kernel_end_address().as_usize() {
 			let mut size = layout.size();
 			if size < HoleList::min_size() {
 				size = HoleList::min_size();

--- a/src/mm/allocator.rs
+++ b/src/mm/allocator.rs
@@ -205,7 +205,9 @@ unsafe impl GlobalAlloc for LockedHeap {
 			.lock()
 			.alloc(layout)
 			.ok()
-			.map_or(ptr::null_mut() as *mut u8, |mut mem| mem.as_mut().as_mut_ptr())
+			.map_or(ptr::null_mut() as *mut u8, |mut mem| {
+				mem.as_mut().as_mut_ptr()
+			})
 	}
 
 	unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -24,17 +24,17 @@ use core::mem;
 
 /// Physical and virtual address of the first 2 MiB page that maps the kernel.
 /// Can be easily accessed through kernel_start_address()
-static mut KERNEL_START_ADDRESS: VirtAddr = VirtAddr(0u64);
+static mut KERNEL_START_ADDRESS: VirtAddr = VirtAddr::zero();
 
 /// Physical and virtual address of the first page after the kernel.
 /// Can be easily accessed through kernel_end_address()
-static mut KERNEL_END_ADDRESS: VirtAddr = VirtAddr(0u64);
+static mut KERNEL_END_ADDRESS: VirtAddr = VirtAddr::zero();
 
 /// Start address of the user heap
-static mut HEAP_START_ADDRESS: VirtAddr = VirtAddr(0u64);
+static mut HEAP_START_ADDRESS: VirtAddr = VirtAddr::zero();
 
 /// End address of the user heap
-static mut HEAP_END_ADDRESS: VirtAddr = VirtAddr(0u64);
+static mut HEAP_END_ADDRESS: VirtAddr = VirtAddr::zero();
 
 pub fn kernel_start_address() -> VirtAddr {
 	unsafe { KERNEL_START_ADDRESS }
@@ -80,7 +80,7 @@ fn map_heap<S: PageSize>(virt_addr: VirtAddr, size: usize) -> usize {
 pub fn init() {
 	// Calculate the start and end addresses of the 2 MiB page(s) that map the kernel.
 	unsafe {
-		KERNEL_START_ADDRESS = environment::get_base_address().align_up_to_large_page();
+		KERNEL_START_ADDRESS = environment::get_base_address().align_down_to_large_page();
 		KERNEL_END_ADDRESS = (environment::get_base_address() + environment::get_image_size())
 			.align_up_to_large_page();
 	}

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -81,14 +81,19 @@ pub fn init() {
 	// Calculate the start and end addresses of the 2 MiB page(s) that map the kernel.
 	unsafe {
 		KERNEL_START_ADDRESS = environment::get_base_address().align_up_to_large_page();
-		KERNEL_END_ADDRESS = (environment::get_base_address() + environment::get_image_size()).align_up_to_large_page();
+		KERNEL_END_ADDRESS = (environment::get_base_address() + environment::get_image_size())
+			.align_up_to_large_page();
 	}
 
 	arch::mm::init();
 	arch::mm::init_page_tables();
 
 	info!("Total memory size: {} MB", total_memory_size() >> 20);
-	info!("Kernel region: [0x{:x} - 0x{:x}]", kernel_start_address(), kernel_end_address());
+	info!(
+		"Kernel region: [0x{:x} - 0x{:x}]",
+		kernel_start_address(),
+		kernel_end_address()
+	);
 
 	// we reserve physical memory for the required page tables
 	// In worst case, we use page size of BasePageSize::SIZE

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -18,42 +18,43 @@ use crate::arch::mm::paging::{
 use crate::arch::mm::physicalmem::total_memory_size;
 #[cfg(feature = "newlib")]
 use crate::arch::mm::virtualmem::kernel_heap_end;
+use crate::arch::mm::{PhysAddr, VirtAddr};
 use crate::environment;
 use core::mem;
 
 /// Physical and virtual address of the first 2 MiB page that maps the kernel.
 /// Can be easily accessed through kernel_start_address()
-static mut KERNEL_START_ADDRESS: usize = 0;
+static mut KERNEL_START_ADDRESS: VirtAddr = VirtAddr(0u64);
 
 /// Physical and virtual address of the first page after the kernel.
 /// Can be easily accessed through kernel_end_address()
-static mut KERNEL_END_ADDRESS: usize = 0;
+static mut KERNEL_END_ADDRESS: VirtAddr = VirtAddr(0u64);
 
 /// Start address of the user heap
-static mut HEAP_START_ADDRESS: usize = 0;
+static mut HEAP_START_ADDRESS: VirtAddr = VirtAddr(0u64);
 
 /// End address of the user heap
-static mut HEAP_END_ADDRESS: usize = 0;
+static mut HEAP_END_ADDRESS: VirtAddr = VirtAddr(0u64);
 
-pub fn kernel_start_address() -> usize {
+pub fn kernel_start_address() -> VirtAddr {
 	unsafe { KERNEL_START_ADDRESS }
 }
 
-pub fn kernel_end_address() -> usize {
+pub fn kernel_end_address() -> VirtAddr {
 	unsafe { KERNEL_END_ADDRESS }
 }
 
 #[cfg(feature = "newlib")]
-pub fn task_heap_start() -> usize {
+pub fn task_heap_start() -> VirtAddr {
 	unsafe { HEAP_START_ADDRESS }
 }
 
 #[cfg(feature = "newlib")]
-pub fn task_heap_end() -> usize {
+pub fn task_heap_end() -> VirtAddr {
 	unsafe { HEAP_END_ADDRESS }
 }
 
-fn map_heap<S: PageSize>(virt_addr: usize, size: usize) -> usize {
+fn map_heap<S: PageSize>(virt_addr: VirtAddr, size: usize) -> usize {
 	let mut i: usize = 0;
 	let mut flags = PageTableEntryFlags::empty();
 
@@ -79,20 +80,15 @@ fn map_heap<S: PageSize>(virt_addr: usize, size: usize) -> usize {
 pub fn init() {
 	// Calculate the start and end addresses of the 2 MiB page(s) that map the kernel.
 	unsafe {
-		KERNEL_START_ADDRESS = align_down!(
-			environment::get_base_address(),
-			arch::mm::paging::LargePageSize::SIZE
-		);
-		KERNEL_END_ADDRESS = align_up!(
-			environment::get_base_address() + environment::get_image_size(),
-			arch::mm::paging::LargePageSize::SIZE
-		);
+		KERNEL_START_ADDRESS = environment::get_base_address().align_up_to_large_page();
+		KERNEL_END_ADDRESS = (environment::get_base_address() + environment::get_image_size()).align_up_to_large_page();
 	}
 
 	arch::mm::init();
 	arch::mm::init_page_tables();
 
 	info!("Total memory size: {} MB", total_memory_size() >> 20);
+	info!("Kernel region: [0x{:x} - 0x{:x}]", kernel_start_address(), kernel_end_address());
 
 	// we reserve physical memory for the required page tables
 	// In worst case, we use page size of BasePageSize::SIZE
@@ -106,11 +102,12 @@ pub fn init() {
 
 	//info!("reserved space {} KB", reserved_space >> 10);
 
-	if total_memory_size() < kernel_end_address() + reserved_space + LargePageSize::SIZE {
+	if total_memory_size() < kernel_end_address().as_usize() + reserved_space + LargePageSize::SIZE
+	{
 		panic!("No enough memory available!");
 	}
 
-	let mut map_addr: usize;
+	let mut map_addr: VirtAddr;
 	let mut map_size: usize;
 
 	#[cfg(feature = "newlib")]
@@ -125,7 +122,9 @@ pub fn init() {
 
 		info!("Kernel heap size: {} MB", size >> 20);
 		let user_heap_size = align_down!(
-			total_memory_size() - kernel_end_address() - reserved_space - 3 * LargePageSize::SIZE,
+			total_memory_size()
+				- kernel_end_address().as_usize()
+				- reserved_space - 3 * LargePageSize::SIZE,
 			LargePageSize::SIZE
 		);
 		info!("User-space heap size: {} MB", user_heap_size >> 20);
@@ -146,7 +145,7 @@ pub fn init() {
 		// the virtual address space.
 
 		let virt_size: usize = {
-			let size = total_memory_size() - kernel_end_address() - reserved_space;
+			let size = total_memory_size() - kernel_end_address().as_usize() - reserved_space;
 
 			// we reserve 10% of the memory for stack allocations
 			align_down!(size - (size * 10) / 100, LargePageSize::SIZE)
@@ -182,7 +181,9 @@ pub fn init() {
 
 		unsafe {
 			HEAP_START_ADDRESS = virt_addr;
-			crate::ALLOCATOR.lock().init(virt_addr, virt_size);
+			crate::ALLOCATOR
+				.lock()
+				.init(virt_addr.as_usize(), virt_size);
 		}
 
 		map_addr = virt_addr + counter;
@@ -191,7 +192,7 @@ pub fn init() {
 
 	if has_1gib_pages
 		&& map_size > HugePageSize::SIZE
-		&& (map_addr & !(HugePageSize::SIZE - 1)) == 0
+		&& (map_addr.as_usize() & !(HugePageSize::SIZE - 1)) == 0
 	{
 		let counter = map_heap::<HugePageSize>(map_addr, map_size);
 		map_size -= counter;
@@ -233,14 +234,14 @@ pub fn print_information() {
 	virtual_address
 }*/
 
-pub fn allocate(sz: usize, no_execution: bool) -> usize {
+pub fn allocate(sz: usize, no_execution: bool) -> VirtAddr {
 	let size = align_up!(sz, BasePageSize::SIZE);
 	let physical_address = arch::mm::physicalmem::allocate(size).unwrap();
 
 	map(physical_address, size, true, no_execution, false)
 }
 
-pub fn deallocate(virtual_address: usize, sz: usize) {
+pub fn deallocate(virtual_address: VirtAddr, sz: usize) {
 	let size = align_up!(sz, BasePageSize::SIZE);
 
 	if let Some(entry) = arch::mm::paging::get_page_table_entry::<BasePageSize>(virtual_address) {
@@ -257,12 +258,12 @@ pub fn deallocate(virtual_address: usize, sz: usize) {
 
 /// Maps a given physical address and size in virtual space and returns address.
 pub fn map(
-	physical_address: usize,
+	physical_address: PhysAddr,
 	sz: usize,
 	writable: bool,
 	no_execution: bool,
 	no_cache: bool,
-) -> usize {
+) -> VirtAddr {
 	let size = align_up!(sz, BasePageSize::SIZE);
 	let count = size / BasePageSize::SIZE;
 
@@ -286,7 +287,7 @@ pub fn map(
 
 #[allow(dead_code)]
 /// unmaps virtual address, without 'freeing' physical memory it is mapped to!
-pub fn unmap(virtual_address: usize, sz: usize) {
+pub fn unmap(virtual_address: VirtAddr, sz: usize) {
 	let size = align_up!(sz, BasePageSize::SIZE);
 
 	if arch::mm::paging::get_page_table_entry::<BasePageSize>(virtual_address).is_some() {

--- a/src/scheduler/task.rs
+++ b/src/scheduler/task.rs
@@ -7,6 +7,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::arch;
+use crate::arch::mm::VirtAddr;
 use crate::arch::percore::*;
 use crate::arch::processor::msb;
 use crate::arch::scheduler::{TaskStacks, TaskTLS};
@@ -370,9 +371,9 @@ pub struct Task {
 	/// Task priority,
 	pub prio: Priority,
 	/// Last stack pointer before a context switch to another task
-	pub last_stack_pointer: usize,
+	pub last_stack_pointer: VirtAddr,
 	/// Last stack pointer on the user stack before jumping to kernel space
-	pub user_stack_pointer: usize,
+	pub user_stack_pointer: VirtAddr,
 	/// Last FPU state before a context switch to another task using the FPU
 	pub last_fpu_state: arch::processor::FPUState,
 	/// ID of the core this task is running on
@@ -411,8 +412,8 @@ impl Task {
 			id: tid,
 			status: task_status,
 			prio: task_prio,
-			last_stack_pointer: 0,
-			user_stack_pointer: 0,
+			last_stack_pointer: VirtAddr(0u64),
+			user_stack_pointer: VirtAddr(0u64),
 			last_fpu_state: arch::processor::FPUState::new(),
 			core_id,
 			stacks: TaskStacks::new(stack_size),
@@ -432,8 +433,8 @@ impl Task {
 			id: tid,
 			status: TaskStatus::TaskIdle,
 			prio: IDLE_PRIO,
-			last_stack_pointer: 0,
-			user_stack_pointer: 0,
+			last_stack_pointer: VirtAddr(0u64),
+			user_stack_pointer: VirtAddr(0u64),
 			last_fpu_state: arch::processor::FPUState::new(),
 			core_id,
 			stacks: TaskStacks::from_boot_stacks(),
@@ -453,8 +454,8 @@ impl Task {
 			id: tid,
 			status: TaskStatus::TaskReady,
 			prio: task.prio,
-			last_stack_pointer: 0,
-			user_stack_pointer: 0,
+			last_stack_pointer: VirtAddr(0u64),
+			user_stack_pointer: VirtAddr(0u64),
 			last_fpu_state: arch::processor::FPUState::new(),
 			core_id,
 			stacks: task.stacks.clone(),


### PR DESCRIPTION
- the logical address space is completly separate from the physical
- consequently, different names are used