### PR TITLE
add RTL8139 driver

### DIFF
--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -24,12 +24,14 @@ pub mod virtio;
 /// passed on to higher layers.
 #[cfg(feature = "pci")]
 pub mod error {
+	use crate::drivers::net::rtl8139::RTL8139Error;
 	use crate::drivers::virtio::error::VirtioError;
 	use core::fmt;
 
 	#[derive(Debug)]
 	pub enum DriverError {
 		InitVirtioDevFail(VirtioError),
+		InitRTL8139DevFail(RTL8139Error),
 	}
 
 	impl From<VirtioError> for DriverError {
@@ -38,11 +40,20 @@ pub mod error {
 		}
 	}
 
+	impl From<RTL8139Error> for DriverError {
+		fn from(err: RTL8139Error) -> Self {
+			DriverError::InitRTL8139DevFail(err)
+		}
+	}
+
 	impl fmt::Display for DriverError {
 		fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 			match *self {
 				DriverError::InitVirtioDevFail(ref err) => {
 					write!(f, "Virtio driver failed: {:?}", err)
+				}
+				DriverError::InitRTL8139DevFail(ref err) => {
+					write!(f, "RTL8139 driver failed: {:?}", err)
 				}
 			}
 		}

--- a/src/drivers/net/mod.rs
+++ b/src/drivers/net/mod.rs
@@ -7,14 +7,41 @@
 // copied, modified, or distributed except according to those terms.
 
 #[cfg(feature = "pci")]
+pub mod rtl8139;
+#[cfg(feature = "pci")]
 pub mod virtio_net;
 
+use crate::arch::kernel::apic;
+use crate::arch::kernel::irq::ExceptionStackFrame;
+use crate::arch::kernel::pci;
 use crate::arch::kernel::percore::*;
 use crate::scheduler::task::TaskHandle;
 use crate::synch::semaphore::*;
 use crate::synch::spinlock::SpinlockIrqSave;
 use alloc::collections::BTreeMap;
 use core::sync::atomic::{AtomicBool, Ordering};
+
+/// A trait for accessing the network interface
+pub trait NetworkInterface {
+	/// Returns the mac address of the device.
+	fn get_mac_address(&self) -> [u8; 6];
+	/// Returns the current MTU of the device.
+	fn get_mtu(&self) -> u16;
+	/// Get buffer to create a TX packet
+	fn get_tx_buffer(&mut self, len: usize) -> Result<(*mut u8, usize), ()>;
+	/// Send TC packets
+	fn send_tx_buffer(&mut self, tkn_handle: usize, len: usize) -> Result<(), ()>;
+	/// Check if a packet is available
+	fn has_packet(&self) -> bool;
+	/// Get RX buffer with an received packet
+	fn receive_rx_buffer(&mut self) -> Result<(&'static [u8], usize), ()>;
+	/// Tells driver, that buffer is consumed and can be deallocated
+	fn rx_buffer_consumed(&mut self, trf_handle: usize);
+	/// Enable / disable the polling mode of the network interface
+	fn set_polling_mode(&mut self, value: bool);
+	/// Handle interrupt and check if a packet is available
+	fn handle_interrupt(&mut self) -> bool;
+}
 
 static NET_SEM: Semaphore = Semaphore::new(0);
 static NIC_QUEUE: SpinlockIrqSave<BTreeMap<usize, TaskHandle>> =
@@ -110,5 +137,23 @@ pub fn netwait(handle: usize, millis: Option<u64>) {
 
 			guard.remove(&handle);
 		}
+	}
+}
+
+#[cfg(target_arch = "x86_64")]
+pub extern "x86-interrupt" fn network_irqhandler(_stack_frame: &mut ExceptionStackFrame) {
+	debug!("Receive network interrupt");
+	apic::eoi();
+
+	let check_scheduler = match pci::get_network_driver() {
+		Some(driver) => driver.lock().handle_interrupt(),
+		_ => {
+			debug!("Unable to handle interrupt!");
+			false
+		}
+	};
+
+	if check_scheduler {
+		core_scheduler().scheduler();
 	}
 }

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -29,8 +29,8 @@ use crate::drivers::virtio::env::memory::{MemLen, MemOff, VirtMemAddr};
 use crate::drivers::virtio::error::VirtioError;
 
 use crate::arch::x86_64::kernel::irq::*;
+use crate::drivers::net::network_irqhandler;
 use crate::drivers::virtio::depr::virtio_fs;
-use crate::drivers::virtio::{virtio_irqhandler, VIRTIO_IRQ_NO};
 
 /// Virtio device ID's
 /// See Virtio specification v1.1. - 5
@@ -1306,11 +1306,8 @@ pub fn init_device(adapter: &PciAdapter) -> Result<VirtioDriver, DriverError> {
 			match &drv {
 				VirtioDriver::Network(_) => {
 					info!("Install virtio interrupt handler at line {}", adapter.irq);
-					unsafe {
-						VIRTIO_IRQ_NO = adapter.irq;
-					}
 					// Install interrupt handler
-					irq_install_handler(adapter.irq as u32, virtio_irqhandler as usize);
+					irq_install_handler(adapter.irq as u32, network_irqhandler as usize);
 					add_irq_name(adapter.irq as u32, "virtio_net");
 
 					Ok(drv)

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -230,20 +230,6 @@ pub fn print_information() {
 	arch::mm::virtualmem::print_information();
 }
 
-/*pub fn allocate_iomem(sz: usize) -> usize {
-	let size = align_up!(sz, BasePageSize::SIZE);
-
-	let physical_address = arch::mm::physicalmem::allocate(size).unwrap();
-	let virtual_address = arch::mm::virtualmem::allocate(size).unwrap();
-
-	let count = size / BasePageSize::SIZE;
-	let mut flags = PageTableEntryFlags::empty();
-	flags.normal().writable().execute_disable();
-	arch::mm::paging::map::<BasePageSize>(virtual_address, physical_address, count, flags);
-
-	virtual_address
-}*/
-
 pub fn allocate(sz: usize, no_execution: bool) -> VirtAddr {
 	let size = align_up!(sz, BasePageSize::SIZE);
 	let physical_address = arch::mm::physicalmem::allocate(size).unwrap();


### PR DESCRIPTION
- add driver for the network interface Realteak 8139
- this interface is often emulated by hypervisors or emulators like Qemu
- to support different network interface, the tait `NetworkInterface` is introduced as abstraction layer