### PR TITLE
revise virtio-fs integration

### DIFF
--- a/src/arch/x86_64/kernel/pci.rs
+++ b/src/arch/x86_64/kernel/pci.rs
@@ -499,17 +499,16 @@ pub fn init() {
 pub fn init_drivers() {
 	// virtio: 4.1.2 PCI Device Discovery
 	irqsave(|| {
-		for adapter in unsafe { PCI_ADAPTERS.iter() } {
-			if adapter.vendor_id == 0x1AF4
-				&& adapter.device_id >= 0x1000
-				&& adapter.device_id <= 0x107F
-			{
-				info!(
-					"Found virtio device with device id 0x{:x}",
-					adapter.device_id
-				);
-				virtio::init_virtio_device(adapter);
-			}
+		for adapter in unsafe {
+			PCI_ADAPTERS
+				.iter()
+				.filter(|x| x.vendor_id == 0x1AF4 && x.device_id >= 0x1000 && x.device_id <= 0x107F)
+		} {
+			info!(
+				"Found virtio device with device id 0x{:x}",
+				adapter.device_id
+			);
+			virtio::init_virtio_device(adapter);
 		}
 	});
 }

--- a/src/arch/x86_64/kernel/pci.rs
+++ b/src/arch/x86_64/kernel/pci.rs
@@ -11,6 +11,7 @@ use crate::arch::x86_64::kernel::virtio;
 use crate::arch::x86_64::kernel::virtio_fs::VirtioFsDriver;
 use crate::arch::x86_64::kernel::virtio_net::VirtioNetDriver;
 use crate::arch::x86_64::mm::{PhysAddr, VirtAddr};
+use crate::collections::irqsave;
 use crate::synch::spinlock::SpinlockIrqSave;
 use crate::x86::io::*;
 use alloc::vec::Vec;
@@ -497,16 +498,20 @@ pub fn init() {
 
 pub fn init_drivers() {
 	// virtio: 4.1.2 PCI Device Discovery
-	for adapter in unsafe { PCI_ADAPTERS.iter() } {
-		if adapter.vendor_id == 0x1AF4 && adapter.device_id >= 0x1000 && adapter.device_id <= 0x107F
-		{
-			info!(
-				"Found virtio device with device id 0x{:x}",
-				adapter.device_id
-			);
-			virtio::init_virtio_device(adapter);
+	irqsave(|| {
+		for adapter in unsafe { PCI_ADAPTERS.iter() } {
+			if adapter.vendor_id == 0x1AF4
+				&& adapter.device_id >= 0x1000
+				&& adapter.device_id <= 0x107F
+			{
+				info!(
+					"Found virtio device with device id 0x{:x}",
+					adapter.device_id
+				);
+				virtio::init_virtio_device(adapter);
+			}
 		}
-	}
+	});
 }
 
 pub fn print_information() {

--- a/src/arch/x86_64/kernel/virtio.rs
+++ b/src/arch/x86_64/kernel/virtio.rs
@@ -850,11 +850,15 @@ pub fn init_virtio_device(adapter: &pci::PciAdapter) {
 			}
 		}
 		0x105a => {
-			info!("Found Virtio-FS device!");
+			info!("Found VirtioFS device!");
 			// TODO: check subclass
 			// TODO: proper error handling on driver creation fail
-			let drv = virtio_fs::create_virtiofs_driver(adapter).unwrap();
-			pci::register_driver(PciDriver::VirtioFs(SpinlockIrqSave::new(drv)));
+			{
+				let drv = virtio_fs::create_virtiofs_driver(adapter).unwrap();
+				pci::register_driver(PciDriver::VirtioFs(SpinlockIrqSave::new(drv)));
+			}
+			// initialize file system
+			virtio_fs::init_fs();
 		}
 		_ => {
 			warn!("Virtio device is NOT supported, skipping!");

--- a/src/arch/x86_64/kernel/virtio_fs.rs
+++ b/src/arch/x86_64/kernel/virtio_fs.rs
@@ -306,6 +306,12 @@ pub fn create_virtiofs_driver(adapter: &pci::PciAdapter) -> Option<VirtioFsDrive
 	drv.init();
 	trace!("Driver after init: {:?}", drv);
 
+	Some(drv)
+}
+
+pub fn init_fs() {
+	let drv = pci::get_filesystem_driver().expect("Unable to get access to the device driver");
+
 	// Instanciate global fuse object
 	let fuse = fuse::Fuse::new();
 
@@ -313,10 +319,8 @@ pub fn create_virtiofs_driver(adapter: &pci::PciAdapter) -> Option<VirtioFsDrive
 	fuse.send_init();
 
 	let mut fs = fs::FILESYSTEM.lock();
-	let tag = util::c_buf_to_str(&device_cfg.tag);
+	let tag = util::c_buf_to_str(&drv.lock().device_cfg.tag);
 	info!("Mounting virtio-fs at /{}", tag);
 	fs.mount(tag, Box::new(fuse))
 		.expect("Mount failed. Duplicate tag?");
-
-	Some(drv)
 }

--- a/src/syscalls/fs.rs
+++ b/src/syscalls/fs.rs
@@ -109,7 +109,7 @@ impl Filesystem {
 				return Ok((fs.deref(), internal_path));
 			}
 
-			info!(
+			warn!(
 				"Trying to open file on non-existing mount point '{}'!",
 				mount
 			);
@@ -126,6 +126,7 @@ impl Filesystem {
 				"Assume that the directory '{}' is used as mount point!",
 				mount
 			);
+
 			if let Some(fs) = self.mounts.get(mount) {
 				return Ok((fs.deref(), internal_path));
 			}

--- a/src/syscalls/fs.rs
+++ b/src/syscalls/fs.rs
@@ -5,6 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::environment::is_uhyve;
 use crate::synch::spinlock::Spinlock;
 use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
@@ -98,25 +99,44 @@ impl Filesystem {
 		&'a self,
 		path: &'b str,
 	) -> Result<(&'a (dyn PosixFileSystem + Send), &'b str), FileError> {
-		// assert start with / (no pwd relative!), split path at /, look first element. Determine backing fs. If non existent, -ENOENT
-		if !path.starts_with('/') {
-			warn!("Relative paths not allowed!");
-			return Err(FileError::ENOENT());
-		}
-		let mut pathsplit = path.splitn(3, '/');
-		pathsplit.next(); // always empty, since first char is /
-		let mount = pathsplit.next().unwrap();
-		let internal_path = pathsplit.next().unwrap(); //TODO: this can fail from userspace, eg when passing "/test"
+		if path.starts_with('/') {
+			let mut pathsplit = path.splitn(3, '/');
+			pathsplit.next(); // empty, since first char is /
 
-		if let Some(fs) = self.mounts.get(mount) {
-			Ok((fs.deref(), internal_path))
-		} else {
+			let mount = pathsplit.next().unwrap();
+			let internal_path = pathsplit.next().unwrap();
+			if let Some(fs) = self.mounts.get(mount) {
+				return Ok((fs.deref(), internal_path));
+			}
+
 			info!(
 				"Trying to open file on non-existing mount point '{}'!",
 				mount
 			);
-			Err(FileError::ENOENT())
+		} else {
+			let mut pathsplit = path.splitn(3, '/');
+			let mount = if !is_uhyve() {
+				option_env!("HERMIT_WD").unwrap_or("root")
+			} else {
+				"."
+			};
+			let internal_path = pathsplit.next().unwrap();
+
+			debug!(
+				"Assume that the directory '{}' is used as mount point!",
+				mount
+			);
+			if let Some(fs) = self.mounts.get(mount) {
+				return Ok((fs.deref(), internal_path));
+			}
+
+			info!(
+				"Trying to open file on non-existing mount point '{}'!",
+				mount
+			);
 		}
+
+		Err(FileError::ENOENT())
 	}
 
 	/// Tries to open file at given path (/MOUNTPOINT/internal-path).


### PR DESCRIPTION
- disable interrupts during the initialization of pci devices
- add support of relative paths
- in case of virtio-fs the file system uses a static location as working directory
- the location is definable at compile time by setting the environment variable `HERMIT_WD`