### PR TITLE
revision of the memory subsystem initialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(HERMIT_RS "${CMAKE_BINARY_DIR}/hermit_rs/${HERMIT_ARCH}-unknown-hermit-kerne
 add_custom_target(hermit_rs
 	COMMAND
 		${CMAKE_COMMAND} -E env CARGO_TARGET_DIR=${CMAKE_BINARY_DIR}/hermit_rs RUST_TARGET_PATH=${HERMIT_ROOT}/librs
-		cargo build ${CARGO_BUILDTYPE_PARAMETER} -Z build-std=core,alloc --target ${HERMIT_ARCH}-unknown-hermit-kernel.json --features newlib
+		cargo build ${CARGO_BUILDTYPE_PARAMETER} -Z build-std=core,alloc -Zbuild-std-features=compiler-builtins-asm,compiler-builtins-mem --target ${HERMIT_ARCH}-unknown-hermit-kernel.json --features newlib
 	WORKING_DIRECTORY
 		${CMAKE_CURRENT_LIST_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,12 @@ add_custom_command(
 	COMMAND
 		${CMAKE_OBJCOPY} --redefine-sym bcmp=kernel_bcmp $<TARGET_FILE:hermit-bootstrap>
 
+	COMMAND
+		${CMAKE_OBJCOPY} --redefine-sym __umodti3=kernel_umodti3 $<TARGET_FILE:hermit-bootstrap>
+
+	COMMAND
+		${CMAKE_OBJCOPY} --redefine-sym __udivti3=kernel_udivti3 $<TARGET_FILE:hermit-bootstrap>
+
 	# Copy libhermit.a into local prefix directory so that all subsequent
 	# targets can link against the freshly built version (as opposed to
 	# linking against the one supplied by the toolchain)

--- a/src/arch/x86_64/kernel/gdt.rs
+++ b/src/arch/x86_64/kernel/gdt.rs
@@ -31,27 +31,28 @@ const GDT_ENTRIES: usize = 8192;
 /// interrupts. See also irq.rs.
 const IST_ENTRIES: usize = 4;
 
-static mut GDT: *mut Gdt = 0 as *mut Gdt;
+static mut GDT: Gdt = Gdt::new();
 static mut GDTR: DescriptorTablePointer<Descriptor> = DescriptorTablePointer {
 	base: 0 as *const Descriptor,
 	limit: 0,
 };
 
-struct Gdt {
-	entries: [Descriptor; GDT_ENTRIES],
-}
+#[repr(align(4096))]
+struct Gdt([Descriptor; GDT_ENTRIES]);
 
+impl Gdt {
+	pub const fn new() -> Self {
+		Gdt([Descriptor::NULL; GDT_ENTRIES])
+	}
+}
 pub fn init() {
 	unsafe {
-		// Dynamically allocate memory for the GDT.
-		GDT = crate::mm::allocate(mem::size_of::<Gdt>(), false).as_mut_ptr::<Gdt>();
-
 		// The NULL descriptor is always the first entry.
-		(*GDT).entries[GDT_NULL as usize] = Descriptor::NULL;
+		GDT.0[GDT_NULL as usize] = Descriptor::NULL;
 
 		// The second entry is a 64-bit Code Segment in kernel-space (Ring 0).
 		// All other parameters are ignored.
-		(*GDT).entries[GDT_KERNEL_CODE as usize] =
+		GDT.0[GDT_KERNEL_CODE as usize] =
 			DescriptorBuilder::code_descriptor(0, 0, CodeSegmentType::ExecuteRead)
 				.present()
 				.dpl(Ring::Ring0)
@@ -60,14 +61,14 @@ pub fn init() {
 
 		// The third entry is a 64-bit Data Segment in kernel-space (Ring 0).
 		// All other parameters are ignored.
-		(*GDT).entries[GDT_KERNEL_DATA as usize] =
+		GDT.0[GDT_KERNEL_DATA as usize] =
 			DescriptorBuilder::data_descriptor(0, 0, DataSegmentType::ReadWrite)
 				.present()
 				.dpl(Ring::Ring0)
 				.finish();
 
 		// Let GDTR point to our newly crafted GDT.
-		GDTR = DescriptorTablePointer::new_from_slice(&((*GDT).entries[0..GDT_ENTRIES]));
+		GDTR = DescriptorTablePointer::new_from_slice(&(GDT.0[0..GDT_ENTRIES]));
 	}
 }
 
@@ -115,10 +116,9 @@ pub fn add_current_core() {
 				.present()
 				.dpl(Ring::Ring0)
 				.finish();
-			(*GDT).entries[idx..idx + 2]
-				.copy_from_slice(&mem::transmute::<Descriptor64, [Descriptor; 2]>(
-					tss_descriptor,
-				));
+			GDT.0[idx..idx + 2].copy_from_slice(&mem::transmute::<Descriptor64, [Descriptor; 2]>(
+				tss_descriptor,
+			));
 		}
 
 		// Load it.

--- a/src/arch/x86_64/kernel/idt.rs
+++ b/src/arch/x86_64/kernel/idt.rs
@@ -98,11 +98,15 @@ impl IdtEntry {
 pub const IDT_ENTRIES: usize = 256;
 
 #[repr(align(4096))]
-struct IdtArray([IdtEntry; IDT_ENTRIES]);
+struct IdtArray {
+	entries: [IdtEntry; IDT_ENTRIES],
+}
 
 impl IdtArray {
 	pub const fn new() -> Self {
-		IdtArray([IdtEntry::MISSING; IDT_ENTRIES])
+		IdtArray {
+			entries: [IdtEntry::MISSING; IDT_ENTRIES],
+		}
 	}
 }
 
@@ -119,11 +123,11 @@ pub fn install() {
 		let is_init = IDT_INIT.swap(true, Ordering::SeqCst);
 
 		if !is_init {
-			debug!("IDT address: 0x{:x}", &IDT.0 as *const _ as usize);
+			debug!("IDT address: 0x{:x}", &IDT.entries as *const _ as usize);
 
 			// TODO: As soon as https://github.com/rust-lang/rust/issues/44580 is implemented, it should be possible to
 			// implement "new" as "const fn" and do this call already in the initialization of IDTP.
-			IDTP = DescriptorTablePointer::new_from_slice(&IDT.0);
+			IDTP = DescriptorTablePointer::new_from_slice(&IDT.entries);
 		};
 
 		dtables::lidt(&IDTP);
@@ -149,6 +153,6 @@ pub fn set_gate(index: u8, handler: usize, ist_index: u8) {
 	);
 
 	unsafe {
-		IDT.0[index as usize] = entry;
+		IDT.entries[index as usize] = entry;
 	}
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -58,7 +58,7 @@ macro_rules! infoheader {
 	($str:expr) => {{
 		info!("");
 		info!("{:=^70}", $str);
-		}};
+	}};
 }
 
 macro_rules! infoentry {
@@ -70,5 +70,5 @@ macro_rules! infofooter {
 	() => {{
 		info!("{:=^70}", '=');
 		info!("");
-		}};
+	}};
 }


### PR DESCRIPTION
Especially with a C-base user space the subsystem doesn't align GDT/IDT correctly. In addition, the initial page table wasn't correctly initialized and triggers sometimes page faults.