### PR TITLE
build per default the target x86_64-unknown-hermit-kernel

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,8 @@
-#[target.x86_64-unknown-hermit-kernel]
-#runner = "uhyve -v"
+[unstable]
+build-std = ["core", "alloc"]
+
+[build]
+target = "x86_64-unknown-hermit-kernel"
 
 [target.x86_64-unknown-hermit-kernel]
 runner = "tests/hermit_test_runner.py"


### PR DESCRIPTION
afterwards `cargo build` without any additional flag builds libhermit-rs for x86_64