### PR TITLE
clearify license text, add workround to use raw-cpuid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 [[package]]
 name = "x86"
 version = "0.35.0"
-source = "git+https://github.com/stlankes/rust-x86?branch=master#b79819bd82075e3065d87617380ce3b5b77d3371"
+source = "git+https://github.com/gz/rust-x86.git?branch=master#c8a844e36a55f0ab45ba81e3efa6919c2d5d0a6c"
 dependencies = [
  "bit_field",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,12 +19,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "cc"
-version = "1.0.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,22 +161,11 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "8.1.2"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdf7d9dbd43f3d81d94a49c1c3df73cc2b3827995147e6cf7f89d4ec5483e73"
+checksum = "c27cb5785b85bd05d4eb171556c9a1a514552e26123aeae6bb7d811353148026"
 dependencies = [
  "bitflags",
- "cc",
- "rustc_version",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
 ]
 
 [[package]]
@@ -208,21 +191,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
 name = "syn"
 version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,8 +210,7 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 [[package]]
 name = "x86"
 version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1851696db84188e868fffb08002a5635f6abb136b68fe65a5bae38cdbdbc4852"
+source = "git+https://github.com/stlankes/rust-x86?branch=master#b79819bd82075e3065d87617380ce3b5b77d3371"
 dependencies = [
  "bit_field",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,8 +209,9 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "x86"
-version = "0.35.0"
-source = "git+https://github.com/gz/rust-x86.git?branch=master#c8a844e36a55f0ab45ba81e3efa6919c2d5d0a6c"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "268696f47813d5744c80c868e014485e27b30d40eaeeff2f7685b10b70215e5c"
 dependencies = [
  "bit_field",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
 	"Colin Finck <colin.finck@rwth-aachen.de>"
 ]
 build = "build.rs"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 keywords = ["unikernel", "libos"]
 categories = ["os"]
@@ -82,6 +82,9 @@ version = "0.6.*"
 [target.'cfg(target_arch = "x86_64")'.dependencies.x86]
 version = "0.35.*"
 default-features = false
+
+[patch.crates-io]
+x86 = { git = "https://github.com/stlankes/rust-x86", branch = "master" }
 
 # The development profile, used for `cargo build`.
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ version = "0.35.*"
 default-features = false
 
 [patch.crates-io]
-x86 = { git = "https://github.com/stlankes/rust-x86", branch = "master" }
+x86 = { git = "https://github.com/gz/rust-x86.git", branch = "master" }
 
 # The development profile, used for `cargo build`.
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ smp = []
 fsgsbase = []
 
 [dev-dependencies]
-x86 = { version = "0.35.*", default-features = false }
+x86 = { version = "0.36.*", default-features = false }
 float-cmp = "0.8.0"
 
 [dependencies.scopeguard]
@@ -80,11 +80,8 @@ default-features = false
 version = "0.6.*"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies.x86]
-version = "0.35.*"
+version = "0.36.*"
 default-features = false
-
-[patch.crates-io]
-x86 = { git = "https://github.com/gz/rust-x86.git", branch = "master" }
 
 # The development profile, used for `cargo build`.
 [profile.dev]


### PR DESCRIPTION
The workaround should solve issue hermitcore/libhermit-rs#164 and is only necessry until gz/rust-x86#71 is accepted.