### PR TITLE
switch to the latest nightly compiler

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,6 +1,6 @@
 [unstable]
 build-std = ["core", "alloc"]
-build-std-features = ["compiler-builtins-mem", "compiler-builtins-asm"]
+build-std-features = ["compiler-builtins-mem"]
 
 [build]
 target = "x86_64-unknown-hermit-kernel"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(HERMIT_RS "${CMAKE_BINARY_DIR}/hermit_rs/${HERMIT_ARCH}-unknown-hermit-kerne
 add_custom_target(hermit_rs
 	COMMAND
 		${CMAKE_COMMAND} -E env CARGO_TARGET_DIR=${CMAKE_BINARY_DIR}/hermit_rs RUST_TARGET_PATH=${HERMIT_ROOT}/librs
-		cargo build ${CARGO_BUILDTYPE_PARAMETER} -Z build-std=core,alloc -Zbuild-std-features=compiler-builtins-asm,compiler-builtins-mem --target ${HERMIT_ARCH}-unknown-hermit-kernel.json --features newlib
+		cargo build ${CARGO_BUILDTYPE_PARAMETER} -Z build-std=core,alloc -Zbuild-std-features=compiler-builtins-mem --target ${HERMIT_ARCH}-unknown-hermit-kernel.json --features newlib
 	WORKING_DIRECTORY
 		${CMAKE_CURRENT_LIST_DIR})
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,3 @@
 [toolchain]
-channel = "nightly-2020-12-23"
+channel = "nightly-2021-01-22"
 components = [ "rustfmt", "rust-src", "llvm-tools-preview"]
-targets = [ "x86_64-unknown-hermit" ]


### PR DESCRIPTION
- explicit activation of optimized core functions (e.g. memcpy) isn't longer required