### PR TITLE
Integration tests

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,5 @@
+#[target.x86_64-unknown-hermit-kernel]
+#runner = "uhyve -v"
+
 [target.x86_64-unknown-hermit-kernel]
-runner = "uhyve -v"
+runner = "tests/hermit_test_runner.py"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,8 +54,8 @@ jobs:
           path: 'libhermit-rs'
       - name: Check Cargo availability
         run: cargo --version
-      - name: Cargo Test libhermit-rs
-        run: cargo test
+      - name: Cargo Test libhermit-rs (Unittests on Host)
+        run: cargo test --lib
         working-directory: libhermit-rs
       - name: Install qemu/nasm (apt)
         run: sudo apt-get update --fix-missing && sudo apt-get install qemu-system-x86 nasm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,14 +101,18 @@ jobs:
       - name: Test dev version (smp)
         run:
           qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/debug/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr
-        timeout-minutes: 20  
+        timeout-minutes: 20
       - name: Test release version
         run:
           qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr
       - name: Test release version (smp)
         run:
           qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr
-        timeout-minutes: 20  
+        timeout-minutes: 20
+      - name: (Experimental) - Integration Tests
+        run:
+          cargo test --tests --no-fail-fast -Z build-std=core,alloc --target x86_64-unknown-hermit-kernel -- --bootloader_path=../loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader
+        continue-on-error: true
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,4 +50,8 @@ jobs:
         - RUSTFLAGS="-Clinker-plugin-lto" cargo build -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit --release
         - sudo -E sudo -u $USER -E bash -c "HERMIT_VERBOSE=1 $HOME/.cargo/bin/uhyve target/x86_64-unknown-hermit/release/rusty_demo"
         - sudo -E sudo -u $USER -E bash -c "HERMIT_VERBOSE=1 HERMIT_CPUS=2 $HOME/.cargo/bin/uhyve target/x86_64-unknown-hermit/release/rusty_demo"
+    - name: "Integration Tests (experimental)"
+      script:
+        - cd $TRAVIS_BUILD_DIR/rusty-hermit/libhermit-rs
+        - sudo -E sudo -u $USER -E bash -c "$HOME/.cargo/bin/cargo test --tests --no-fail-fast -Z build-std=core,alloc --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,14 @@ travis-ci = { repository = "hermitcore/libhermit-rs" }
 crate-type = ["staticlib"]
 name = "hermit"
 
+[[test]]
+name = "basic_print"
+harness = false
+
+[[test]]
+name = "basic_math"
+harness = false
+
 [features]
 default = ["pci", "acpi"]
 vga = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,10 @@ acpi = []
 [dev-dependencies]
 x86_64 = "0.11.0"
 
+[dev-dependencies.num-traits]
+version = "0.2.12"
+default-features = false
+
 [dependencies]
 bitflags = "1.2"
 #cfg-if = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,10 @@ acpi = []
 
 [dev-dependencies]
 x86_64 = "0.11.0"
+float-cmp = "0.8.0"
 
 [dev-dependencies.num-traits]
-version = "0.2.12"
+version = "0.2"
 default-features = false
 
 [dependencies]
@@ -54,7 +55,7 @@ bitflags = "1.2"
 num-derive = "0.3"
 
 [dependencies.num]
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [dependencies.num-traits]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ float-cmp = "0.8.0"
 [dev-dependencies.num-traits]
 version = "0.2"
 default-features = false
+# features = ["i128"] // Blocked by: https://github.com/rust-num/num-traits/issues/177
 
 [dependencies]
 bitflags = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ newlib = []
 pci = []
 acpi = []
 
+[dev-dependencies]
+x86_64 = "0.11.0"
+
 [dependencies]
 bitflags = "1.2"
 #cfg-if = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ exclude = ["/img/*", "./CMakeLists.txt", "/.travis.yml", "/.gitlab-ci.yml", ".gi
 travis-ci = { repository = "hermitcore/libhermit-rs" }
 
 [lib]
-crate-type = ["staticlib"]
+crate-type = ["staticlib", "lib"]  # "lib" required for integration tests
 name = "hermit"
 
 [[test]]
@@ -31,6 +31,10 @@ harness = false
 
 [[test]]
 name = "basic_math"
+harness = true
+
+[[test]]
+name = "measure_startup_time"
 harness = false
 
 [features]
@@ -55,7 +59,7 @@ bitflags = "1.2"
 num-derive = "0.3"
 
 [dependencies.num]
-version = "0.3"
+version = "0.2"
 default-features = false
 
 [dependencies.num-traits]
@@ -78,11 +82,12 @@ default-features = false
 [profile.dev]
 opt-level = 1      # controls the `--opt-level` the compiler builds with
 debug = true       # controls whether the compiler passes `-C debuginfo`
-                   # a value of `true` is equivalent to `2`
+# a value of `true` is equivalent to `2`
 rpath = false      # controls whether the compiler passes `-C rpath`
 lto = false         # controls `-C lto` for binaries and staticlibs
 debug-assertions = true # controls whether debug assertions are enabled
-panic = "abort" # Call abort on panic https://github.com/rust-lang/rust/pull/32900
+# Disabled because of https://github.com/rust-lang/cargo/issues/7359
+#panic = "abort" # Call abort on panic https://github.com/rust-lang/rust/pull/32900
 
 # The release profile, used for `cargo build --release`.
 [profile.release]
@@ -91,4 +96,4 @@ debug = false
 rpath = false
 lto = "thin"
 debug-assertions = false
-panic = "abort"
+#panic = "abort"

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -61,7 +61,7 @@ pub use crate::arch::x86_64::kernel::processor;
 pub use crate::arch::x86_64::kernel::scheduler;
 #[cfg(target_arch = "x86_64")]
 pub use crate::arch::x86_64::kernel::systemtime::get_boot_time;
