### PR TITLE
switching to crate "multiboot 0.6"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,12 @@ dependencies = [
 
 [[package]]
 name = "multiboot"
-version = "0.3.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745e351d4f128ea9e266fe2dd04a1bd7349c60441d45ec8677520bae08e25d43"
+checksum = "0f442c65adef7bc9676eb8212598d14b7ba799b8bb2a312ed32f410e85e2f5ad"
+dependencies = [
+ "paste",
+]
 
 [[package]]
 name = "num"
@@ -143,6 +146,12 @@ checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d65c4d95931acda4498f675e332fcbdc9a06705cd07086c510e9b6009cd1c1"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ default-features = false
 #features = ["release_max_level_info"]
 
 [target.'cfg(target_arch = "x86_64")'.dependencies.multiboot]
-version = "0.3.*"
+version = "0.6.*"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies.x86]
 version = "0.34.*"

--- a/src/arch/x86_64/mm/paging.rs
+++ b/src/arch/x86_64/mm/paging.rs
@@ -10,7 +10,7 @@
 use core::marker::PhantomData;
 use core::mem;
 use core::ptr;
-use multiboot::Multiboot;
+use multiboot::information::Multiboot;
 use x86::controlregs;
 use x86::irq::PageFaultError;
 
@@ -19,7 +19,7 @@ use crate::arch::x86_64::kernel::get_mbinfo;
 use crate::arch::x86_64::kernel::irq;
 use crate::arch::x86_64::kernel::processor;
 use crate::arch::x86_64::mm::physicalmem;
-use crate::arch::x86_64::mm::{paddr_to_slice, PhysAddr, VirtAddr};
+use crate::arch::x86_64::mm::{PhysAddr, VirtAddr, MEM};
 use crate::environment;
 use crate::mm;
 use crate::scheduler;
@@ -759,7 +759,7 @@ pub fn init_page_tables() {
 			identity_map(PhysAddr(mb_info.as_u64()), PhysAddr(mb_info.as_u64()));
 
 			// Map the "Memory Map" information too.
-			let mb = Multiboot::new(mb_info.as_u64(), paddr_to_slice).unwrap();
+			let mb = Multiboot::from_ptr(mb_info.as_u64(), &mut MEM).unwrap();
 			let memory_map_address = mb
 				.memory_regions()
 				.expect("Could not find a memory map in the Multiboot information")

--- a/src/arch/x86_64/mm/physicalmem.rs
+++ b/src/arch/x86_64/mm/physicalmem.rs
@@ -7,11 +7,11 @@
 
 use core::convert::TryInto;
 use core::sync::atomic::{AtomicUsize, Ordering};
-use multiboot::{MemoryType, Multiboot};
+use multiboot::information::{MemoryType, Multiboot};
 
 use crate::arch::x86_64::kernel::{get_limit, get_mbinfo};
-use crate::arch::x86_64::mm::paddr_to_slice;
 use crate::arch::x86_64::mm::paging::{BasePageSize, PageSize};
+use crate::arch::x86_64::mm::MEM;
 use crate::arch::x86_64::mm::{PhysAddr, VirtAddr};
 use crate::mm;
 use crate::mm::freelist::{FreeList, FreeListEntry};
@@ -26,7 +26,7 @@ fn detect_from_multiboot_info() -> Result<(), ()> {
 		return Err(());
 	}
 
-	let mb = unsafe { Multiboot::new(mb_info.as_u64(), paddr_to_slice).unwrap() };
+	let mb = unsafe { Multiboot::from_ptr(mb_info.as_u64(), &mut MEM).unwrap() };
 	let all_regions = mb
 		.memory_regions()
 		.expect("Could not find a memory map in the Multiboot information");


### PR DESCRIPTION
- minor changes are required to initialize the multiboot information