### PR TITLE
define default target, using build-std to define the dependencies

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,8 @@
-#[target.x86_64-unknown-hermit-kernel]
-#runner = "uhyve -v"
+[unstable]
+build-std = ["core", "alloc"]
+
+[build]
+target = "x86_64-unknown-hermit-kernel"
 
 [target.x86_64-unknown-hermit-kernel]
 runner = "tests/hermit_test_runner.py"


### PR DESCRIPTION
After the definition of the default target and the definition of the dependencies, the crate can be build with standard command `crate build`.