### PR TITLE
Rename AllocErr to AllocError

### DIFF
--- a/src/mm/allocator.rs
+++ b/src/mm/allocator.rs
@@ -10,7 +10,7 @@
 use crate::mm::hole::{Hole, HoleList};
 use crate::mm::kernel_end_address;
 use crate::synch::spinlock::*;
-use core::alloc::{AllocErr, GlobalAlloc, Layout};
+use core::alloc::{AllocError, GlobalAlloc, Layout};
 use core::ops::Deref;
 use core::ptr::NonNull;
 use core::{mem, ptr};
@@ -69,14 +69,14 @@ impl Heap {
 	}
 
 	/// An allocation using the always available Bootstrap Allocator.
-	unsafe fn alloc_bootstrap(&mut self, layout: Layout) -> Result<(NonNull<u8>, usize), AllocErr> {
+	unsafe fn alloc_bootstrap(&mut self, layout: Layout) -> Result<(NonNull<u8>, usize), AllocError> {
 		let ptr = &mut self.first_block[self.index] as *mut u8;
 		let size = align_up!(layout.size(), HoleList::min_size());
 
 		// Bump the heap index and align it up to the next boundary.
 		self.index = align_up!(self.index + size, HoleList::min_size());
 		if self.index >= BOOTSTRAP_HEAP_SIZE {
-			Err(AllocErr)
+			Err(AllocError)
 		} else {
 			Ok((NonNull::new(ptr).unwrap(), layout.size()))
 		}
@@ -87,7 +87,7 @@ impl Heap {
 	/// This function scans the list of free memory blocks and uses the first block that is big
 	/// enough. The runtime is in O(n) where n is the number of free blocks, but it should be
 	/// reasonably fast for small allocations.
-	pub fn allocate_first_fit(&mut self, layout: Layout) -> Result<(NonNull<u8>, usize), AllocErr> {
+	pub fn allocate_first_fit(&mut self, layout: Layout) -> Result<(NonNull<u8>, usize), AllocError> {
 		if self.bottom == 0 {
 			unsafe { self.alloc_bootstrap(layout) }
 		} else {

--- a/src/mm/hole.rs
+++ b/src/mm/hole.rs
@@ -2,7 +2,7 @@
 // (https://github.com/phil-opp/linked-list-allocator).
 // This crate is dual-licensed under MIT or the Apache License (Version 2.0).
 
-use alloc::alloc::{AllocErr, Layout};
+use alloc::alloc::{AllocError, Layout};
 use core::mem::size_of;
 use core::ptr::NonNull;
 
@@ -43,7 +43,7 @@ impl HoleList {
 	/// block is returned.
 	/// This function uses the “first fit” strategy, so it uses the first hole that is big
 	/// enough. Thus the runtime is in O(n) but it should be reasonably fast for small allocations.
-	pub fn allocate_first_fit(&mut self, layout: Layout) -> Result<(NonNull<u8>, usize), AllocErr> {
+	pub fn allocate_first_fit(&mut self, layout: Layout) -> Result<(NonNull<u8>, usize), AllocError> {
 		assert!(layout.size() >= Self::min_size());
 
 		allocate_first_fit(&mut self.first, layout).map(|allocation| {
@@ -203,7 +203,7 @@ fn split_hole(hole: HoleInfo, required_layout: Layout) -> Option<Allocation> {
 /// care of freeing it again.
 /// This function uses the “first fit” strategy, so it breaks as soon as a big enough hole is
 /// found (and returns it).
-fn allocate_first_fit(mut previous: &mut Hole, layout: Layout) -> Result<Allocation, AllocErr> {
+fn allocate_first_fit(mut previous: &mut Hole, layout: Layout) -> Result<Allocation, AllocError> {
 	loop {
 		let allocation: Option<Allocation> = previous
 			.next
@@ -221,7 +221,7 @@ fn allocate_first_fit(mut previous: &mut Hole, layout: Layout) -> Result<Allocat
 			}
 			None => {
 				// this was the last hole, so no hole is big enough -> allocation not possible
-				return Err(AllocErr);
+				return Err(AllocError);
 			}
 		}
 	}


### PR DESCRIPTION
- these changes are required to support the latest version of the nightly compiler