### PR TITLE
activate assembly support for basic function (e.g. memcpy)

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,6 +1,6 @@
 [unstable]
 build-std = ["core", "alloc"]
-build-std-features = ["compiler-builtins-mem"]
+build-std-features = ["compiler-builtins-mem", "compiler-builtins-asm"]
 
 [build]
 target = "x86_64-unknown-hermit-kernel"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,22 +84,6 @@ add_custom_command(
 	COMMAND
 		${CMAKE_ELFEDIT} --output-osabi Standalone $<TARGET_FILE:hermit-bootstrap>
 
-	# rename basic functions like memcpy to avoid collisions with the user space
-	COMMAND
-		${CMAKE_OBJCOPY} --redefine-sym memmove=kernel_memmove $<TARGET_FILE:hermit-bootstrap>
-
-	COMMAND
-		${CMAKE_OBJCOPY} --redefine-sym memcpy=kernel_memcpy $<TARGET_FILE:hermit-bootstrap>
-
-	COMMAND
-		${CMAKE_OBJCOPY} --redefine-sym memset=kernel_memset $<TARGET_FILE:hermit-bootstrap>
-
-	COMMAND
-		${CMAKE_OBJCOPY} --redefine-sym memcmp=kernel_memcmp $<TARGET_FILE:hermit-bootstrap>
-
-	COMMAND
-		${CMAKE_OBJCOPY} --redefine-sym bcmp=kernel_bcmp $<TARGET_FILE:hermit-bootstrap>
-
 	# Copy libhermit.a into local prefix directory so that all subsequent
 	# targets can link against the freshly built version (as opposed to
 	# linking against the one supplied by the toolchain)


### PR DESCRIPTION
- don't rename symbols for newlib