### PR TITLE
spelling police: inital -> initial

### DIFF
--- a/src/drivers/net/virtio_net.rs
+++ b/src/drivers/net/virtio_net.rs
@@ -498,7 +498,7 @@ impl TxQueues {
 			Ok(tkn) => return Some((tkn, 0)),
 			Err(_) => {
 				// Here it is possible if multiple ques are enabled to get another buffertoken from them!
-				// Info the queues are disbaled upon initalization and should be enabled somehow!
+				// Info the queues are disbaled upon initialization and should be enabled somehow!
 				None
 			}
 		}
@@ -866,7 +866,7 @@ impl VirtioNetDriver {
 		})
 	}
 
-	/// Initallizes the device in adherence to specificaton. Returns Some(VirtioNetError)
+	/// Initiallizes the device in adherence to specificaton. Returns Some(VirtioNetError)
 	/// upon failure and None in case everything worked as expected.
 	///
 	/// See Virtio specification v1.1. - 3.1.1.
@@ -984,7 +984,7 @@ impl VirtioNetDriver {
 
 		match self.dev_spec_init() {
 			Ok(_) => info!(
-				"Device specific initalization for Virtio network defice {:x} finished",
+				"Device specific initialization for Virtio network defice {:x} finished",
 				self.dev_cfg.dev_id
 			),
 			Err(vnet_err) => return Err(vnet_err),
@@ -1024,10 +1024,10 @@ impl VirtioNetDriver {
 		}
 	}
 
-	/// Device Specfic initalization according to Virtio specifictation v1.1. - 5.1.5
+	/// Device Specfic initialization according to Virtio specifictation v1.1. - 5.1.5
 	fn dev_spec_init(&mut self) -> Result<(), VirtioNetError> {
 		match self.virtqueue_init() {
-			Ok(_) => info!("Network driver successfully initalized virtqueues."),
+			Ok(_) => info!("Network driver successfully initialized virtqueues."),
 			Err(vnet_err) => return Err(vnet_err),
 		}
 
@@ -1074,7 +1074,7 @@ impl VirtioNetDriver {
 		Ok(())
 	}
 
-	/// Initalize virtqueues via the queue interface and populates receiving queues
+	/// Initialize virtqueues via the queue interface and populates receiving queues
 	fn virtqueue_init(&mut self) -> Result<(), VirtioNetError> {
 		// We are assuming here, that the device single source of truth is the
 		// device specific configuration. Hence we do NOT check if
@@ -1196,7 +1196,7 @@ impl VirtioNetDriver {
 
 		match drv.init_dev() {
 			Ok(_) => info!(
-				"Network device with id {:x}, has been initalized by driver!",
+				"Network device with id {:x}, has been initialized by driver!",
 				drv.dev_cfg.dev_id
 			),
 			Err(vnet_err) => {
@@ -1206,9 +1206,9 @@ impl VirtioNetDriver {
 		}
 
 		if drv.is_link_up() {
-			info!("Virtio-net link is up after initalization.")
+			info!("Virtio-net link is up after initialization.")
 		} else {
-			info!("Virtio-net link is down after initalization!")
+			info!("Virtio-net link is down after initialization!")
 		}
 
 		Ok(drv)
@@ -1930,7 +1930,7 @@ mod constants {
 		}
 
 		/// Returns a new instance of (FeatureSet)[FeatureSet] with all features
-		/// initalized to false.
+		/// initialized to false.
 		pub fn new(val: u64) -> Self {
 			FeatureSet(val)
 		}

--- a/src/drivers/virtio/mod.rs
+++ b/src/drivers/virtio/mod.rs
@@ -29,14 +29,14 @@ pub mod error {
 	impl fmt::Display for VirtioError {
 		fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 			match self {
-                VirtioError::Unknown =>write!(f, "Driver failed to initalize virtio device due to unknown reasosn!"),
+                VirtioError::Unknown =>write!(f, "Driver failed to initialize virtio device due to unknown reasosn!"),
                 VirtioError::FromPci(pci_error) => match pci_error {
-                    PciError::General(id) => write!(f, "Driver failed to initalize device with id: 0x{:x}. Due to unknown reasosn!", id),
-                    PciError::NoBar(id ) => write!(f, "Driver failed to initalize device with id: 0x{:x}. Reason: No BAR's found.", id), 
-                    PciError::NoCapPtr(id) => write!(f, "Driver failed to initalize device with id: 0x{:x}. Reason: No Capabilites pointer found.", id),
-                    PciError::BadCapPtr(id) => write!(f, "Driver failed to initalize device with id: 0x{:x}. Reason: Malformed Capabilites pointer.", id),
-                    PciError::NoBarForCap(id) => write!(f, "Driver failed to initalize device with id: 0x{:x}. Reason: Bar indicated by capability not found.", id),
-                    PciError::NoVirtioCaps(id) => write!(f, "Driver failed to initalize device with id: 0x{:x}. Reason: No Virtio capabilites were found.", id),
+                    PciError::General(id) => write!(f, "Driver failed to initialize device with id: 0x{:x}. Due to unknown reasosn!", id),
+                    PciError::NoBar(id ) => write!(f, "Driver failed to initialize device with id: 0x{:x}. Reason: No BAR's found.", id), 
+                    PciError::NoCapPtr(id) => write!(f, "Driver failed to initialize device with id: 0x{:x}. Reason: No Capabilites pointer found.", id),
+                    PciError::BadCapPtr(id) => write!(f, "Driver failed to initialize device with id: 0x{:x}. Reason: Malformed Capabilites pointer.", id),
+                    PciError::NoBarForCap(id) => write!(f, "Driver failed to initialize device with id: 0x{:x}. Reason: Bar indicated by capability not found.", id),
+                    PciError::NoVirtioCaps(id) => write!(f, "Driver failed to initialize device with id: 0x{:x}. Reason: No Virtio capabilites were found.", id),
                 },
                 VirtioError::DevNotSupported(id) => write!(f, "Devie with id 0x{:x} not supported.", id),
                 VirtioError::NetDriver(net_error) => match net_error {

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -486,7 +486,7 @@ impl ComCfg {
 	}
 
 	/// Sets the device status field to FAILED.
-	/// A driver MUST NOT initalize and use the device any further after this.
+	/// A driver MUST NOT initialize and use the device any further after this.
 	/// A driver MAY use the device again after a proper reset of the device.
 	pub fn set_failed(&mut self) {
 		self.com_cfg.device_status = u8::from(device::Status::FAILED);
@@ -923,7 +923,7 @@ impl ShMemCfg {
 		let virt_addr_raw = cap.bar.mem_addr + offset;
 		let raw_ptr = usize::from(virt_addr_raw) as *mut u8;
 
-		// Zero initalize shared memory area
+		// Zero initialize shared memory area
 		unsafe {
 			for i in 0..usize::from(length) {
 				*(raw_ptr.add(i)) = 0;
@@ -1027,9 +1027,9 @@ fn read_cap_raw(adapter: &PciAdapter, register: u32) -> PciCapRaw {
 		cfg_type: quadruple_word[3],
 		bar_index: quadruple_word[4],
 		id: quadruple_word[5],
-		// Unwrapping is okay here, as transformed array slice is always 2 * u8 long and initalized
+		// Unwrapping is okay here, as transformed array slice is always 2 * u8 long and initialized
 		padding: quadruple_word[6..8].try_into().unwrap(),
-		// Unwrapping is okay here, as transformed array slice is always 4 * u8 long and initalized
+		// Unwrapping is okay here, as transformed array slice is always 4 * u8 long and initialized
 		offset: u32::from_le_bytes(quadruple_word[8..12].try_into().unwrap()),
 		length: u32::from_le_bytes(quadruple_word[12..16].try_into().unwrap()),
 	}
@@ -1261,12 +1261,12 @@ pub fn init_device(adapter: &PciAdapter) -> Result<VirtioDriver, DriverError> {
 		}
 		DevId::VIRTIO_DEV_ID_NET => match VirtioNetDriver::init(adapter) {
 			Ok(virt_net_drv) => {
-				info!("Virtio network driver initalized with Virtio network device.");
+				info!("Virtio network driver initialized with Virtio network device.");
 				Ok(VirtioDriver::Network(virt_net_drv))
 			}
 			Err(virtio_error) => {
 				error!(
-					"Virtio networkd driver could not be initalized with device: {:x}",
+					"Virtio networkd driver could not be initialized with device: {:x}",
 					adapter.device_id
 				);
 				Err(DriverError::InitVirtioDevFail(virtio_error))

--- a/src/drivers/virtio/virtqueue/mod.rs
+++ b/src/drivers/virtio/virtqueue/mod.rs
@@ -1213,7 +1213,7 @@ impl BufferToken {
 	///
 	/// Includes:
 	/// * Resetting the write status inside the MemDescr. -> Allowing to rewrite the buffers
-	/// * Resetting the MemDescr length at initalization. This length might be reduced upon writes
+	/// * Resetting the MemDescr length at initialization. This length might be reduced upon writes
 	/// of the driver or the device.
 	/// * Erazing all memory areas with zeros
 	fn reset_purge(mut self) -> Self {
@@ -1319,7 +1319,7 @@ impl BufferToken {
 	///
 	/// Includes:
 	/// * Resetting the write status inside the MemDescr. -> Allowing to rewrite the buffers
-	/// * Resetting the MemDescr length at initalization. This length might be reduced upon writes
+	/// * Resetting the MemDescr length at initialization. This length might be reduced upon writes
 	/// of the driver or the device.
 	fn reset(mut self) -> Self {
 		let mut ctrl_desc_cnt = 0usize;
@@ -1822,7 +1822,7 @@ enum Buffer {
 
 // Private Interface of Buffer
 impl Buffer {
-	/// Resets the Buffers length to the given len. This MUST be the length at initalization.
+	/// Resets the Buffers length to the given len. This MUST be the length at initialization.
 	fn reset_len(&mut self, init_len: usize) {
 		match self {
 			Buffer::Single {
@@ -1845,7 +1845,7 @@ impl Buffer {
 	}
 
 	/// Restricts the Buffers length to the given len. This length MUST NOT be larger than the
-	/// length at initalization or smaller-equal 0.
+	/// length at initialization or smaller-equal 0.
 	fn restr_len(&mut self, new_len: usize) {
 		match self {
 			Buffer::Single {
@@ -2275,7 +2275,7 @@ struct MemDescr {
 	/// Defines the len of the memory area that is accesible by users
 	/// This field is needed as the `MemDescr.len` field might change
 	/// after writes of the device, but the Descriptors need to be reset
-	/// in case they are reused. So the inital length must be preserved.
+	/// in case they are reused. So the initial length must be preserved.
 	_init_len: usize,
 	/// Defines the length of the controlled memory area
 	/// starting a `ptr: *mut u8`. Never Changes.
@@ -2433,7 +2433,7 @@ enum Dealloc {
 
 /// MemPool allows to easily control, request and provide memory for Virtqueues.
 ///
-/// * The struct is initalized with a limit of free running "tracked" (see `fn pull_untracked`)
+/// * The struct is initialized with a limit of free running "tracked" (see `fn pull_untracked`)
 /// memory descriptors. As Virtqueus do only allow a limited amount of descriptors in their queue,
 /// the independent queues, can control the number of descriptors by this.
 /// * Furthermore the MemPool struct provides an interface to easily retrieve memory of a wanted size

--- a/src/drivers/virtio/virtqueue/packed.rs
+++ b/src/drivers/virtio/virtqueue/packed.rs
@@ -42,7 +42,7 @@ impl WrapCount {
 		1 << 7 | 1 << 15
 	}
 
-	/// Returns a new WrapCount struct initalized to true or 1.
+	/// Returns a new WrapCount struct initialized to true or 1.
 	///
 	/// See virtio specification v1.1. - 2.7.1
 	fn new() -> Self {
@@ -171,7 +171,7 @@ impl DescriptorRing {
 		&mut self,
 		tkn_lst: Vec<TransferToken>,
 	) -> (Vec<Pinned<TransferToken>>, usize, u8) {
-		// Catch empty push, in order to allow zero initalized first_ctrl_settings struct
+		// Catch empty push, in order to allow zero initialized first_ctrl_settings struct
 		// which will be overwritten in the first iteration of the for-loop
 		assert!(tkn_lst.len() > 0);
 
@@ -444,7 +444,7 @@ impl DescriptorRing {
 		self.ring.as_ptr() as usize
 	}
 
-	/// Returns an initalized write controler in order
+	/// Returns an initialized write controler in order
 	/// to write the queue correctly.
 	fn get_write_ctrler(&mut self) -> WriteCtrl {
 		WriteCtrl {
@@ -458,7 +458,7 @@ impl DescriptorRing {
 		}
 	}
 
-	/// Returns an initalized read controler in order
+	/// Returns an initialized read controler in order
 	/// to read the queue correctly.
 	fn get_read_ctrler(&mut self) -> ReadCtrl {
 		ReadCtrl {
@@ -954,7 +954,7 @@ struct DevNotif {
 }
 
 impl EventSuppr {
-	/// Returns a zero initalized EventSuppr structure
+	/// Returns a zero initialized EventSuppr structure
 	fn new() -> Self {
 		EventSuppr { event: 0, flags: 0 }
 	}
@@ -1331,10 +1331,10 @@ impl PackedVq {
 			drv_event.borrow_mut().f_notif_idx = true;
 		}
 
-		// Initalize new memory pool.
+		// Initialize new memory pool.
 		let mem_pool = Rc::new(MemPool::new(vq_size));
 
-		// Initalize an empty vector for future dropped transfers
+		// Initialize an empty vector for future dropped transfers
 		let dropped: RefCell<Vec<Pinned<TransferToken>>> = RefCell::new(Vec::new());
 
 		vq_handler.enable_queue();

--- a/src/drivers/virtio/virtqueue/split.rs
+++ b/src/drivers/virtio/virtqueue/split.rs
@@ -470,10 +470,10 @@ impl SplitVq {
 				+ usize::try_from(notif_cfg.multiplier()).unwrap()) as *mut usize,
 		);
 
-		// Initalize new memory pool.
+		// Initialize new memory pool.
 		let mem_pool = Rc::new(MemPool::new(size));
 
-		// Initalize an empty vector for future dropped transfers
+		// Initialize an empty vector for future dropped transfers
 		let dropped: RefCell<Vec<Pinned<TransferToken>>> = RefCell::new(Vec::new());
 
 		vq_handler.enable_queue();


### PR DESCRIPTION
I hope this type of PR does not annoy you :) but I believe the correct spelling is [initial](https://www.oxfordlearnersdictionaries.com/spellcheck/english/?q=inital)