### PR TITLE
disable interrupts during programming of the ICR

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -126,9 +126,11 @@ jobs:
         working-directory: libhermit-rs
         run:
           cargo test --tests --no-fail-fast -Z build-std=core,alloc --target x86_64-unknown-hermit-kernel -- --bootloader_path=../loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader
+        experimental: true
         if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Integration Tests (smp)
         working-directory: libhermit-rs
         run:
           cargo test --tests --no-fail-fast -Z build-std=core,alloc --target x86_64-unknown-hermit-kernel -- --bootloader_path=../loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader --num_cores 2
+        experimental: true
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -106,21 +106,19 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
       - name: Test dev version
         run:
-          qemu-system-x86_64 -display none -smp 1 -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/debug/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr
+          qemu-system-x86_64 -display none -smp 1 -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/debug/rusty_demo -cpu qemu64,x2apic,fsgsbase,rdtscp,xsave,fxsr
         if: ${{ ( matrix.os == 'macOS-latest' ) || ( matrix.os == 'ubuntu-latest' ) }}
       - name: Test dev version (smp)
         run:
-          qemu-system-x86_64 -display none -smp 2 -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/debug/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr
-        timeout-minutes: 20
+          qemu-system-x86_64 -display none -smp 2 -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/debug/rusty_demo -cpu qemu64,x2apic,fsgsbase,rdtscp,xsave,fxsr
         if: ${{ ( matrix.os == 'macOS-latest' ) || ( matrix.os == 'ubuntu-latest' ) }}
       - name: Test release version
         run:
-          qemu-system-x86_64 -display none -smp 1 -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr
+          qemu-system-x86_64 -display none -smp 1 -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,x2apic,fsgsbase,rdtscp,xsave,fxsr
         if: ${{ ( matrix.os == 'macOS-latest' ) || ( matrix.os == 'ubuntu-latest' ) }}
       - name: Test release version (smp)
         run:
-          qemu-system-x86_64 -display none -smp 2 -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr
-        timeout-minutes: 20
+          qemu-system-x86_64 -display none -smp 2 -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,x2apic,fsgsbase,rdtscp,xsave,fxsr
         if: ${{ ( matrix.os == 'macOS-latest' ) || ( matrix.os == 'ubuntu-latest' ) }}
       - name: Integration Tests
         working-directory: libhermit-rs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -126,11 +126,11 @@ jobs:
         working-directory: libhermit-rs
         run:
           cargo test --tests --no-fail-fast -Z build-std=core,alloc --target x86_64-unknown-hermit-kernel -- --bootloader_path=../loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader
-        experimental: true
+        continue-on-error: true
         if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Integration Tests (smp)
         working-directory: libhermit-rs
         run:
           cargo test --tests --no-fail-fast -Z build-std=core,alloc --target x86_64-unknown-hermit-kernel -- --bootloader_path=../loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader --num_cores 2
-        experimental: true
+        continue-on-error: true
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -106,19 +106,21 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
       - name: Test dev version
         run:
-          qemu-system-x86_64 -display none -smp 1 -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/debug/rusty_demo -cpu qemu64,x2apic,fsgsbase,rdtscp,xsave,fxsr
+          qemu-system-x86_64 -display none -smp 1 -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/debug/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr
         if: ${{ ( matrix.os == 'macOS-latest' ) || ( matrix.os == 'ubuntu-latest' ) }}
       - name: Test dev version (smp)
         run:
-          qemu-system-x86_64 -display none -smp 2 -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/debug/rusty_demo -cpu qemu64,x2apic,fsgsbase,rdtscp,xsave,fxsr
+          qemu-system-x86_64 -display none -smp 2 -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/debug/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr
+        timeout-minutes: 20
         if: ${{ ( matrix.os == 'macOS-latest' ) || ( matrix.os == 'ubuntu-latest' ) }}
       - name: Test release version
         run:
-          qemu-system-x86_64 -display none -smp 1 -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,x2apic,fsgsbase,rdtscp,xsave,fxsr
+          qemu-system-x86_64 -display none -smp 1 -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr
         if: ${{ ( matrix.os == 'macOS-latest' ) || ( matrix.os == 'ubuntu-latest' ) }}
       - name: Test release version (smp)
         run:
-          qemu-system-x86_64 -display none -smp 2 -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,x2apic,fsgsbase,rdtscp,xsave,fxsr
+          qemu-system-x86_64 -display none -smp 2 -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr
+        timeout-minutes: 20
         if: ${{ ( matrix.os == 'macOS-latest' ) || ( matrix.os == 'ubuntu-latest' ) }}
       - name: Integration Tests
         working-directory: libhermit-rs

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -733,10 +733,18 @@ fn local_apic_write(x2apic_msr: u32, value: u64) {
 			// The ICR1 register in xAPIC mode also has a Delivery Status bit.
 			// Wait until previous interrupt was deliverd.
 			// This bit does not exist in x2APIC mode (cf. Intel Vol. 3A, 10.12.9).
+			for _ in 0..100 {
+				if (unsafe { core::ptr::read_volatile(value_ref) }
+					& APIC_ICR_DELIVERY_STATUS_PENDING)
+					> 0
+				{
+					spin_loop_hint();
+				}
+			}
+
 			if (unsafe { core::ptr::read_volatile(value_ref) } & APIC_ICR_DELIVERY_STATUS_PENDING)
 				> 0
 			{
-				spin_loop_hint();
 				info!("Previous interrupt is missing");
 			}
 

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -437,7 +437,7 @@ fn calibrate_timer() {
 	}
 }
 
