### PR TITLE
Various newlib fixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ pub mod environment;
 mod errno;
 mod kernel_message_buffer;
 mod mm;
-#[cfg(not(feature = "newlib"))]
+
 mod rlib;
 #[cfg(target_os = "hermit")]
 mod runtime_glue;

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -122,7 +122,7 @@ pub fn init() {
 		let size = 10 * LargePageSize::SIZE;
 		unsafe {
 			let start = allocate(size, true);
-			crate::ALLOCATOR.lock().init(start, size);
+			crate::ALLOCATOR.lock().init(start.as_usize(), size);
 		}
 
 		info!("Kernel heap size: {} MB", size >> 20);

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -119,7 +119,7 @@ pub fn init() {
 	{
 		info!("An application with a C-based runtime is running on top of HermitCore!");
 
-		let size = 2 * LargePageSize::SIZE;
+		let size = 10 * LargePageSize::SIZE;
 		unsafe {
 			let start = allocate(size, true);
 			crate::ALLOCATOR.lock().init(start, size);

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -258,7 +258,7 @@ impl PerCoreScheduler {
 	#[cfg(feature = "newlib")]
 	#[inline]
 	pub fn get_lwip_errno(&self) -> i32 {
-		irqsave(|| self.current_task.borrow().lwip_errno);
+		irqsave(|| self.current_task.borrow().lwip_errno)
 	}
 
 	#[inline]

--- a/src/syscalls/tasks.rs
+++ b/src/syscalls/tasks.rs
@@ -85,14 +85,14 @@ static SBRK_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 #[cfg(feature = "newlib")]
 pub fn sbrk_init() {
-	SBRK_COUNTER.store(task_heap_start(), Ordering::SeqCst);
+	SBRK_COUNTER.store(task_heap_start().as_usize(), Ordering::SeqCst);
 }
 
 #[cfg(feature = "newlib")]
 fn __sys_sbrk(incr: isize) -> usize {
 	// Get the boundaries of the task heap and verify that they are suitable for sbrk.
-	let task_heap_start = task_heap_start();
-	let task_heap_end = task_heap_end();
+	let task_heap_start = task_heap_start().as_usize();
+	let task_heap_end = task_heap_end().as_usize();
 	let old_end;
 
 	if incr >= 0 {


### PR DESCRIPTION
The current kernel does not build with `feature=newlib`. This pull request fixes various issues:

1. Kernel Heap Size is increased from 2MB to 20MB.
2. Rust userland reserves 10% of available memory for task stacks. This is previously not done with newlib, leading to crashes when many threads are spawned. This is fixed, and newlib now also reserves 10% of memory.
3. Some misc. compiler errors are fixed (extra `;`, missing conversion from VirtAddr to usize.
4. Newlib now uses the kernel-builtin (non-optimized, non SSE) `memcpy`, `memmove` etc. See issue #107 for a detailed reasoning of this.