### PR TITLE
Tests: Add timeout for integration tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,9 +63,9 @@ test:integration:
     - kvm-ok
     - python3 --version
     - |
-        bash -c "HERMIT_LOG_LEVEL_FILTER=Debug cargo test --tests --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --veryverbose"
+        HERMIT_LOG_LEVEL_FILTER=Debug cargo test --tests --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --veryverbose
     - |
-        bash -c "HERMIT_LOG_LEVEL_FILTER=Debug cargo test --tests --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --num_cores 2 --veryverbose"
+        HERMIT_LOG_LEVEL_FILTER=Debug cargo test --tests --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --num_cores 2 --veryverbose
   tags:
     - privileged
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,6 +65,12 @@ test:integration:
         bash -c "cargo test --tests --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve"
     - |
         bash -c "cargo test --tests --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --num_cores 2"
+  artifacts:
+    when: always
+    paths:
+      - /builds/acs/public/hermitcore/libhermit-rs/target/x86_64-unknown-hermit-kernel/debug/deps/basic_*
+      - target/x86_64-unknown-hermit-kernel/debug/deps/measure_*
+      - target/x86_64-unknown-hermit-kernel/debug/deps/thread*
   tags:
     - privileged
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,9 +63,9 @@ test:integration:
     - kvm-ok
     - python3 --version
     - |
-        bash -c "cargo test --tests --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --veryverbose"
+        bash -c "HERMIT_LOG_LEVEL_FILTER=Debug cargo test --tests --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --veryverbose"
     - |
-        bash -c "cargo test --tests --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --num_cores 2 --veryverbose"
+        bash -c "HERMIT_LOG_LEVEL_FILTER=Debug cargo test --tests --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --num_cores 2 --veryverbose"
   artifacts:
     when: always
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,18 +55,18 @@ build:demo:
       - rusty-hermit/target/x86_64-unknown-hermit/debug/rusty_demo
       - rusty-hermit/target/x86_64-unknown-hermit/release/rusty_demo
 
-#test:integration:
-#   stage: test
-#   image: ${CI_REGISTRY_IMAGE}
-#   script:
-#     - lscpu
-#     - kvm-ok
-#     - |
-#         bash -c "cargo test --tests --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve"
-#     - |
-#         bash -c "cargo test --tests --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --num_cores 2"
-#   tags:
-#     - privileged
+test:integration:
+  stage: test
+  image: ${CI_REGISTRY_IMAGE}
+  script:
+    - lscpu
+    - kvm-ok
+    - |
+        bash -c "cargo test --tests --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve"
+    - |
+        bash -c "cargo test --tests --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --num_cores 2"
+  tags:
+    - privileged
 
 test:uhyve:
    stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,9 +63,9 @@ test:integration:
     - kvm-ok
     - python3 --version
     - |
-        HERMIT_LOG_LEVEL_FILTER=Debug cargo test --tests --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --veryverbose
+        HERMIT_LOG_LEVEL_FILTER=Debug cargo test --test '*' --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --veryverbose
     - |
-        HERMIT_LOG_LEVEL_FILTER=Debug cargo test --tests --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --num_cores 2 --veryverbose
+        HERMIT_LOG_LEVEL_FILTER=Debug cargo test --test '*' --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --num_cores 2 --veryverbose
   tags:
     - privileged
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,10 +62,14 @@ test:integration:
     - lscpu
     - kvm-ok
     - python3 --version
-    - |
-        HERMIT_LOG_LEVEL_FILTER=Debug cargo test --test '*' --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --veryverbose
-    - |
-        HERMIT_LOG_LEVEL_FILTER=Debug cargo test --test '*' --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --num_cores 2 --veryverbose
+    - HERMIT_LOG_LEVEL_FILTER=Debug cargo test --test '*' --no-fail-fast -Z build-std=core,alloc 
+        -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi 
+        --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --veryverbose
+    # 2 cores
+    - HERMIT_LOG_LEVEL_FILTER=Debug cargo test --test '*' --no-fail-fast -Z build-std=core,alloc 
+        -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi 
+        --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --num_cores 2 
+        --veryverbose
   tags:
     - privileged
 
@@ -97,9 +101,17 @@ test:qemu:
      - make
      - make release=1
      - cd -
