### PR TITLE
using mangled names for basic opertions to avoid linker conflicts

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,6 +1,6 @@
 [unstable]
 build-std = ["core", "alloc"]
-build-std-features = ["compiler-builtins-mem"]
+build-std-features = ["compiler-builtins-mem", "compiler-builtins-mangled-names"]
 
 [build]
 target = "x86_64-unknown-hermit-kernel"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,6 @@ pub mod environment;
 mod errno;
 mod kernel_message_buffer;
 mod mm;
-#[cfg(target_os = "hermit")]
 mod runtime_glue;
 mod scheduler;
 mod synch;

--- a/src/runtime_glue.rs
+++ b/src/runtime_glue.rs
@@ -40,6 +40,7 @@ fn panic(info: &PanicInfo) -> ! {
 	}
 }
 
+#[cfg(target_os = "hermit")]
 #[linkage = "weak"]
 #[alloc_error_handler]
 fn rust_oom(layout: Layout) -> ! {
@@ -54,6 +55,7 @@ fn rust_oom(layout: Layout) -> ! {
 	}
 }
 
+#[cfg(target_os = "hermit")]
 #[no_mangle]
 pub unsafe extern "C" fn __rg_oom(size: usize, align: usize) -> ! {
 	let layout = Layout::from_size_align_unchecked(size, align);

--- a/src/runtime_glue.rs
+++ b/src/runtime_glue.rs
@@ -59,3 +59,9 @@ pub unsafe extern "C" fn __rg_oom(size: usize, align: usize) -> ! {
 	let layout = Layout::from_size_align_unchecked(size, align);
 	rust_oom(layout)
 }
+
+
+// TODO: currently, the implementation of "stack probes" is missing
+#[no_mangle]
+pub unsafe extern "C" fn __rust_probestack() {
+}

--- a/src/runtime_glue.rs
+++ b/src/runtime_glue.rs
@@ -60,8 +60,6 @@ pub unsafe extern "C" fn __rg_oom(size: usize, align: usize) -> ! {
 	rust_oom(layout)
 }
 
-
 // TODO: currently, the implementation of "stack probes" is missing
 #[no_mangle]
-pub unsafe extern "C" fn __rust_probestack() {
-}
+pub unsafe extern "C" fn __rust_probestack() {}

--- a/src/runtime_glue.rs
+++ b/src/runtime_glue.rs
@@ -62,6 +62,6 @@ pub unsafe extern "C" fn __rg_oom(size: usize, align: usize) -> ! {
 	rust_oom(layout)
 }
 
-// TODO: currently, the implementation of "stack probes" is missing
+#[cfg(not(target_os = "hermit"))]
 #[no_mangle]
 pub unsafe extern "C" fn __rust_probestack() {}


### PR DESCRIPTION
avoiding collisions of symbols by using mangled names