-pub fn set_oneshot_timer(wakeup_time: Option<u64>) {
+fn __set_oneshot_timer(wakeup_time: Option<u64>) {
 	if let Some(wt) = wakeup_time {
 		if processor::supports_tsc_deadline() {
 			// wt is the absolute wakeup time in microseconds based on processor::get_timer_ticks.
@@ -478,6 +478,11 @@ pub fn set_oneshot_timer(wakeup_time: Option<u64>) {
 	}
 }
 
+pub fn set_oneshot_timer(wakeup_time: Option<u64>) {
+	irqsave(|| {
+		__set_oneshot_timer(wakeup_time);
+	});
+}
 pub fn init_x2apic() {
 	if processor::supports_x2apic() {
 		debug!("Enable x2APIC support");

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -733,19 +733,11 @@ fn local_apic_write(x2apic_msr: u32, value: u64) {
 			// The ICR1 register in xAPIC mode also has a Delivery Status bit.
 			// Wait until previous interrupt was deliverd.
 			// This bit does not exist in x2APIC mode (cf. Intel Vol. 3A, 10.12.9).
-			for _ in 0..100 {
-				if (unsafe { core::ptr::read_volatile(value_ref) }
-					& APIC_ICR_DELIVERY_STATUS_PENDING)
-					> 0
-				{
-					spin_loop_hint();
-				}
-			}
-
-			if (unsafe { core::ptr::read_volatile(value_ref) } & APIC_ICR_DELIVERY_STATUS_PENDING)
+			while (unsafe { core::ptr::read_volatile(value_ref) }
+				& APIC_ICR_DELIVERY_STATUS_PENDING)
 				> 0
 			{
-				info!("Previous interrupt is missing");
+				spin_loop_hint();
 			}
 
 			// Instead of a single 64-bit ICR register, xAPIC has two 32-bit registers (ICR1 and ICR2).

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -733,11 +733,11 @@ fn local_apic_write(x2apic_msr: u32, value: u64) {
 			// The ICR1 register in xAPIC mode also has a Delivery Status bit.
 			// Wait until previous interrupt was deliverd.
 			// This bit does not exist in x2APIC mode (cf. Intel Vol. 3A, 10.12.9).
-			while (unsafe { core::ptr::read_volatile(value_ref) }
-				& APIC_ICR_DELIVERY_STATUS_PENDING)
+			if (unsafe { core::ptr::read_volatile(value_ref) } & APIC_ICR_DELIVERY_STATUS_PENDING)
 				> 0
 			{
 				spin_loop_hint();
+				info!("Previous interrupt is missing");
 			}
 
 			// Instead of a single 64-bit ICR register, xAPIC has two 32-bit registers (ICR1 and ICR2).

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -15,7 +15,7 @@ use crate::arch::x86_64::kernel::IRQ_COUNTERS;
 use crate::arch::x86_64::mm::paging::{BasePageSize, PageSize, PageTableEntryFlags};
 use crate::arch::x86_64::mm::{paging, virtualmem};
 use crate::arch::x86_64::mm::{PhysAddr, VirtAddr};
-use crate::collections::CachePadded;
+use crate::collections::{irqsave, CachePadded};
 use crate::config::*;
 use crate::environment;
 use crate::mm;
@@ -632,34 +632,38 @@ pub fn ipi_tlb_flush() {
 		}
 
 		// Send an IPI with our TLB Flush interrupt number to all other CPUs.
-		for core_id_to_interrupt in 0..apic_ids.len() {
-			if core_id_to_interrupt != core_id.try_into().unwrap() {
-				let local_apic_id = apic_ids[core_id_to_interrupt];
-				let destination = u64::from(local_apic_id) << 32;
-				local_apic_write(
-					IA32_X2APIC_ICR,
-					destination
-						| APIC_ICR_LEVEL_ASSERT | APIC_ICR_DELIVERY_MODE_FIXED
-						| u64::from(TLB_FLUSH_INTERRUPT_NUMBER),
-				);
+		irqsave(|| {
+			for core_id_to_interrupt in 0..apic_ids.len() {
+				if core_id_to_interrupt != core_id.try_into().unwrap() {
+					let local_apic_id = apic_ids[core_id_to_interrupt];
+					let destination = u64::from(local_apic_id) << 32;
+					local_apic_write(
+						IA32_X2APIC_ICR,
+						destination
+							| APIC_ICR_LEVEL_ASSERT | APIC_ICR_DELIVERY_MODE_FIXED
+							| u64::from(TLB_FLUSH_INTERRUPT_NUMBER),
+					);
+				}
 			}
-		}
+		});
 	}
 }
 
 /// Send an inter-processor interrupt to wake up a CPU Core that is in a HALT state.
 pub fn wakeup_core(core_id_to_wakeup: CoreId) {
 	if core_id_to_wakeup != core_id() {
-		let apic_ids = unsafe { CPU_LOCAL_APIC_IDS.as_ref().unwrap() };
-		let local_apic_id = apic_ids[core_id_to_wakeup as usize];
-		let destination = u64::from(local_apic_id) << 32;
-		local_apic_write(
-			IA32_X2APIC_ICR,
-			destination
-				| APIC_ICR_LEVEL_ASSERT
-				| APIC_ICR_DELIVERY_MODE_FIXED
-				| u64::from(WAKEUP_INTERRUPT_NUMBER),
-		);
+		irqsave(|| {
+			let apic_ids = unsafe { CPU_LOCAL_APIC_IDS.as_ref().unwrap() };
+			let local_apic_id = apic_ids[core_id_to_wakeup as usize];
+			let destination = u64::from(local_apic_id) << 32;
+			local_apic_write(
+				IA32_X2APIC_ICR,
+				destination
+					| APIC_ICR_LEVEL_ASSERT
+					| APIC_ICR_DELIVERY_MODE_FIXED
+					| u64::from(WAKEUP_INTERRUPT_NUMBER),
+			);
+		});
 	}
 }
 
@@ -715,7 +719,22 @@ fn local_apic_write(x2apic_msr: u32, value: u64) {
 			wrmsr(x2apic_msr, value);
 		}
 	} else {
+		// Write the value.
+		let value_ref = unsafe {
+			&mut *(translate_x2apic_msr_to_xapic_address(x2apic_msr).as_mut_ptr::<u32>())
+		};
+
 		if x2apic_msr == IA32_X2APIC_ICR {
+			// The ICR1 register in xAPIC mode also has a Delivery Status bit.
+			// Wait until previous interrupt was deliverd.
+			// This bit does not exist in x2APIC mode (cf. Intel Vol. 3A, 10.12.9).
+			while (unsafe { core::ptr::read_volatile(value_ref) }
+				& APIC_ICR_DELIVERY_STATUS_PENDING)
+				> 0
+			{
+				spin_loop_hint();
+			}
+
 			// Instead of a single 64-bit ICR register, xAPIC has two 32-bit registers (ICR1 and ICR2).
 			// There is a gap between them and the destination field in ICR2 is also 8 bits instead of 32 bits.
 			let destination = ((value >> 8) & 0xFF00_0000) as u32;
@@ -725,23 +744,7 @@ fn local_apic_write(x2apic_msr: u32, value: u64) {
 			// The remaining data without the destination will now be written into ICR1.
 		}
 
-		// Write the value.
-		let value_ref = unsafe {
-			&mut *(translate_x2apic_msr_to_xapic_address(x2apic_msr).as_mut_ptr::<u32>())
-		};
 		*value_ref = value as u32;
-
-		if x2apic_msr == IA32_X2APIC_ICR {
-			// The ICR1 register in xAPIC mode also has a Delivery Status bit that must be checked.
-			// Wait until the CPU clears it.
-			// This bit does not exist in x2APIC mode (cf. Intel Vol. 3A, 10.12.9).
-			while (unsafe { core::ptr::read_volatile(value_ref) }
-				& APIC_ICR_DELIVERY_STATUS_PENDING)
-				> 0
-			{
-				spin_loop_hint();
-			}
-		}
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,9 +349,7 @@ fn boot_processor_main() -> ! {
 
 	let core_scheduler = core_scheduler();
 	// Run the scheduler loop.
-	loop {
-		core_scheduler.reschedule_and_wait();
-	}
+	core_scheduler.run();
 }
 
 /// Entry Point of HermitCore for an Application Processor
@@ -366,7 +364,5 @@ fn application_processor_main() -> ! {
 
 	let core_scheduler = core_scheduler();
 	// Run the scheduler loop.
-	loop {
-		core_scheduler.reschedule_and_wait();
-	}
+	core_scheduler.run();
 }

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -10,7 +10,7 @@ use alloc::boxed::Box;
 use alloc::collections::{BTreeMap, VecDeque};
 use alloc::rc::Rc;
 use core::cell::RefCell;
-use core::sync::atomic::{AtomicU32, Ordering, spin_loop_hint};
+use core::sync::atomic::{spin_loop_hint, AtomicU32, Ordering};
 
 use crate::arch;
 use crate::arch::irq;
@@ -501,10 +501,10 @@ impl PerCoreScheduler {
 					}
 				}
 			}
-			
+
 			false
-		} else { 
-			status == TaskStatus::TaskIdle 
+		} else {
+			status == TaskStatus::TaskIdle
 		}
 	}
 }

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -382,7 +382,7 @@ impl PerCoreScheduler {
 
 		loop {
 			irq::disable();
-			if self.scheduler() {
+			if self.scheduler() && idle_counter <= 1000 {
 				idle_counter = idle_counter + 1;
 			} else {
 				idle_counter = 0;


### PR DESCRIPTION
ICR programming should be not-interruptable to avoid corrupted values