-     - qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio -kernel $CI_BUILDS_DIR/loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd rusty-hermit/target/x86_64-unknown-hermit/debug/rusty_demo -cpu host -enable-kvm
-     - qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio -kernel $CI_BUILDS_DIR/loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd rusty-hermit/target/x86_64-unknown-hermit/debug/rusty_demo -cpu host -enable-kvm
-     - qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio -kernel $CI_BUILDS_DIR/loader/target/x86_64-unknown-hermit-loader/release/rusty-loader -initrd rusty-hermit/target/x86_64-unknown-hermit/release/rusty_demo -cpu host -enable-kvm
-     - qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio -kernel $CI_BUILDS_DIR/loader/target/x86_64-unknown-hermit-loader/release/rusty-loader -initrd rusty-hermit/target/x86_64-unknown-hermit/release/rusty_demo -cpu host -enable-kvm
+     - qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio 
+        -kernel $CI_BUILDS_DIR/loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader 
+        -initrd rusty-hermit/target/x86_64-unknown-hermit/debug/rusty_demo -cpu host -enable-kvm
+     - qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio 
+        -kernel $CI_BUILDS_DIR/loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader 
+        -initrd rusty-hermit/target/x86_64-unknown-hermit/debug/rusty_demo -cpu host -enable-kvm
+     - qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio 
+        -kernel $CI_BUILDS_DIR/loader/target/x86_64-unknown-hermit-loader/release/rusty-loader 
+        -initrd rusty-hermit/target/x86_64-unknown-hermit/release/rusty_demo -cpu host -enable-kvm
+     - qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio 
+        -kernel $CI_BUILDS_DIR/loader/target/x86_64-unknown-hermit-loader/release/rusty-loader 
+        -initrd rusty-hermit/target/x86_64-unknown-hermit/release/rusty_demo -cpu host -enable-kvm
    tags:
      - privileged

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,10 +61,11 @@ test:integration:
   script:
     - lscpu
     - kvm-ok
+    - python3 --version
     - |
-        bash -c "cargo test --tests --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve"
+        bash -c "cargo test --tests --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --veryverbose"
     - |
-        bash -c "cargo test --tests --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --num_cores 2"
+        bash -c "cargo test --tests --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --num_cores 2 --veryverbose"
   artifacts:
     when: always
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,12 +66,6 @@ test:integration:
         bash -c "HERMIT_LOG_LEVEL_FILTER=Debug cargo test --tests --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --veryverbose"
     - |
         bash -c "HERMIT_LOG_LEVEL_FILTER=Debug cargo test --tests --no-fail-fast -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi --target x86_64-unknown-hermit-kernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --num_cores 2 --veryverbose"
-  artifacts:
-    when: always
-    paths:
-      - /builds/acs/public/hermitcore/libhermit-rs/target/x86_64-unknown-hermit-kernel/debug/deps/basic_*
-      - target/x86_64-unknown-hermit-kernel/debug/deps/measure_*
-      - target/x86_64-unknown-hermit-kernel/debug/deps/thread*
   tags:
     - privileged
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,4 @@
-nightly
+[toolchain]
+channel = "nightly-2020-12-23"
+components = [ "rustfmt", "rust-src", "llvm-tools-preview"]
+targets = [ "x86_64-unknown-hermit" ]