-#[cfg(not(test))]
+#[cfg(target_os = "hermit")]
 #[cfg(target_arch = "x86_64")]
 pub use crate::arch::x86_64::kernel::{
 	application_processor_init, boot_application_processors, boot_processor_init,

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -9,7 +9,7 @@ use crate::arch;
 #[cfg(feature = "acpi")]
 use crate::arch::x86_64::kernel::acpi;
 use crate::arch::x86_64::kernel::irq::IrqStatistics;
-#[cfg(not(test))]
+#[cfg(target_os = "hermit")]
 use crate::arch::x86_64::kernel::smp_boot_code::SMP_BOOT_CODE;
 use crate::arch::x86_64::kernel::IRQ_COUNTERS;
 use crate::arch::x86_64::mm::paging::{BasePageSize, PageSize, PageTableEntryFlags};
@@ -526,7 +526,7 @@ extern "C" {
 /// This algorithm is derived from Intel MultiProcessor Specification 1.4, B.4, but testing has shown
 /// that a second STARTUP IPI and setting the BIOS Reset Vector are no longer necessary.
 /// This is partly confirmed by https://wiki.osdev.org/Symmetric_Multiprocessing
-#[cfg(not(test))]
+#[cfg(target_os = "hermit")]
 pub fn boot_application_processors() {
 	// We shouldn't have any problems fitting the boot code into a single page, but let's better be sure.
 	assert!(

--- a/src/arch/x86_64/kernel/irq.rs
+++ b/src/arch/x86_64/kernel/irq.rs
@@ -89,7 +89,7 @@ pub fn disable() {
 /// This function together with nested_enable can be used
 /// in situations when interrupts shouldn't be activated if they
 /// were not activated before calling this function.
-#[cfg(not(test))]
+#[cfg(target_os = "hermit")]
 #[inline]
 pub fn nested_disable() -> bool {
 	unsafe {
@@ -100,7 +100,7 @@ pub fn nested_disable() -> bool {
 	}
 }
 
-#[cfg(test)]
+#[cfg(not(target_os = "hermit"))]
 pub fn nested_disable() -> bool {
 	false
 }

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -262,6 +262,7 @@ pub fn output_message_byte(byte: u8) {
 	}
 }
 
+#[cfg(not(target_os = "hermit"))]
 #[test]
 fn test_output() {
 	output_message_byte('t' as u8);

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -23,7 +23,7 @@ pub mod pit;
 pub mod processor;
 pub mod scheduler;
 pub mod serial;
-#[cfg(not(test))]
+#[cfg(target_os = "hermit")]
 mod smp_boot_code;
 pub mod systemtime;
 #[cfg(feature = "vga")]
@@ -89,14 +89,14 @@ pub struct BootInfo {
 }
 
 /// Kernel header to announce machine features
-#[cfg(test)]
+#[cfg(not(target_os = "hermit"))]
 static mut BOOT_INFO: *mut BootInfo = ptr::null_mut();
 
-#[cfg(all(not(test), not(feature = "newlib")))]
+#[cfg(all(target_os = "hermit", not(feature = "newlib")))]
 #[link_section = ".data"]
 static mut BOOT_INFO: *mut BootInfo = ptr::null_mut();
 
-#[cfg(all(not(test), feature = "newlib"))]
+#[cfg(all(target_os = "hermit", feature = "newlib"))]
 #[link_section = ".mboot"]
 static mut BOOT_INFO: *mut BootInfo = ptr::null_mut();
 
@@ -240,7 +240,7 @@ pub fn message_output_init() {
 	}
 }
 
-#[cfg(all(test, not(target_os = "windows")))]
+#[cfg(all(not(target_os = "hermit"), not(target_os = "windows")))]
 pub fn output_message_byte(byte: u8) {
 	extern "C" {
 		fn write(fd: i32, buf: *const u8, count: usize) -> isize;
@@ -251,7 +251,7 @@ pub fn output_message_byte(byte: u8) {
 	}
 }
 
-#[cfg(all(test, target_os = "windows"))]
+#[cfg(target_os = "windows")]
 pub fn output_message_byte(byte: u8) {
 	extern "C" {
 		fn _write(fd: i32, buf: *const u8, count: u32) -> isize;
@@ -271,7 +271,7 @@ fn test_output() {
 	output_message_byte('\n' as u8);
 }
 
-#[cfg(not(test))]
+#[cfg(target_os = "hermit")]
 pub fn output_message_byte(byte: u8) {
 	if environment::is_single_kernel() {
 		// Output messages to the serial port and VGA screen in unikernel mode.
@@ -289,7 +289,7 @@ pub fn output_message_byte(byte: u8) {
 	}
 }
 
-//#[cfg(not(test))]
+//#[cfg(target_os = "hermit")]
 pub fn output_message_buf(buf: &[u8]) {
 	for byte in buf {
 		output_message_byte(*byte);
@@ -297,7 +297,7 @@ pub fn output_message_buf(buf: &[u8]) {
 }
 
 /// Real Boot Processor initialization as soon as we have put the first Welcome message on the screen.
-#[cfg(not(test))]
+#[cfg(target_os = "hermit")]
 pub fn boot_processor_init() {
 	processor::detect_features();
 	processor::configure();
@@ -344,14 +344,14 @@ pub fn boot_processor_init() {
 
 /// Boots all available Application Processors on bare-metal or QEMU.
 /// Called after the Boot Processor has been fully initialized along with its scheduler.
-#[cfg(not(test))]
+#[cfg(target_os = "hermit")]
 pub fn boot_application_processors() {
 	apic::boot_application_processors();
 	apic::print_information();
 }
 
 /// Application Processor initialization
-#[cfg(not(test))]
+#[cfg(target_os = "hermit")]
 pub fn application_processor_init() {
 	percore::init();
 	processor::configure();
@@ -406,7 +406,7 @@ pub fn print_statistics() {
 	}
 }
 
-#[cfg(not(test))]
+#[cfg(target_os = "hermit")]
 #[inline(never)]
 #[no_mangle]
 unsafe fn pre_init(boot_info: &'static mut BootInfo) -> ! {

--- a/src/arch/x86_64/kernel/percore.rs
+++ b/src/arch/x86_64/kernel/percore.rs
@@ -102,13 +102,13 @@ impl<T: Is32BitVariable> PerCoreVariableMethods<T> for PerCoreVariable<T> {
 	}
 }
 
-#[cfg(not(test))]
+#[cfg(target_os = "hermit")]
 #[inline]
 pub fn core_id() -> CoreId {
 	unsafe { PERCORE.core_id.get() }
 }
 
-#[cfg(test)]
+#[cfg(not(target_os = "hermit"))]
 pub fn core_id() -> CoreId {
 	0
 }

--- a/src/arch/x86_64/kernel/processor.rs
+++ b/src/arch/x86_64/kernel/processor.rs
@@ -868,7 +868,8 @@ pub fn print_information() {
 	infofooter!();
 }
 
-/*#[test]
+/*#[cfg(not(target_os = "hermit"))]
+#[test]
 fn print_cpu_information() {
 	::logging::init();
 	detect_features();

--- a/src/arch/x86_64/kernel/processor.rs
+++ b/src/arch/x86_64/kernel/processor.rs
@@ -347,14 +347,14 @@ impl CpuFrequency {
 		pic::eoi(pit::PIT_INTERRUPT_NUMBER);
 	}
 
-	#[cfg(test)]
+	#[cfg(not(target_os = "hermit"))]
 	fn measure_frequency(&mut self) -> Result<(), ()> {
 		// return just Ok because the real implementation must run in ring 0
 		self.source = CpuFrequencySources::Measurement;
 		Ok(())
 	}
 
-	#[cfg(not(test))]
+	#[cfg(target_os = "hermit")]
 	fn measure_frequency(&mut self) -> Result<(), ()> {
 		// The PIC is not initialized for uhyve, so we cannot measure anything.
 		if environment::is_uhyve() {

--- a/src/arch/x86_64/kernel/scheduler.rs
+++ b/src/arch/x86_64/kernel/scheduler.rs
@@ -326,10 +326,10 @@ impl Clone for TaskTLS {
 	}
 }
 
-#[cfg(test)]
+#[cfg(not(target_os = "hermit"))]
 extern "C" fn task_start(func: extern "C" fn(usize), arg: usize, user_stack: u64) {}
 
-#[cfg(not(test))]
+#[cfg(target_os = "hermit")]
 extern "C" {
 	fn task_start(func: extern "C" fn(usize), arg: usize, user_stack: u64);
 }

--- a/src/console.rs
+++ b/src/console.rs
@@ -33,6 +33,7 @@ impl fmt::Write for Console {
 
 pub static CONSOLE: SpinlockIrqSave<Console> = SpinlockIrqSave::new(Console);
 
+#[cfg(not(target_os = "hermit"))]
 #[test]
 fn test_console() {
 	println!("HelloWorld");

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -59,6 +59,8 @@ unsafe fn parse_command_line() {
 			}
 			"--" => {
 				// Collect remaining arguments as applications argv
+				//ToDo -> we know the length here, so we could (should convert this into a safe
+				// rust type (at least for rust applications)
 				COMMAND_LINE_APPLICATION = Some(tokeniter.collect());
 				break;
 			}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,7 @@ pub fn test_runner(tests: &[&dyn Fn()]) {
 	sys_exit(0);
 }
 
+#[cfg(target_os = "hermit")]
 #[test_case]
 fn trivial_test() {
 	println!("Test test test");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,15 @@ pub fn _print(args: ::core::fmt::Arguments) {
 	crate::console::CONSOLE.lock().write_fmt(args).unwrap();
 }
 
+#[cfg(test)]
+#[cfg(target_os = "hermit")]
+#[no_mangle]
+extern "C" fn runtime_entry(_argc: i32, _argv: *const *const u8, _env: *const *const u8) -> ! {
+	println!("Executing hermit unittests. Any arguments are dropped");
+	test_main();
+	sys_exit(0);
+}
+
 //https://github.com/rust-lang/rust/issues/50297#issuecomment-524180479
 #[cfg(test)]
 pub fn test_runner(tests: &[&dyn Fn()]) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,11 @@
 #![allow(unused_macros)]
 #![no_std]
 #![cfg_attr(target_os = "hermit", feature(custom_test_frameworks))]
-#![cfg_attr(target_os = "hermit", test_runner(crate::test_runner))]
-#![cfg_attr(target_os = "hermit", reexport_test_harness_main = "test_main")]
+#![cfg_attr(target_os = "hermit", cfg_attr(test, test_runner(crate::test_runner)))]
+#![cfg_attr(
+	target_os = "hermit",
+	cfg_attr(test, reexport_test_harness_main = "test_main")
+)]
 #![cfg_attr(target_os = "hermit", cfg_attr(test, no_main))]
 
 // EXTERNAL CRATES
@@ -113,6 +116,12 @@ pub fn test_runner(tests: &[&dyn Fn()]) {
 		test();
 	}
 	sys_exit(0);
+}
+
+#[test_case]
+fn trivial_test() {
+	println!("Test test test");
+	panic!("Test called");
 }
 
 #[cfg(target_os = "hermit")]
@@ -279,11 +288,10 @@ extern "C" fn initd(_arg: usize) {
 	#[cfg(not(test))]
 	unsafe {
 		// And finally start the application.
-		runtime_entry(argc, argv, environ);
+		runtime_entry(argc, argv, environ)
 	}
 	#[cfg(test)]
 	test_main();
-	loop {}
 }
 
 fn synch_all_cores() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,6 @@ extern crate x86;
 
 use alloc::alloc::Layout;
 use core::alloc::GlobalAlloc;
-use core::panic::PanicInfo;
 use core::sync::atomic::{spin_loop_hint, AtomicU32, Ordering};
 
 use arch::percore::*;
@@ -260,6 +259,7 @@ fn has_ipdevice() -> bool {
 #[cfg(target_os = "hermit")]
 extern "C" fn initd(_arg: usize) {
 	extern "C" {
+		#[cfg(not(test))]
 		fn runtime_entry(argc: i32, argv: *const *const u8, env: *const *const u8) -> !;
 		#[cfg(feature = "newlib")]
 		fn init_lwip();
@@ -290,6 +290,7 @@ extern "C" fn initd(_arg: usize) {
 	syscalls::init();
 
 	// Get the application arguments and environment variables.
+	#[cfg(not(test))]
 	let (argc, argv, environ) = syscalls::get_application_parameters();
 
 	// give the IP thread time to initialize the network interface

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ mod collections;
 mod config;
 mod console;
 mod drivers;
-mod environment;
+pub mod environment;
 mod errno;
 mod kernel_message_buffer;
 mod mm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 #![feature(allocator_api)]
 #![feature(const_btree_new)]
 #![feature(const_fn)]
+#![feature(custom_test_frameworks)]
 #![feature(global_asm)]
 #![feature(lang_items)]
 #![feature(linkage)]
@@ -38,6 +39,9 @@
 #![feature(core_intrinsics)]
 #![feature(alloc_error_handler)]
 #![allow(unused_macros)]
+#![test_runner(crate::test_runner)]
+#![reexport_test_harness_main = "test_main"]
+#![cfg_attr(test, no_main)]
 #![no_std]
 
 // EXTERNAL CRATES
@@ -61,6 +65,7 @@ extern crate x86;
 
 use alloc::alloc::Layout;
 use core::alloc::GlobalAlloc;
+use core::panic::PanicInfo;
 use core::sync::atomic::{spin_loop_hint, AtomicU32, Ordering};
 
 use arch::percore::*;
@@ -93,6 +98,20 @@ mod scheduler;
 mod synch;
 mod syscalls;
 mod util;
+
+#[doc(hidden)]
+pub fn _print(args: ::core::fmt::Arguments) {
+	use core::fmt::Write;
+	crate::console::CONSOLE.lock().write_fmt(args).unwrap();
+}
+
+pub fn test_runner(tests: &[&dyn Fn()]) {
+	println!("Running {} tests", tests.len());
+	for test in tests {
+		test();
+	}
+	sys_exit(0);
+}
 
 #[cfg(target_os = "hermit")]
 #[global_allocator]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -22,14 +22,15 @@ macro_rules! align_up {
 ///
 /// From http://blog.phil-opp.com/rust-os/printing-to-screen.html, but tweaked
 /// for HermitCore.
+#[macro_export]
 macro_rules! print {
 	($($arg:tt)+) => ({
-		use core::fmt::Write;
-		$crate::console::CONSOLE.lock().write_fmt(format_args!($($arg)+)).unwrap();
+        $crate::_print(format_args!($($arg)*));
 	});
 }
 
 /// Print formatted text to our console, followed by a newline.
+#[macro_export]
 macro_rules! println {
     () => (print!("\n"));
 	($($arg:tt)+) => (print!("{}\n", format_args!($($arg)+)));

--- a/src/mm/allocator.rs
+++ b/src/mm/allocator.rs
@@ -24,9 +24,9 @@ pub struct Heap {
 	index: usize,
 	bottom: usize,
 	size: usize,
-	#[cfg(not(test))]
+	#[cfg(target_os = "hermit")]
 	holes: HoleList,
-	#[cfg(test)]
+	#[cfg(not(target_os = "hermit"))]
 	pub holes: HoleList,
 }
 

--- a/src/mm/freelist.rs
+++ b/src/mm/freelist.rs
@@ -231,6 +231,7 @@ impl FreeList {
 	}
 }
 
+#[cfg(not(target_os = "hermit"))]
 #[test]
 fn add_element() {
 	let mut freelist = FreeList::new();
@@ -247,6 +248,7 @@ fn add_element() {
 	}
 }
 
+#[cfg(not(target_os = "hermit"))]
 #[test]
 fn allocate() {
 	let mut freelist = FreeList::new();
@@ -270,6 +272,7 @@ fn allocate() {
 	}
 }
 
+#[cfg(not(target_os = "hermit"))]
 #[test]
 fn deallocate() {
 	let mut freelist = FreeList::new();

--- a/src/mm/hole.rs
+++ b/src/mm/hole.rs
@@ -88,7 +88,7 @@ impl HoleList {
 }
 
 /// A block containing free memory. It points to the next hole and thus forms a linked list.
-#[cfg(not(test))]
+#[cfg(target_os = "hermit")]
 pub struct Hole {
 	size: usize,
 	next: Option<&'static mut Hole>,
@@ -96,7 +96,7 @@ pub struct Hole {
 	padding: [usize; 6],
 }
 
-#[cfg(test)]
+#[cfg(not(target_os = "hermit"))]
 pub struct Hole {
 	pub size: usize,
 	pub next: Option<&'static mut Hole>,

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -76,7 +76,7 @@ fn map_heap<S: PageSize>(virt_addr: VirtAddr, size: usize) -> usize {
 	i
 }
 
-#[cfg(not(test))]
+#[cfg(target_os = "hermit")]
 pub fn init() {
 	// Calculate the start and end addresses of the 2 MiB page(s) that map the kernel.
 	unsafe {

--- a/src/mm/test.rs
+++ b/src/mm/test.rs
@@ -5,280 +5,298 @@
 // To avoid false sharing, our version allocate as smallest block 64 byte (= cache line).
 // In addition, for pre
 
-use super::*;
-use core::alloc::Layout;
-use std::mem::{align_of, size_of};
-use std::prelude::v1::*;
+#[cfg(not(target_os = "hermit"))]
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use core::alloc::Layout;
+	use std::mem::{align_of, size_of};
+	use std::prelude::v1::*;
 
-use crate::mm::allocator::*;
-use crate::mm::hole::*;
+	use crate::mm::allocator::*;
+	use crate::mm::hole::*;
 
-fn new_heap() -> Heap {
-	const HEAP_SIZE: usize = 1000;
-	let heap_space = Box::into_raw(Box::new([0u8; HEAP_SIZE]));
+	fn new_heap() -> Heap {
+		const HEAP_SIZE: usize = 1000;
+		let heap_space = Box::into_raw(Box::new([0u8; HEAP_SIZE]));
 
-	let heap = unsafe { Heap::new(heap_space as usize, HEAP_SIZE) };
-	assert_eq!(heap.bottom(), heap_space as usize);
-	assert_eq!(heap.size(), HEAP_SIZE);
-	heap
-}
-
-fn new_max_heap() -> Heap {
-	const HEAP_SIZE: usize = 1024;
-	const HEAP_SIZE_MAX: usize = 2048;
-	let heap_space = Box::into_raw(Box::new([0u8; HEAP_SIZE_MAX]));
-
-	let heap = unsafe { Heap::new(heap_space as usize, HEAP_SIZE) };
-	assert_eq!(heap.bottom(), heap_space as usize);
-	assert_eq!(heap.size(), HEAP_SIZE);
-	heap
-}
-
-#[test]
-fn empty() {
-	let mut heap = Heap::empty();
-	let layout = Layout::from_size_align(1, 1).unwrap();
-	// we have 4 kbyte static memory
-	assert!(heap.allocate_first_fit(layout.clone()).is_ok());
-
-	let layout = Layout::from_size_align(0x1000, align_of::<usize>());
-	let addr = heap.allocate_first_fit(layout.unwrap());
-	assert!(addr.is_err());
-}
-
-#[test]
-fn oom() {
-	let mut heap = new_heap();
-	let layout = Layout::from_size_align(heap.size() + 1, align_of::<usize>());
-	let addr = heap.allocate_first_fit(layout.unwrap());
-	assert!(addr.is_err());
-}
-
-#[test]
-fn allocate_double_usize() {
-	let mut heap = new_heap();
-	let size = size_of::<usize>() * 2;
-	let layout = Layout::from_size_align(size, align_of::<usize>());
-	let addr = heap.allocate_first_fit(layout.unwrap());
-	assert!(addr.is_ok());
-	let addr = addr.unwrap().0.as_ptr() as usize;
-	assert_eq!(addr, heap.bottom());
-	let (hole_addr, hole_size) = heap.holes.first_hole().expect("ERROR: no hole left");
-
-	// note: the smallest allocation granularity is 64 byte
-	let size = align_up!(size, 64);
-	assert!(hole_addr == heap.bottom() + size);
-	assert!(hole_size == heap.size() - size);
-
-	unsafe {
-		assert_eq!((*((addr + size) as *const Hole)).size, heap.size() - size);
+		let heap = unsafe { Heap::new(heap_space as usize, HEAP_SIZE) };
+		assert_eq!(heap.bottom(), heap_space as usize);
+		assert_eq!(heap.size(), HEAP_SIZE);
+		heap
 	}
-}
 
-#[test]
-fn allocate_and_free_double_usize() {
-	let mut heap = new_heap();
+	fn new_max_heap() -> Heap {
+		const HEAP_SIZE: usize = 1024;
+		const HEAP_SIZE_MAX: usize = 2048;
+		let heap_space = Box::into_raw(Box::new([0u8; HEAP_SIZE_MAX]));
 
-	let layout = Layout::from_size_align(size_of::<usize>() * 2, align_of::<usize>()).unwrap();
-	let x = heap.allocate_first_fit(layout.clone()).unwrap().0;
-	unsafe {
-		*(x.as_ptr() as *mut (usize, usize)) = (0xdeafdeadbeafbabe, 0xdeafdeadbeafbabe);
-
-		heap.deallocate(x, layout.clone());
-		assert_eq!((*(heap.bottom() as *const Hole)).size, heap.size());
-		assert!((*(heap.bottom() as *const Hole)).next.is_none());
+		let heap = unsafe { Heap::new(heap_space as usize, HEAP_SIZE) };
+		assert_eq!(heap.bottom(), heap_space as usize);
+		assert_eq!(heap.size(), HEAP_SIZE);
+		heap
 	}
-}
 
-#[test]
-fn deallocate_right_before() {
-	let mut heap = new_heap();
-	let layout = Layout::from_size_align(size_of::<usize>() * 5, 1).unwrap();
+	#[cfg(not(target_os = "hermit"))]
+	#[test]
+	fn empty() {
+		let mut heap = Heap::empty();
+		let layout = Layout::from_size_align(1, 1).unwrap();
+		// we have 4 kbyte static memory
+		assert!(heap.allocate_first_fit(layout.clone()).is_ok());
 
-	let x = heap.allocate_first_fit(layout.clone()).unwrap().0;
-	let y = heap.allocate_first_fit(layout.clone()).unwrap().0;
-	let z = heap.allocate_first_fit(layout.clone()).unwrap().0;
-
-	unsafe {
-		heap.deallocate(y, layout.clone());
-		// note: the smallest allocation granularity is 64 byte
-		assert_eq!(
-			(*(y.as_ptr() as *const Hole)).size,
-			align_up!(layout.size(), 64)
-		);
-		heap.deallocate(x, layout.clone());
-		assert_eq!(
-			(*(x.as_ptr() as *const Hole)).size,
-			align_up!(layout.size(), 64) * 2
-		);
-		heap.deallocate(z, layout.clone());
-		assert_eq!((*(x.as_ptr() as *const Hole)).size, heap.size());
+		let layout = Layout::from_size_align(0x1000, align_of::<usize>());
+		let addr = heap.allocate_first_fit(layout.unwrap());
+		assert!(addr.is_err());
 	}
-}
 
-#[test]
-fn deallocate_right_behind() {
-	let mut heap = new_heap();
-	let size = size_of::<usize>() * 5;
-	let layout = Layout::from_size_align(size, 1).unwrap();
-
-	let x = heap.allocate_first_fit(layout.clone()).unwrap().0;
-	let y = heap.allocate_first_fit(layout.clone()).unwrap().0;
-	let z = heap.allocate_first_fit(layout.clone()).unwrap().0;
-
-	unsafe {
-		heap.deallocate(x, layout.clone());
-		let size = align_up!(size, 64);
-		assert_eq!((*(x.as_ptr() as *const Hole)).size, size);
-		heap.deallocate(y, layout.clone());
-		assert_eq!((*(x.as_ptr() as *const Hole)).size, size * 2);
-		heap.deallocate(z, layout.clone());
-		assert_eq!((*(x.as_ptr() as *const Hole)).size, heap.size());
+	#[cfg(not(target_os = "hermit"))]
+	#[test]
+	fn oom() {
+		let mut heap = new_heap();
+		let layout = Layout::from_size_align(heap.size() + 1, align_of::<usize>());
+		let addr = heap.allocate_first_fit(layout.unwrap());
+		assert!(addr.is_err());
 	}
-}
 
-#[test]
-fn deallocate_middle() {
-	let mut heap = new_heap();
-	let size = size_of::<usize>() * 5;
-	let layout = Layout::from_size_align(size, 1).unwrap();
+	#[cfg(not(target_os = "hermit"))]
+	#[test]
+	fn allocate_double_usize() {
+		let mut heap = new_heap();
+		let size = size_of::<usize>() * 2;
+		let layout = Layout::from_size_align(size, align_of::<usize>());
+		let addr = heap.allocate_first_fit(layout.unwrap());
+		assert!(addr.is_ok());
+		let addr = addr.unwrap().0.as_ptr() as usize;
+		assert_eq!(addr, heap.bottom());
+		let (hole_addr, hole_size) = heap.holes.first_hole().expect("ERROR: no hole left");
 
-	let x = heap.allocate_first_fit(layout.clone()).unwrap().0;
-	let y = heap.allocate_first_fit(layout.clone()).unwrap().0;
-	let z = heap.allocate_first_fit(layout.clone()).unwrap().0;
-	let a = heap.allocate_first_fit(layout.clone()).unwrap().0;
-
-	unsafe {
-		heap.deallocate(x, layout.clone());
 		// note: the smallest allocation granularity is 64 byte
 		let size = align_up!(size, 64);
-		assert_eq!((*(x.as_ptr() as *const Hole)).size, size);
-		heap.deallocate(z, layout.clone());
-		assert_eq!((*(x.as_ptr() as *const Hole)).size, size);
-		assert_eq!((*(z.as_ptr() as *const Hole)).size, size);
-		heap.deallocate(y, layout.clone());
-		assert_eq!((*(x.as_ptr() as *const Hole)).size, size * 3);
-		heap.deallocate(a, layout.clone());
-		assert_eq!((*(x.as_ptr() as *const Hole)).size, heap.size());
-	}
-}
+		assert!(hole_addr == heap.bottom() + size);
+		assert!(hole_size == heap.size() - size);
 
-#[test]
-fn reallocate_double_usize() {
-	let mut heap = new_heap();
-
-	let layout = Layout::from_size_align(size_of::<usize>() * 2, align_of::<usize>()).unwrap();
-
-	let x = heap.allocate_first_fit(layout.clone()).unwrap().0;
-	unsafe {
-		heap.deallocate(x, layout.clone());
+		unsafe {
+			assert_eq!((*((addr + size) as *const Hole)).size, heap.size() - size);
+		}
 	}
 
-	let y = heap.allocate_first_fit(layout.clone()).unwrap().0;
-	unsafe {
-		heap.deallocate(y, layout.clone());
+	#[cfg(not(target_os = "hermit"))]
+	#[test]
+	fn allocate_and_free_double_usize() {
+		let mut heap = new_heap();
+
+		let layout = Layout::from_size_align(size_of::<usize>() * 2, align_of::<usize>()).unwrap();
+		let x = heap.allocate_first_fit(layout.clone()).unwrap().0;
+		unsafe {
+			*(x.as_ptr() as *mut (usize, usize)) = (0xdeafdeadbeafbabe, 0xdeafdeadbeafbabe);
+
+			heap.deallocate(x, layout.clone());
+			assert_eq!((*(heap.bottom() as *const Hole)).size, heap.size());
+			assert!((*(heap.bottom() as *const Hole)).next.is_none());
+		}
 	}
 
-	assert_eq!(x, y);
-}
+	#[cfg(not(target_os = "hermit"))]
+	#[test]
+	fn deallocate_right_before() {
+		let mut heap = new_heap();
+		let layout = Layout::from_size_align(size_of::<usize>() * 5, 1).unwrap();
 
-#[test]
-fn allocate_usize() {
-	let mut heap = new_heap();
+		let x = heap.allocate_first_fit(layout.clone()).unwrap().0;
+		let y = heap.allocate_first_fit(layout.clone()).unwrap().0;
+		let z = heap.allocate_first_fit(layout.clone()).unwrap().0;
 
-	let layout = Layout::from_size_align(size_of::<usize>(), 1).unwrap();
-
-	assert!(heap.allocate_first_fit(layout.clone()).is_ok());
-}
-
-#[test]
-fn allocate_usize_in_bigger_block() {
-	let mut heap = new_heap();
-
-	let layout_1 = Layout::from_size_align(size_of::<usize>() * 2, 1).unwrap();
-	let layout_2 = Layout::from_size_align(size_of::<usize>(), 1).unwrap();
-
-	let x = heap.allocate_first_fit(layout_1.clone()).unwrap().0;
-	let y = heap.allocate_first_fit(layout_1.clone()).unwrap().0;
-	unsafe {
-		heap.deallocate(x, layout_1.clone());
+		unsafe {
+			heap.deallocate(y, layout.clone());
+			// note: the smallest allocation granularity is 64 byte
+			assert_eq!(
+				(*(y.as_ptr() as *const Hole)).size,
+				align_up!(layout.size(), 64)
+			);
+			heap.deallocate(x, layout.clone());
+			assert_eq!(
+				(*(x.as_ptr() as *const Hole)).size,
+				align_up!(layout.size(), 64) * 2
+			);
+			heap.deallocate(z, layout.clone());
+			assert_eq!((*(x.as_ptr() as *const Hole)).size, heap.size());
+		}
 	}
 
-	let z = heap.allocate_first_fit(layout_2.clone());
-	assert!(z.is_ok());
-	let z = z.unwrap().0;
-	assert_eq!(x, z);
+	#[cfg(not(target_os = "hermit"))]
+	#[test]
+	fn deallocate_right_behind() {
+		let mut heap = new_heap();
+		let size = size_of::<usize>() * 5;
+		let layout = Layout::from_size_align(size, 1).unwrap();
 
-	unsafe {
-		heap.deallocate(y, layout_1.clone());
-		heap.deallocate(z, layout_2);
-	}
-}
+		let x = heap.allocate_first_fit(layout.clone()).unwrap().0;
+		let y = heap.allocate_first_fit(layout.clone()).unwrap().0;
+		let z = heap.allocate_first_fit(layout.clone()).unwrap().0;
 
-#[test]
-// see https://github.com/phil-opp/blog_os/issues/160
-fn align_from_small_to_big() {
-	let mut heap = new_heap();
-
-	let layout_1 = Layout::from_size_align(28, 4).unwrap();
-	let layout_2 = Layout::from_size_align(8, 8).unwrap();
-
-	// allocate 28 bytes so that the heap end is only 4 byte aligned
-	assert!(heap.allocate_first_fit(layout_1.clone()).is_ok());
-	// try to allocate a 8 byte aligned block
-	assert!(heap.allocate_first_fit(layout_2.clone()).is_ok());
-}
-
-#[test]
-fn extend_empty_heap() {
-	let mut heap = new_max_heap();
-
-	unsafe {
-		heap.extend(1024);
+		unsafe {
+			heap.deallocate(x, layout.clone());
+			let size = align_up!(size, 64);
+			assert_eq!((*(x.as_ptr() as *const Hole)).size, size);
+			heap.deallocate(y, layout.clone());
+			assert_eq!((*(x.as_ptr() as *const Hole)).size, size * 2);
+			heap.deallocate(z, layout.clone());
+			assert_eq!((*(x.as_ptr() as *const Hole)).size, heap.size());
+		}
 	}
 
-	// Try to allocate full heap after extend
-	let layout = Layout::from_size_align(2048, 1).unwrap();
-	assert!(heap.allocate_first_fit(layout.clone()).is_ok());
-}
+	#[cfg(not(target_os = "hermit"))]
+	#[test]
+	fn deallocate_middle() {
+		let mut heap = new_heap();
+		let size = size_of::<usize>() * 5;
+		let layout = Layout::from_size_align(size, 1).unwrap();
 
-#[test]
-fn extend_full_heap() {
-	let mut heap = new_max_heap();
+		let x = heap.allocate_first_fit(layout.clone()).unwrap().0;
+		let y = heap.allocate_first_fit(layout.clone()).unwrap().0;
+		let z = heap.allocate_first_fit(layout.clone()).unwrap().0;
+		let a = heap.allocate_first_fit(layout.clone()).unwrap().0;
 
-	let layout = Layout::from_size_align(1024, 1).unwrap();
-
-	// Allocate full heap, extend and allocate again to the max
-	assert!(heap.allocate_first_fit(layout.clone()).is_ok());
-	unsafe {
-		heap.extend(1024);
-	}
-	assert!(heap.allocate_first_fit(layout.clone()).is_ok());
-}
-
-#[test]
-fn extend_fragmented_heap() {
-	let mut heap = new_max_heap();
-
-	let layout_1 = Layout::from_size_align(512, 1).unwrap();
-	let layout_2 = Layout::from_size_align(1024, 1).unwrap();
-
-	let alloc1 = heap.allocate_first_fit(layout_1.clone());
-	let alloc2 = heap.allocate_first_fit(layout_1.clone());
-
-	assert!(alloc1.is_ok());
-	assert!(alloc2.is_ok());
-
-	unsafe {
-		// Create a hole at the beginning of the heap
-		heap.deallocate(alloc1.unwrap().0, layout_1.clone());
+		unsafe {
+			heap.deallocate(x, layout.clone());
+			// note: the smallest allocation granularity is 64 byte
+			let size = align_up!(size, 64);
+			assert_eq!((*(x.as_ptr() as *const Hole)).size, size);
+			heap.deallocate(z, layout.clone());
+			assert_eq!((*(x.as_ptr() as *const Hole)).size, size);
+			assert_eq!((*(z.as_ptr() as *const Hole)).size, size);
+			heap.deallocate(y, layout.clone());
+			assert_eq!((*(x.as_ptr() as *const Hole)).size, size * 3);
+			heap.deallocate(a, layout.clone());
+			assert_eq!((*(x.as_ptr() as *const Hole)).size, heap.size());
+		}
 	}
 
-	unsafe {
-		heap.extend(1024);
+	#[cfg(not(target_os = "hermit"))]
+	#[test]
+	fn reallocate_double_usize() {
+		let mut heap = new_heap();
+
+		let layout = Layout::from_size_align(size_of::<usize>() * 2, align_of::<usize>()).unwrap();
+
+		let x = heap.allocate_first_fit(layout.clone()).unwrap().0;
+		unsafe {
+			heap.deallocate(x, layout.clone());
+		}
+
+		let y = heap.allocate_first_fit(layout.clone()).unwrap().0;
+		unsafe {
+			heap.deallocate(y, layout.clone());
+		}
+
+		assert_eq!(x, y);
 	}
 
-	// We got additional 1024 bytes hole at the end of the heap
-	// Try to allocate there
-	assert!(heap.allocate_first_fit(layout_2.clone()).is_ok());
+	#[cfg(not(target_os = "hermit"))]
+	#[test]
+	fn allocate_usize() {
+		let mut heap = new_heap();
+
+		let layout = Layout::from_size_align(size_of::<usize>(), 1).unwrap();
+
+		assert!(heap.allocate_first_fit(layout.clone()).is_ok());
+	}
+
+	#[cfg(not(target_os = "hermit"))]
+	#[test]
+	fn allocate_usize_in_bigger_block() {
+		let mut heap = new_heap();
+
+		let layout_1 = Layout::from_size_align(size_of::<usize>() * 2, 1).unwrap();
+		let layout_2 = Layout::from_size_align(size_of::<usize>(), 1).unwrap();
+
+		let x = heap.allocate_first_fit(layout_1.clone()).unwrap().0;
+		let y = heap.allocate_first_fit(layout_1.clone()).unwrap().0;
+		unsafe {
+			heap.deallocate(x, layout_1.clone());
+		}
+
+		let z = heap.allocate_first_fit(layout_2.clone());
+		assert!(z.is_ok());
+		let z = z.unwrap().0;
+		assert_eq!(x, z);
+
+		unsafe {
+			heap.deallocate(y, layout_1.clone());
+			heap.deallocate(z, layout_2);
+		}
+	}
+
+	#[cfg(not(target_os = "hermit"))]
+	#[test]
+	// see https://github.com/phil-opp/blog_os/issues/160
+	fn align_from_small_to_big() {
+		let mut heap = new_heap();
+
+		let layout_1 = Layout::from_size_align(28, 4).unwrap();
+		let layout_2 = Layout::from_size_align(8, 8).unwrap();
+
+		// allocate 28 bytes so that the heap end is only 4 byte aligned
+		assert!(heap.allocate_first_fit(layout_1.clone()).is_ok());
+		// try to allocate a 8 byte aligned block
+		assert!(heap.allocate_first_fit(layout_2.clone()).is_ok());
+	}
+
+	#[cfg(not(target_os = "hermit"))]
+	#[test]
+	fn extend_empty_heap() {
+		let mut heap = new_max_heap();
+
+		unsafe {
+			heap.extend(1024);
+		}
+
+		// Try to allocate full heap after extend
+		let layout = Layout::from_size_align(2048, 1).unwrap();
+		assert!(heap.allocate_first_fit(layout.clone()).is_ok());
+	}
+
+	#[cfg(not(target_os = "hermit"))]
+	#[test]
+	fn extend_full_heap() {
+		let mut heap = new_max_heap();
+
+		let layout = Layout::from_size_align(1024, 1).unwrap();
+
+		// Allocate full heap, extend and allocate again to the max
+		assert!(heap.allocate_first_fit(layout.clone()).is_ok());
+		unsafe {
+			heap.extend(1024);
+		}
+		assert!(heap.allocate_first_fit(layout.clone()).is_ok());
+	}
+
+	#[cfg(not(target_os = "hermit"))]
+	#[test]
+	fn extend_fragmented_heap() {
+		let mut heap = new_max_heap();
+
+		let layout_1 = Layout::from_size_align(512, 1).unwrap();
+		let layout_2 = Layout::from_size_align(1024, 1).unwrap();
+
+		let alloc1 = heap.allocate_first_fit(layout_1.clone());
+		let alloc2 = heap.allocate_first_fit(layout_1.clone());
+
+		assert!(alloc1.is_ok());
+		assert!(alloc2.is_ok());
+
+		unsafe {
+			// Create a hole at the beginning of the heap
+			heap.deallocate(alloc1.unwrap().0, layout_1.clone());
+		}
+
+		unsafe {
+			heap.extend(1024);
+		}
+
+		// We got additional 1024 bytes hole at the end of the heap
+		// Try to allocate there
+		assert!(heap.allocate_first_fit(layout_2.clone()).is_ok());
+	}
 }

--- a/src/rlib.rs
+++ b/src/rlib.rs
@@ -73,6 +73,7 @@ pub unsafe extern "C" fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
 mod test {
 	use super::{memcmp, memcpy, memmove, memset};
 
+	#[cfg(not(target_os = "hermit"))]
 	#[test]
 	fn memcmp_single_byte_pointers() {
 		unsafe {
@@ -81,6 +82,7 @@ mod test {
 		}
 	}
 
+	#[cfg(not(target_os = "hermit"))]
 	#[test]
 	fn memcmp_strings() {
 		{
@@ -101,6 +103,7 @@ mod test {
 		}
 	}
 
+	#[cfg(not(target_os = "hermit"))]
 	#[test]
 	fn memset_single_byte_pointers() {
 		let mut x: u8 = 0xFF;
@@ -115,6 +118,7 @@ mod test {
 		}
 	}
 
+	#[cfg(not(target_os = "hermit"))]
 	#[test]
 	fn memset_array() {
 		let mut buffer = [b'X'; 100];
@@ -126,6 +130,7 @@ mod test {
 		}
 	}
 
+	#[cfg(not(target_os = "hermit"))]
 	#[test]
 	fn memcpy_and_memcmp_arrays() {
 		let (src, mut dst) = ([b'X'; 100], [b'Y'; 100]);
@@ -136,6 +141,7 @@ mod test {
 		}
 	}
 
+	#[cfg(not(target_os = "hermit"))]
 	#[test]
 	fn memmove_overlapping() {
 		{

--- a/src/rlib.rs
+++ b/src/rlib.rs
@@ -69,6 +69,7 @@ pub unsafe extern "C" fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
 	0
 }
 
+#[cfg(not(target_os = "hermit"))]
 #[cfg(test)]
 mod test {
 	use super::{memcmp, memcpy, memmove, memset};

--- a/src/runtime_glue.rs
+++ b/src/runtime_glue.rs
@@ -15,7 +15,7 @@ use alloc::alloc::Layout;
 use core::panic::PanicInfo;
 
 // see https://users.rust-lang.org/t/psa-breaking-change-panic-fmt-language-item-removed-in-favor-of-panic-implementation/17875
-#[cfg(not(test))]
+#[cfg(target_os = "hermit")]
 #[linkage = "weak"]
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {

--- a/src/syscalls/interfaces/uhyve.rs
+++ b/src/syscalls/interfaces/uhyve.rs
@@ -213,7 +213,7 @@ impl SyscallInterface for Uhyve {
 	///
 	/// ToDo: Add Safety section under which circumctances this is safe/unsafe to use
 	/// ToDo: Add an Errors section - What happens when e.g. malloc fails, how is that handled (currently it isn't)
-	#[cfg(not(test))]
+	#[cfg(target_os = "hermit")]
 	fn get_application_parameters(&self) -> (i32, *const *const u8, *const *const u8) {
 		//FIXME: Determine how to make this safer, check return values of malloc etc
 		// and then remove the unsafe block and only wrap the parts where it is needed

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -12,7 +12,7 @@ use crate::environment;
 #[cfg(feature = "newlib")]
 use crate::synch::spinlock::SpinlockIrqSave;
 use crate::syscalls::interfaces::SyscallInterface;
-#[cfg(not(test))]
+#[cfg(target_os = "hermit")]
 use crate::{__sys_free, __sys_malloc, __sys_realloc};
 
 pub use self::condvar::*;
@@ -66,19 +66,19 @@ pub fn init() {
 	sbrk_init();
 }
 
-#[cfg(not(test))]
+#[cfg(target_os = "hermit")]
 #[no_mangle]
 pub extern "C" fn sys_malloc(size: usize, align: usize) -> *mut u8 {
 	__sys_malloc(size, align)
 }
 
-#[cfg(not(test))]
+#[cfg(target_os = "hermit")]
 #[no_mangle]
 pub extern "C" fn sys_realloc(ptr: *mut u8, size: usize, align: usize, new_size: usize) -> *mut u8 {
 	unsafe { __sys_realloc(ptr, size, align, new_size) }
 }
 
-#[cfg(not(test))]
+#[cfg(target_os = "hermit")]
 #[no_mangle]
 pub extern "C" fn sys_free(ptr: *mut u8, size: usize, align: usize) {
 	unsafe { __sys_free(ptr, size, align) }

--- a/tests/basic_math.rs
+++ b/tests/basic_math.rs
@@ -1,0 +1,80 @@
+#![no_std]
+#![no_main]
+
+extern crate hermit;
+use hermit::{print, println};
+
+// Workaround since the "real" runtime_entry function (defined in libstd) is not available,
+// since the target-os is hermit-kernel and not hermit
+#[no_mangle]
+extern "C"
+fn runtime_entry(argc: i32, argv: *const *const u8, _env: *const *const u8) -> ! {
+    let res = main(argc as isize, argv);
+    match res {
+        Ok(_) => hermit::sys_exit(0),
+        Err(_) => hermit::sys_exit(1),  //ToDo: sys_exit exitcode doesn't seem to get passed to qemu
+        // sys_exit argument doesn't actually get used, gets silently dropped!
+        // Maybe this is not possible on QEMU?
+        // https://os.phil-opp.com/testing/#exiting-qemu device needed?
+    }
+}
+
+
+
+
+/*
+/// assert_eq but returns Result<(),&str> instead of panicking
+/// no error message possible
+/// adapted from libcore assert_eq macro
+macro_rules! equals {
+    ($left:expr, $right:expr) => ({
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    return Err(r#"assertion failed: `(left == right)`
+  left: `{:?}`,
+ right: `{:?}`"# &*left_val, &*right_val);
+                }
+                else { return Ok(()); }
+            }
+        }
+    });
+    ($left:expr, $right:expr,) => ({
+        $crate::assert_eq!($left, $right)
+    });
+}
+
+macro_rules! n_equals {
+    ($left:expr, $right:expr) => ({
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if *left_val == *right_val {
+                    // The reborrows below are intentional. Without them, the stack slot for the
+                    // borrow is initialized even before the values are compared, leading to a
+                    // noticeable slow down.
+                    return Err(r#"assertion failed: `(left == right)`
+  left: `{:?}`,
+ right: `{:?}`"#, &*left_val, &*right_val);
+                }
+                else return Ok(());
+            }
+        }
+    });
+    ($left:expr, $right:expr,) => {
+        $crate::assert_ne!($left, $right)
+    };
+}
+*/
+
+//ToDo - add a testrunner so we can group multiple similar tests
+
+//ToDo - Idea: pass some values into main - compute and print result to stdout
+//ToDo - add some kind of assert like macro that returns a result instead of panicking, Err contains line number etc to pinpoint the issue
+pub fn main(_argc: isize, _argv: *const *const u8) -> Result<(), ()>{
+    let x = 25;
+    let y = 310;
+    let z = x * y;
+    println!("25 * 310 = {}", z);
+    assert_eq!(z, 7750);
+    Ok(())
+}

--- a/tests/basic_math.rs
+++ b/tests/basic_math.rs
@@ -3,87 +3,51 @@
 
 extern crate hermit;
 extern crate x86_64;
-use hermit::{print, println};
 
-// Workaround since the "real" runtime_entry function (defined in libstd) is not available,
-// since the target-os is hermit-kernel and not hermit
-#[no_mangle]
-extern "C"
-fn runtime_entry(argc: i32, argv: *const *const u8, _env: *const *const u8) -> ! {
-    let res = main(argc as isize, argv);
-    match res {
-        Ok(_) => exit_qemu(QemuExitCode::Success),
-        Err(_) => exit_qemu(QemuExitCode::Failed),
-        // sys_exit argument doesn't actually get used, gets silently dropped!
-        // Maybe this is not possible on QEMU?
-        // https://os.phil-opp.com/testing/#exiting-qemu device needed?
-    }
-    println!("Failed to debug exit qemu");
-    hermit::sys_exit(0);  //sys_exit exitcode on qemu gets silently dropped
-
-}
-
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u32)]
-pub enum QemuExitCode {
-    Success = 0x10,
-    Failed = 0x11,
-}
-
-pub fn exit_qemu(exit_code: QemuExitCode) {
-    use x86_64::instructions::port::Port;
-
-    unsafe {
-        let mut port = Port::new(0xf4);
-        port.write(exit_code as u32);
-    }
-}
-
-
-
+mod common;
+use common::*;
 
 /*
 /// assert_eq but returns Result<(),&str> instead of panicking
 /// no error message possible
 /// adapted from libcore assert_eq macro
 macro_rules! equals {
-    ($left:expr, $right:expr) => ({
-        match (&$left, &$right) {
-            (left_val, right_val) => {
-                if !(*left_val == *right_val) {
-                    return Err(r#"assertion failed: `(left == right)`
+	($left:expr, $right:expr) => ({
+		match (&$left, &$right) {
+			(left_val, right_val) => {
+				if !(*left_val == *right_val) {
+					return Err(r#"assertion failed: `(left == right)`
   left: `{:?}`,
  right: `{:?}`"# &*left_val, &*right_val);
-                }
-                else { return Ok(()); }
-            }
-        }
-    });
-    ($left:expr, $right:expr,) => ({
-        $crate::assert_eq!($left, $right)
-    });
+				}
+				else { return Ok(()); }
+			}
+		}
+	});
+	($left:expr, $right:expr,) => ({
+		$crate::assert_eq!($left, $right)
+	});
 }
 
 macro_rules! n_equals {
-    ($left:expr, $right:expr) => ({
-        match (&$left, &$right) {
-            (left_val, right_val) => {
-                if *left_val == *right_val {
-                    // The reborrows below are intentional. Without them, the stack slot for the
-                    // borrow is initialized even before the values are compared, leading to a
-                    // noticeable slow down.
-                    return Err(r#"assertion failed: `(left == right)`
+	($left:expr, $right:expr) => ({
+		match (&$left, &$right) {
+			(left_val, right_val) => {
+				if *left_val == *right_val {
+					// The reborrows below are intentional. Without them, the stack slot for the
+					// borrow is initialized even before the values are compared, leading to a
+					// noticeable slow down.
+					return Err(r#"assertion failed: `(left == right)`
   left: `{:?}`,
  right: `{:?}`"#, &*left_val, &*right_val);
-                }
-                else return Ok(());
-            }
-        }
-    });
-    ($left:expr, $right:expr,) => {
-        $crate::assert_ne!($left, $right)
-    };
+				}
+				else return Ok(());
+			}
+		}
+	});
+	($left:expr, $right:expr,) => {
+		$crate::assert_ne!($left, $right)
+	};
 }
 */
 
@@ -91,11 +55,12 @@ macro_rules! n_equals {
 
 //ToDo - Idea: pass some values into main - compute and print result to stdout
 //ToDo - add some kind of assert like macro that returns a result instead of panicking, Err contains line number etc to pinpoint the issue
-pub fn main(_argc: isize, _argv: *const *const u8) -> Result<(), ()>{
-    let x = 25;
-    let y = 310;
-    let z = x * y;
-    println!("25 * 310 = {}", z);
-    assert_eq!(z, 7750);
-    Ok(())
+#[no_mangle]
+pub fn main(args: Vec<String>) -> Result<(), ()> {
+	let x = 25;
+	let y = 310;
+	let z = x * y;
+	println!("25 * 310 = {}", z);
+	assert_eq!(z, 7750);
+	Ok(())
 }

--- a/tests/basic_math.rs
+++ b/tests/basic_math.rs
@@ -43,6 +43,7 @@ fn subtest() {
 	int_test::<i16>();
 	int_test::<i32>();
 	int_test::<i64>();
+	// int_test::<i128>();  Blocked by https://github.com/rust-num/num-traits/issues/177
 
 	sint_test::<i8>();
 	sint_test::<i16>();

--- a/tests/basic_mem.rs
+++ b/tests/basic_mem.rs
@@ -1,0 +1,149 @@
+#![feature(test)]
+#![no_std]
+#![no_main]
+#![test_runner(common::test_case_runner)]
+#![feature(custom_test_frameworks)]
+#![reexport_test_harness_main = "test_main"]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::mem::size_of;
+
+use hermit::{print, println};
+
+//no-std otherwise std::mem::size_of
+mod common;
+
+const PATTERN: u8 = 0xAB;
+
+/// Mainly test if memcpy works as expected. Also somewhat tests memcmp
+/// Works with u8, u16, u32, u64, i16, i32 and i64
+/// u128 is blocked due to issue with num_traits, for reason see `basic_math`
+/// Probably not a super good test
+fn mem<T>()
+where
+	T: core::fmt::Debug,
+	T: num_traits::int::PrimInt,
+{
+	extern "C" {
+		fn memcpy(dest: *mut u8, src: *const u8, n: usize) -> *mut u8;
+		fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32;
+	}
+	let vec_size: u32 = 10000;
+	let pre_dest_vec_size: u32 = 1;
+	let post_dest_vec_size: u32 = 1;
+	let t_base_pattern: T = T::from(PATTERN).unwrap();
+	let mut pattern: T = t_base_pattern;
+	// Fill pattern of type T with size_of<T> times the byte pattern
+	// The "pre" and "post part of the destination vector are later filled with this pattern
+	for i in 1..size_of::<T>() {
+		pattern = pattern.shl(8) + t_base_pattern;
+	}
+	let pattern = pattern; // remove mut
+
+	let a: Vec<T> = {
+		//Vec containing 0..min(vec_size, T::max_value()) as pattern for vec_size elements
+		let mut a: Vec<T> = Vec::with_capacity(vec_size as usize);
+		let max = {
+			// the max value in a is the minimun of (vec_size -1) and T::max
+			let tmax = T::max_value();
+			if T::from(vec_size).is_none() {
+				tmax.to_u64().unwrap() // If vec_size can't be represented in T, then tmax must fit in u64
+			} else {
+				(vec_size - 1) as u64
+			}
+		};
+		// ToDo - This loop should be rewritten in a nicer way
+		while a.len() < vec_size as usize {
+			for i in 0..=max {
+				a.push(T::from(i).unwrap());
+				if a.len() == vec_size as usize {
+					break;
+				};
+			}
+		}
+		a
+	};
+	assert_eq!(a.len(), vec_size as usize);
+
+	let mut b: Vec<T> =
+		Vec::with_capacity((vec_size + pre_dest_vec_size + post_dest_vec_size) as usize);
+	// Manually set length, since we will be manually filling the vector
+	unsafe {
+		b.set_len((vec_size + pre_dest_vec_size + post_dest_vec_size) as usize);
+	}
+	// Fill pre and post section with `pattern`
+	for i in 0..pre_dest_vec_size {
+		b[i as usize] = pattern;
+	}
+	for i in 0..post_dest_vec_size {
+		b[(pre_dest_vec_size + vec_size + i) as usize] = pattern;
+	}
+	// Copy the actual vector
+	unsafe {
+		memcpy(
+			b.as_mut_ptr().offset(pre_dest_vec_size as isize) as *mut u8,
+			a.as_ptr() as *const u8,
+			((size_of::<T>() as u32) * vec_size) as usize,
+		);
+	}
+	// Assert that `pattern` in pre section was not changed by memcpy
+	for i in 0..pre_dest_vec_size {
+		assert_eq!(b[i as usize], pattern);
+	}
+	// Assert that `a` was correctly copied to `b`
+	{
+		let mut i = 0; // a[i] should match b[pre_dest_vec_size + i]
+		let mut j: T = T::from(0).unwrap();
+		while i < vec_size {
+			assert_eq!(b[(pre_dest_vec_size + i) as usize], j);
+			i += 1;
+			j = if j == T::max_value() {
+				T::from(0).unwrap()
+			} else {
+				j + T::from(1).unwrap()
+			}
+		}
+	}
+	// Assert that `pattern` in post section was not changed
+	for i in 0..post_dest_vec_size {
+		assert_eq!(b[(pre_dest_vec_size + vec_size + i) as usize], pattern);
+	}
+	// Do the assertions again, but this time using `memcmp`
+	unsafe {
+		assert_eq!(
+			memcmp(
+				b.as_ptr().offset(pre_dest_vec_size as isize) as *const u8,
+				a.as_ptr() as *const u8,
+				((size_of::<T>() as usize) * vec_size as usize),
+			),
+			0
+		);
+		// pattern is larger, a[0] is 0
+		assert!(memcmp(b.as_ptr() as *const u8, a.as_ptr() as *const u8, 1) > 0);
+		assert!(memcmp(a.as_ptr() as *const u8, b.as_ptr() as *const u8, 1) < 0);
+		assert!(
+			memcmp(
+				b.as_ptr().offset((vec_size + pre_dest_vec_size) as isize) as *const u8,
+				a.as_ptr() as *const u8,
+				1,
+			) > 0
+		);
+	}
+}
+
+#[test_case]
+fn test_mem() {
+	mem::<u32>();
+	mem::<u64>();
+	mem::<u16>();
+	mem::<u8>();
+	mem::<usize>();
+}
+
+#[no_mangle]
+extern "C" fn runtime_entry(_argc: i32, _argv: *const *const u8, _env: *const *const u8) -> ! {
+	test_main();
+	common::exit(false)
+}

--- a/tests/basic_print.rs
+++ b/tests/basic_print.rs
@@ -1,3 +1,4 @@
+#![feature(test)]
 #![no_std]
 #![no_main]
 //#![test_runner(hermit::test_runner)]
@@ -12,8 +13,9 @@ use common::*;
 
 /// Print all Strings the application got passed as arguments
 #[no_mangle]
-pub fn main(args: Vec<String>) {
+pub fn main(args: Vec<String>) -> Result<(), ()> {
 	for s in args {
 		println!("{}", &s);
 	}
+	Ok(()) // real assertion is done by the runner
 }

--- a/tests/basic_print.rs
+++ b/tests/basic_print.rs
@@ -8,8 +8,9 @@
 //use core::panic::PanicInfo;
 extern crate hermit;
 
-mod common;
+#[macro_use]
 use common::*;
+mod common;
 
 /// Print all Strings the application got passed as arguments
 #[no_mangle]
@@ -19,3 +20,5 @@ pub fn main(args: Vec<String>) -> Result<(), ()> {
 	}
 	Ok(()) // real assertion is done by the runner
 }
+
+runtime_entry_with_args!();

--- a/tests/basic_print.rs
+++ b/tests/basic_print.rs
@@ -6,19 +6,14 @@
 
 //use core::panic::PanicInfo;
 extern crate hermit;
-use hermit::{print, println};
 
-//ToDo: Define exit code enum in hermit!!!
+mod common;
+use common::*;
 
-// Workaround since the "real" runtime_entry function (defined in libstd) is not available,
-// since the target-os is hermit-kernel and not hermit
+/// Print all Strings the application got passed as arguments
 #[no_mangle]
-extern "C" fn runtime_entry(argc: i32, argv: *const *const u8, env: *const *const u8) -> ! {
-	main(argc as isize, argv);
-	hermit::sys_exit(-1);
-}
-
-//#[test_case]
-pub fn main(argc: isize, argv: *const *const u8) {
-	println!("hey we made it to the test function :O");
+pub fn main(args: Vec<String>) {
+	for s in args {
+		println!("{}", &s);
+	}
 }

--- a/tests/basic_print.rs
+++ b/tests/basic_print.rs
@@ -1,0 +1,24 @@
+#![no_std]
+#![no_main]
+//#![test_runner(hermit::test_runner)]
+//#![feature(custom_test_frameworks)]
+//#![reexport_test_harness_main = "test_main"]
+
+//use core::panic::PanicInfo;
+extern crate hermit;
+use hermit::{print, println};
+
+//ToDo: Define exit code enum in hermit!!!
+
+// Workaround since the "real" runtime_entry function (defined in libstd) is not available,
+// since the target-os is hermit-kernel and not hermit
+#[no_mangle]
+extern "C" fn runtime_entry(argc: i32, argv: *const *const u8, env: *const *const u8) -> ! {
+	main(argc as isize, argv);
+	hermit::sys_exit(-1);
+}
+
+//#[test_case]
+pub fn main(argc: isize, argv: *const *const u8) {
+	println!("hey we made it to the test function :O");
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,73 @@
+/// Common functionality for all integration tests
+pub extern crate alloc;
+pub use alloc::string::String;
+pub use alloc::vec::Vec;
+pub use hermit::{print, println};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum QemuExitCode {
+	Success = 0x10,
+	Failed = 0x11,
+}
+
+/// Debug exit from qemu with a returncode
+/// '-device', 'isa-debug-exit,iobase=0xf4,iosize=0x04' must be passed to qemu for this to work
+pub fn exit_qemu(exit_code: QemuExitCode) {
+	use x86_64::instructions::port::Port;
+
+	unsafe {
+		let mut port = Port::new(0xf4);
+		port.write(exit_code as u32);
+	}
+}
+
+// ToDo: Maybe we could add a hard limit on the length of `s` to make this slightly safer?
+unsafe fn parse_str(s: *const u8) -> Result<String, ()> {
+	let mut vec: Vec<u8> = Vec::new();
+	let mut off = s;
+	while *off != 0 {
+		vec.push(*off);
+		off = off.offset(1);
+	}
+	let str = String::from_utf8(vec);
+	match str {
+		Ok(s) => Ok(s),
+		Err(_) => Err(()), //Convert error here since we might want to add another error type later
+	}
+}
+
+// Workaround since the "real" runtime_entry function (defined in libstd) is not available,
+// since the target-os is hermit-kernel and not hermit
+#[no_mangle]
+extern "C" fn runtime_entry(argc: i32, argv: *const *const u8, _env: *const *const u8) -> ! {
+	extern "Rust" {
+		/// main functions of integration test get their arguments as a Vec<String> and
+		/// must return a Result<(), ()> indicating success or failure of the tests
+		fn main(args: Vec<String>) -> Result<(), ()>;
+	}
+
+	let mut str_vec: Vec<String> = Vec::new();
+	let mut off = argv;
+	for i in 0..argc {
+		let s = unsafe { parse_str(*off) };
+		unsafe {
+			off = off.offset(1);
+		}
+		match s {
+			Ok(s) => str_vec.push(s),
+			Err(_) => println!(
+				"Warning: Application argument {} is not valid utf-8 - Dropping it",
+				i
+			),
+		}
+	}
+
+	let res = unsafe { main(str_vec) };
+	match res {
+		Ok(_) => exit_qemu(QemuExitCode::Success),
+		Err(_) => exit_qemu(QemuExitCode::Failed),
+	}
+	println!("Warning - Failed to debug exit qemu - exiting via sys_exit()");
+	hermit::sys_exit(0); //sys_exit exitcode on qemu gets silently dropped
+}

--- a/tests/hermit_test_runner.py
+++ b/tests/hermit_test_runner.py
@@ -181,7 +181,8 @@ test_name = os.path.basename(test_exe)
 test_name = clean_test_name(test_name)
 if test_name == "hermit":
     print("Executing the Unittests is currently broken... Skipping Test and marking as failed")
-    exit(-1)
+    print("Note: If you want to execute all tests, consider adding the '--no-fail-fast' flag")
+    exit(36)
 
 if args.bootloader_path is not None:
     test_runner = QemuTestRunner(test_exe, args.bootloader_path)

--- a/tests/hermit_test_runner.py
+++ b/tests/hermit_test_runner.py
@@ -22,6 +22,7 @@ def run_test(process_args):
     print(os.getcwd())
     abs_bootloader_path = os.path.abspath(BOOTLOADER_PATH)
     print("Abspath: ", abs_bootloader_path)
+    start_time = time.time_ns() # Note: Requires python >= 3.7
     p = Popen(process_args, stdout=PIPE, stderr=STDOUT, text=True)
     output: str = ""
     for line in p.stdout:
@@ -29,8 +30,9 @@ def run_test(process_args):
         output += dec_line
         #print(line, end='')  # stdout will already contain line break
     rc = p.wait()
+    end_time = time.time_ns()
     # ToDo: add some timeout
-    return rc, output
+    return rc, output, end_time - start_time
 
 
 def validate_test(returncode, output, test_exe_path):
@@ -82,15 +84,15 @@ for arg in args.runner_args:
     # ToDo: assert that arg is a path to an executable before calling qemu
     # ToDo: Add addional test based arguments for qemu / uhyve
     curr_qemu_arguments.extend(['-initrd', arg])
-    rc, output = run_test(curr_qemu_arguments)
+    rc, output, rtime = run_test(curr_qemu_arguments)
     test_ok = validate_test(rc, output, arg)
     test_name = os.path.basename(arg)
     test_name = clean_test_name(test_name)
     if test_ok:
-        print("Test Ok: {}".format(test_name))
+        print("Test Ok: {} - runtime: {} seconds".format(test_name, rtime / (10 ** 9)))
         ok_tests += 1
     else:
-        print("Test failed: {}".format(test_name))
+        print("Test failed: {} - runtime: {} seconds".format(test_name, rtime / (10 ** 9)))
         failed_tests += 1
     #Todo: improve information about the test
 

--- a/tests/hermit_test_runner.py
+++ b/tests/hermit_test_runner.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python3
 
-import time
 import argparse
-import subprocess
+import os
+import os.path
+import sys
+import time
 from subprocess import Popen, PIPE, STDOUT
-import os, os.path
+import subprocess
+import platform
 
 SMP_CORES = 1  # Number of cores
-MEMORY_MB = 64  # amount of memory
+MEMORY_MB = 256  # amount of memory
 # Path if libhermit-rs was checked out via rusty-hermit repository
 BOOTLOADER_PATH = '../loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader'
+USE_UHYVE = False   # ToDo: consider using a class and dynamic methods instead of global options
 
 
 # ToDo add test dependent section for custom kernel arguments / application arguments
@@ -18,27 +22,41 @@ BOOTLOADER_PATH = '../loader/target/x86_64-unknown-hermit-loader/debug/rusty-loa
 # If it doesn't exist just assure that the return code is not a failure
 
 # ToDo Think about always being verbose, or hiding the output
-def run_test(process_args):
+def run_test_qemu(process_args):
     print(os.getcwd())
     abs_bootloader_path = os.path.abspath(BOOTLOADER_PATH)
     print("Abspath: ", abs_bootloader_path)
-    start_time = time.time_ns() # Note: Requires python >= 3.7
+    start_time = time.time_ns()  # Note: Requires python >= 3.7
     p = Popen(process_args, stdout=PIPE, stderr=STDOUT, text=True)
     output: str = ""
     for line in p.stdout:
         dec_line = line
         output += dec_line
-        #print(line, end='')  # stdout will already contain line break
+        print(line, end='')  # stdout will already contain line break
     rc = p.wait()
     end_time = time.time_ns()
     # ToDo: add some timeout
     return rc, output, end_time - start_time
 
 
+def run_test_uhyve(kernel_path):
+    assert os.path.isfile(kernel_path)
+    process_args = ['uhyve', '-v', kernel_path]
+    start_time = time.time_ns()  # Note: Requires python >= 3.7
+    my_env = os.environ.copy()
+    my_env['HERMIT_GDB_PORT'] = '1234'
+    p = subprocess.run(process_args, stdout=PIPE, stderr=STDOUT, text=True, env=my_env)
+    end_time = time.time_ns()
+    print(p.stdout)
+    return p.returncode, p.stdout, end_time - start_time
+
+
 def validate_test(returncode, output, test_exe_path):
     print("returncode ", returncode)
     # ToDo handle expected failures
-    if returncode != 33:
+    if not USE_UHYVE and returncode != 33:
+        return False
+    if USE_UHYVE and returncode != 0:
         return False
     # ToDo parse output for panic
     return True
@@ -59,6 +77,9 @@ def clean_test_name(name: str):
     return clean_name
 
 
+assert sys.version_info[0] == 3, "Python 3 is required to run this script"
+assert sys.version_info[1] >= 7, "Currently at least Python 3.7 is required for this script, If necessary this could " \
+                                 "be reduced "
 print("Test runner called")
 parser = argparse.ArgumentParser(description='See documentation of cargo test runner for custom test framework')
 parser.add_argument('runner_args', type=str, nargs='*')
@@ -73,40 +94,33 @@ qemu_base_arguments = ['qemu-system-x86_64',
                        '-kernel', BOOTLOADER_PATH,
                        # skip initrd - it depends on test executable
                        '-cpu', 'qemu64,apic,fsgsbase,rdtscp,xsave,fxsr',
-                       '-device', 'isa-debug-exit,iobase=0xf4,iosize=0x04'
+                       '-device', 'isa-debug-exit,iobase=0xf4,iosize=0x04',
                        ]
-ok_tests: int = 0
-failed_tests: int = 0
-# This is assuming test_runner only passes executable files as parameters
-for arg in args.runner_args:
-    assert isinstance(arg, str)
-    curr_qemu_arguments = qemu_base_arguments.copy()
-    # ToDo: assert that arg is a path to an executable before calling qemu
-    # ToDo: Add addional test based arguments for qemu / uhyve
-    curr_qemu_arguments.extend(['-initrd', arg])
-    rc, output, rtime = run_test(curr_qemu_arguments)
-    test_ok = validate_test(rc, output, arg)
-    test_name = os.path.basename(arg)
-    test_name = clean_test_name(test_name)
-    if test_ok:
-        print("Test Ok: {} - runtime: {} seconds".format(test_name, rtime / (10 ** 9)))
-        ok_tests += 1
-    else:
-        print("Test failed: {} - runtime: {} seconds".format(test_name, rtime / (10 ** 9)))
-        failed_tests += 1
-    #Todo: improve information about the test
+# The last argument is the executable, all other arguments are ignored for now
+arg = args.runner_args[-1]
+assert isinstance(arg, str)
+curr_qemu_arguments = qemu_base_arguments.copy()
+assert os.path.isfile(arg)      # If this fails likely something about runner args changed
+# ToDo: Add addional test based arguments for qemu / uhyve
+curr_qemu_arguments.extend(['-initrd', arg])
+if USE_UHYVE:
+    if platform.system() == 'Windows':
+        print("Error: using uhyve requires kvm. Please use Linux or Mac OS")
+        exit(-1)
+    rc, output, rtime = run_test_uhyve(arg)
+else:
+    rc, output, rtime = run_test_qemu(curr_qemu_arguments)
+test_ok = validate_test(rc, output, arg)
+test_name = os.path.basename(arg)
+test_name = clean_test_name(test_name)
+if test_ok:
+    print("Test Ok: {} - runtime: {} seconds".format(test_name, rtime / (10 ** 9)))
+    exit(0)
+else:
+    print("Test failed: {} - runtime: {} seconds".format(test_name, rtime / (10 ** 9)))
+    exit(1)
+#Todo: improve information about the test
 
-print("{} from {} tests successful".format(ok_tests, ok_tests + failed_tests))
 # todo print something ala x/y tests failed etc.
 #  maybe look at existing standards (TAP?)
 #  - TAP: could use tappy to convert to python style unit test output (benefit??)
-
-if failed_tests == 0:
-    exit(0)
-else:
-    exit(1)
-
-
-
-
-

--- a/tests/hermit_test_runner.py
+++ b/tests/hermit_test_runner.py
@@ -13,7 +13,8 @@ SMP_CORES = 1  # Number of cores
 MEMORY_MB = 256  # amount of memory
 # Path if libhermit-rs was checked out via rusty-hermit repository
 BOOTLOADER_PATH = '../loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader'
-USE_UHYVE = False   # ToDo: consider using a class and dynamic methods instead of global options
+USE_UHYVE = True   # ToDo: consider using a class and dynamic methods instead of global options
+GDB = False
 
 
 # ToDo add test dependent section for custom kernel arguments / application arguments
@@ -44,7 +45,8 @@ def run_test_uhyve(kernel_path):
     process_args = ['uhyve', '-v', kernel_path]
     start_time = time.time_ns()  # Note: Requires python >= 3.7
     my_env = os.environ.copy()
-    my_env['HERMIT_GDB_PORT'] = '1234'
+    if GDB:
+        my_env['HERMIT_GDB_PORT'] = '1234'
     p = subprocess.run(process_args, stdout=PIPE, stderr=STDOUT, text=True, env=my_env)
     end_time = time.time_ns()
     print(p.stdout)
@@ -96,6 +98,9 @@ qemu_base_arguments = ['qemu-system-x86_64',
                        '-cpu', 'qemu64,apic,fsgsbase,rdtscp,xsave,fxsr',
                        '-device', 'isa-debug-exit,iobase=0xf4,iosize=0x04',
                        ]
+if GDB:
+    qemu_base_arguments.append('-s')
+    qemu_base_arguments.append('-S')
 # The last argument is the executable, all other arguments are ignored for now
 arg = args.runner_args[-1]
 assert isinstance(arg, str)

--- a/tests/hermit_test_runner.py
+++ b/tests/hermit_test_runner.py
@@ -200,10 +200,6 @@ assert os.path.isfile(test_exe)  # If this fails likely something about runner a
 
 test_name = os.path.basename(test_exe)
 test_name = clean_test_name(test_name)
-if test_name == "hermit":
-    print("Executing the Unittests is currently broken... Skipping Test NOT marking as failed")
-    # print("Note: If you want to execute all tests, consider adding the '--no-fail-fast' flag")
-    exit(0)
 
 if args.bootloader_path is not None:
     test_runner = QemuTestRunner(test_exe, args.bootloader_path, gdb_enabled=args.gdb, num_cores=args.num_cores)
@@ -213,6 +209,12 @@ elif platform.system() == 'Windows':
 else:
     test_runner = UhyveTestRunner(test_exe, verbose=args.veryverbose, gdb_enabled=args.gdb, num_cores=args.num_cores,
                                   uhyve_path=args.uhyve_path)
+if test_name == "hermit":
+    print("Executing the Unittests is currently broken... Skipping Test NOT marking as failed")
+    # print("Note: If you want to execute all tests, consider adding the '--no-fail-fast' flag")
+    print("If you wish to manually execute the Unittests, you can simply run:")
+    print("`{}`".format(' '.join(test_runner.test_command)))
+    exit(0)
 
 rc, stdout, stderr, execution_time = test_runner.run_test()
 test_ok = test_runner.validate_test_success(rc, stdout, stderr, execution_time)

--- a/tests/hermit_test_runner.py
+++ b/tests/hermit_test_runner.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+
+import time
+import argparse
+import subprocess
+from subprocess import Popen, PIPE, STDOUT
+import os, os.path
+
+SMP_CORES = 1  # Number of cores
+MEMORY_MB = 64  # amount of memory
+# Path if libhermit-rs was checked out via rusty-hermit repository
+BOOTLOADER_PATH = '../loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader'
+
+
+# ToDo add test dependent section for custom kernel arguments / application arguments
+# Idea: Use TOML format to specify things like should_panic, expected output
+# Parse test executable name and check tests directory for corresponding toml file
+# If it doesn't exist just assure that the return code is not a failure
+
+# ToDo Think about always being verbose, or hiding the output
+def run_test(process_args):
+    print(os.getcwd())
+    abs_bootloader_path = os.path.abspath(BOOTLOADER_PATH)
+    print("Abspath: ", abs_bootloader_path)
+    p = Popen(process_args, stdout=PIPE, stderr=STDOUT, text=True)
+    output: str = ""
+    for line in p.stdout:
+        dec_line = line
+        output += dec_line
+        #print(line, end='')  # stdout will already contain line break
+    rc = p.wait()
+    # ToDo: add some timeout
+    return rc, output
+
+
+def validate_test(returncode, output, test_exe_path):
+    print("returncode ", returncode)
+    # ToDo handle expected failures
+    if returncode != 0:
+        return False
+    # ToDo parse output for panic
+    return True
+
+
+def clean_test_name(name: str):
+    if name.endswith('.exe'):
+        name = name.replace('.exe', '')
+    # Remove the hash from the name
+    parts = name.split('-')
+    if len(parts) > 1:
+        try:
+            _hex = int(parts[-1], base=16)  # Test if last element is hex hash
+            clean_name = "-".join(parts[:-1])  # Rejoin with '-' as seperator in case test has it in filename
+        except ValueError as e:
+            print(e)
+            clean_name = name  # In this case name doesn't contain a hash, so don't modify it any further
+    return clean_name
+
+
+print("Test runner called")
+parser = argparse.ArgumentParser(description='See documentation of cargo test runner for custom test framework')
+parser.add_argument('runner_args', type=str, nargs='*')
+args = parser.parse_args()
+print("Arguments: {}".format(args.runner_args))
+
+qemu_base_arguments = ['qemu-system-x86_64',
+                       '-display', 'none',
+                       '-smp', str(SMP_CORES),
+                       '-m', str(MEMORY_MB) + 'M',
+                       '-serial', 'stdio',
+                       '-kernel', BOOTLOADER_PATH,
+                       # skip initrd - it depends on test executable
+                       '-cpu', 'qemu64,apic,fsgsbase,rdtscp,xsave,fxsr'
+                       ]
+ok_tests: int = 0
+failed_tests: int = 0
+# This is assuming test_runner only passes executable files as parameters
+for arg in args.runner_args:
+    assert isinstance(arg, str)
+    curr_qemu_arguments = qemu_base_arguments.copy()
+    # ToDo: assert that arg is a path to an executable before calling qemu
+    # ToDo: Add addional test based arguments for qemu / uhyve
+    curr_qemu_arguments.extend(['-initrd', arg])
+    rc, output = run_test(curr_qemu_arguments)
+    test_ok = validate_test(rc, output, arg)
+    test_name = os.path.basename(arg)
+    test_name = clean_test_name(test_name)
+    if test_ok:
+        print("Test Ok: {}".format(test_name))
+        ok_tests += 1
+    else:
+        print("Test failed: {}".format(test_name))
+        failed_tests += 1
+    #Todo: improve information about the test
+
+print("{} from {} tests successful".format(ok_tests, ok_tests + failed_tests))
+# todo print something ala x/y tests failed etc.
+#  maybe look at existing standards (TAP?)
+#  - TAP: could use tappy to convert to python style unit test output (benefit??)
+
+if failed_tests == 0:
+    exit(0)
+else:
+    exit(1)
+
+
+
+
+

--- a/tests/hermit_test_runner.py
+++ b/tests/hermit_test_runner.py
@@ -201,9 +201,9 @@ assert os.path.isfile(test_exe)  # If this fails likely something about runner a
 test_name = os.path.basename(test_exe)
 test_name = clean_test_name(test_name)
 if test_name == "hermit":
-    print("Executing the Unittests is currently broken... Skipping Test and marking as failed")
-    print("Note: If you want to execute all tests, consider adding the '--no-fail-fast' flag")
-    exit(36)
+    print("Executing the Unittests is currently broken... Skipping Test NOT marking as failed")
+    # print("Note: If you want to execute all tests, consider adding the '--no-fail-fast' flag")
+    exit(0)
 
 if args.bootloader_path is not None:
     test_runner = QemuTestRunner(test_exe, args.bootloader_path, gdb_enabled=args.gdb, num_cores=args.num_cores)

--- a/tests/hermit_test_runner.py
+++ b/tests/hermit_test_runner.py
@@ -36,7 +36,7 @@ def run_test(process_args):
 def validate_test(returncode, output, test_exe_path):
     print("returncode ", returncode)
     # ToDo handle expected failures
-    if returncode != 0:
+    if returncode != 33:
         return False
     # ToDo parse output for panic
     return True
@@ -70,7 +70,8 @@ qemu_base_arguments = ['qemu-system-x86_64',
                        '-serial', 'stdio',
                        '-kernel', BOOTLOADER_PATH,
                        # skip initrd - it depends on test executable
-                       '-cpu', 'qemu64,apic,fsgsbase,rdtscp,xsave,fxsr'
+                       '-cpu', 'qemu64,apic,fsgsbase,rdtscp,xsave,fxsr',
+                       '-device', 'isa-debug-exit,iobase=0xf4,iosize=0x04'
                        ]
 ok_tests: int = 0
 failed_tests: int = 0

--- a/tests/measure_startup_time.rs
+++ b/tests/measure_startup_time.rs
@@ -1,0 +1,16 @@
+#![no_std]
+#![no_main]
+
+extern crate hermit;
+
+mod common;
+use common::*;
+
+/// This Test lets the runner measure the basic overhead of the tests including
+/// - hypervisor startup time
+/// - kernel boot-time
+/// - overhead of runtime_entry (test entry)
+#[no_mangle]
+pub fn main(args: Vec<String>) -> Result<(), ()> {
+	Ok(())
+}

--- a/tests/measure_startup_time.rs
+++ b/tests/measure_startup_time.rs
@@ -3,8 +3,10 @@
 
 extern crate hermit;
 
-mod common;
+#[macro_use]
 use common::*;
+
+mod common;
 
 /// This Test lets the runner measure the basic overhead of the tests including
 /// - hypervisor startup time
@@ -14,3 +16,5 @@ use common::*;
 pub fn main(args: Vec<String>) -> Result<(), ()> {
 	Ok(())
 }
+
+runtime_entry_with_args!();


### PR DESCRIPTION
This PR aims to add integration tests to rusty-hermit. This PR consists mostly of the framework necessary, and only contains some basic tests, which realistically don't have a very high quality.  None of the rusty-demo tests have been moved here either (yet). 

The PR mainly adds hermit_test_runner.py which can run the integration tests built by `cargo test --target [...]` either on uhyve or on qemu. 

There are still a couple of open ToDos and points that might need some discussion / rework, so I'm opening this as a draft. I'll also improve the Description of the PR next week when I have a bit more time.

## Usage

### Running Tests

The integration tests can executed by calling:
`cargo test --tests --no-fail-fast -Z build-std=core,alloc --target x86_64-unknown-hermit-kernel [-- [Test Runner arguments]]`
Valid Test Runner arguments currently include:
- `--bootloader_path=some/path`: This implicitly uses qemu to execute the tests. If absent uhyve will be used.
- `--uhyve_path=some/path`: Optional, use if `uhyve` is not in PATH
- `-v`: Optional, always prints the stdout/stderr of the test, regardless of test failure
- `-vv`: Optional, In addition to `-v` this also runs the test in verbose mode (i.e. `uhyve -v`)
- `--gdb`: Enables gdb on port 1234 and stops the test executable at the hermit entrypoint.
- `--num_cores`: Controls the number of CPU cores the test runner uses. Defaults to 1.

This implicitly also executes the unit-tests, however the testrunner currently skips the unit-tests with a warning, since they are currently broken and result in a bootloop. 

### Writing Tests

Integration tests are written in the top-level of the tests folder. The common `mod` provides shared functionality that the tests can `use`. This includes an exit function, that all tests should use to exit, since it ensures that an exit code is passed to the runner regardless of whether qemu or uhyve is used. If you want to use a test_runner you can use `#[test_case]` 

## Existing Tests (Host)

The existing Unit-tests can still be run on the host OS via: `cargo test --lib`. In the future the unit-tests also should be able to run on hermit, but this is currently broken, due to a bootloop, directly after entering hermit.

## Demo Tests

I added some basic tests, which demonstrate how a test could look like. 