--- a/src/arch/x86_64/kernel/processor.rs
+++ b/src/arch/x86_64/kernel/processor.rs
@@ -803,7 +803,7 @@ pub fn configure() {
 	#[cfg(feature = "fsgsbase")]
 	if !supports_fsgs() {
 		error!("FSGSBASE support is enabled, but the processor doesn't support it!");
-		loop {}
+		crate::__sys_shutdown(1);
 	}
 
 	debug!("Set CR4 to 0x{:x}", cr4);

--- a/tests/hermit_test_runner.py
+++ b/tests/hermit_test_runner.py
@@ -16,7 +16,13 @@ class TestRunner:
         Subclassed by QemuTestRunner and UhyveTestRunner that extend this class
     """
 
-    def __init__(self, test_command, num_cores=1, memory_in_megabyte=512, gdb_enabled=False, verbose=False):
+    def __init__(self,
+                 test_command,
+                 timeout_seconds: int,
+                 num_cores=1,
+                 memory_in_megabyte=512,
+                 gdb_enabled=False,
+                 verbose=False):
         online_cpus = multiprocessing.cpu_count()
         if num_cores > online_cpus:
             print("WARNING: You specified num_cores={}, however only {} cpu cores are available."
@@ -29,6 +35,7 @@ class TestRunner:
         self.verbose: bool = verbose
         self.test_command = test_command
         self.custom_env = None
+        self.timeout: int = timeout_seconds
 
     def validate_test_success(self, rc, stdout, stderr, execution_time) -> bool:
         """
@@ -53,10 +60,11 @@ class TestRunner:
         print("Calling {}".format(type(self).__name__))
         start_time = time.perf_counter()  # https://docs.python.org/3/library/time.html#time.perf_counter
         if self.custom_env is None:
-            p = subprocess.run(self.test_command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+            p = subprocess.run(self.test_command, stdout=PIPE, stderr=PIPE, universal_newlines=True,
+                    timeout=self.timeout)
         else:
             p = subprocess.run(self.test_command, stdout=PIPE, stderr=PIPE, universal_newlines=True,
-                               env=self.custom_env)
+                               timeout=self.timeout, env=self.custom_env)
         end_time = time.perf_counter()
         # ToDo: add some timeout
         return p.returncode, p.stdout, p.stderr, end_time - start_time
@@ -70,6 +78,7 @@ class QemuTestRunner(TestRunner):
 
     def __init__(self,
                  test_exe_path: str,
+                 timeout_seconds: int,
                  bootloader_path: str = '../loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader',
                  num_cores=1,
                  memory_in_megabyte=512,
@@ -87,7 +96,13 @@ class QemuTestRunner(TestRunner):
                         '-cpu', 'qemu64,apic,fsgsbase,rdtscp,xsave,fxsr',
                         '-device', 'isa-debug-exit,iobase=0xf4,iosize=0x04',
                         ]
-        super().__init__(test_command, num_cores, memory_in_megabyte, gdb_enabled, verbose=False)
+        super().__init__(test_command, 
+                        timeout_seconds=timeout_seconds, 
+                        num_cores = num_cores, 
+                        memory_in_megabyte = memory_in_megabyte, 
+                        gdb_enabled = gdb_enabled, 
+                        verbose=False
+                        )
         if self.gdb_enabled:
             self.gdb_port = 1234
             self.test_command.append('-s')
@@ -108,8 +123,14 @@ class QemuTestRunner(TestRunner):
 
 
 class UhyveTestRunner(TestRunner):
-    def __init__(self, test_exe_path: str, uhyve_path=None, num_cores=1, memory_in_megabyte=512, gdb_enabled=False,
-                 verbose=False):
+    def __init__(self, 
+                test_exe_path: str, 
+                timeout_seconds: int,
+                uhyve_path=None, 
+                num_cores=1, 
+                memory_in_megabyte=512, 
+                gdb_enabled=False,
+                verbose=False):
         if platform.system() == 'Windows':
             print("Error: using uhyve requires kvm. Please use Linux or Mac OS", file=sys.stderr)
             raise OSError
@@ -122,7 +143,7 @@ class UhyveTestRunner(TestRunner):
         if verbose:
             test_command.append('-v')
         test_command.append(test_exe_path)
-        super().__init__(test_command=test_command, num_cores=num_cores, memory_in_megabyte=memory_in_megabyte,
+        super().__init__(test_command=test_command, timeout_seconds=timeout_seconds, num_cores=num_cores, memory_in_megabyte=memory_in_megabyte,
                          gdb_enabled=gdb_enabled, verbose=verbose)
         # ToDo: This could be done a lot nicer if we could use flags to pass these options to uhyve
         if gdb_enabled or num_cores != 1:
@@ -189,6 +210,8 @@ parser.add_argument('-vv', '--veryverbose', action='store_true', help='verbose a
 parser.add_argument('--gdb', action='store_true', help='Enables gdb on port 1234 and stops at test executable '
                                                        'entrypoint')
 parser.add_argument('--num_cores', type=int, default=1, help="Number of CPU cores the test should run on")
+parser.add_argument('--timeout', type=int, default=300, help="Timeout in seconds for the test process.")
+
 args = parser.parse_args()
 print("Arguments: {}".format(args.runner_args))
 
@@ -196,19 +219,30 @@ print("Arguments: {}".format(args.runner_args))
 test_exe = args.runner_args[-1]
 assert isinstance(test_exe, str)
 assert os.path.isfile(test_exe)  # If this fails likely something about runner args changed
+assert args.timeout > 0, "Timeout must be a positive integer" # Todo: add range checking directly into parser.add_argument
 # ToDo: Add additional test based arguments for qemu / uhyve
 
 test_name = os.path.basename(test_exe)
 test_name = clean_test_name(test_name)
 
 if args.bootloader_path is not None:
-    test_runner = QemuTestRunner(test_exe, args.bootloader_path, gdb_enabled=args.gdb, num_cores=args.num_cores)
+    test_runner = QemuTestRunner(test_exe, 
+                    timeout_seconds=args.timeout, 
+                    bootloader_path = args.bootloader_path, 
+                    gdb_enabled=args.gdb, 
+                    num_cores=args.num_cores
+                    )
 elif platform.system() == 'Windows':
     print("Error: using uhyve requires kvm. Please use Linux or Mac OS, or use qemu", file=sys.stderr)
     exit(-1)
 else:
-    test_runner = UhyveTestRunner(test_exe, verbose=args.veryverbose, gdb_enabled=args.gdb, num_cores=args.num_cores,
-                                  uhyve_path=args.uhyve_path)
+    test_runner = UhyveTestRunner(test_exe, 
+                    timeout_seconds=args.timeout, 
+                    verbose=args.veryverbose, 
+                    gdb_enabled=args.gdb, 
+                    num_cores=args.num_cores,
+                    uhyve_path=args.uhyve_path)
+
 if test_name == "hermit":
     print("Executing the Unittests is currently broken... Skipping Test NOT marking as failed")
     # print("Note: If you want to execute all tests, consider adding the '--no-fail-fast' flag")


### PR DESCRIPTION
This adds the --timeout flag to `hermit_test_runner.py`. For now the value is simply a positive integer meaning a timeout in seconds.
The default timeout is 300 seconds.
This timeout applies to all integration tests (as in each integration test may take up to timeout seconds). 
