### PR TITLE
rename kernel target

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -3,7 +3,7 @@ build-std = ["core", "alloc"]
 build-std-features = ["compiler-builtins-mem"]
 
 [build]
-target = "x86_64-unknown-hermit-kernel"
+target = "x86_64-unknown-none-hermitkernel"
 
 [target.x86_64-unknown-hermit-kernel]
 runner = "tests/hermit_test_runner.py"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2021-02-11"
+channel = "nightly-2021-04-20"
 components = [ "rustfmt", "rust-src", "llvm-tools-preview"]

--- a/src/arch/x86_64/kernel/acpi.rs
+++ b/src/arch/x86_64/kernel/acpi.rs
@@ -412,7 +412,8 @@ fn parse_fadt(fadt: AcpiTable<'_>) {
 
 	// Map the "Differentiated System Description Table" (DSDT).
 	// TODO: This must not require "unsafe", see https://github.com/rust-lang/rust/issues/46043#issuecomment-393072398
-	let x_dsdt_field_address = unsafe { &fadt_table.x_dsdt as *const _ as usize };
+	let x_dsdt = core::ptr::addr_of!(fadt_table.x_dsdt);
+	let x_dsdt_field_address = unsafe { x_dsdt.read_unaligned() as usize };
 	let dsdt_address = if x_dsdt_field_address < fadt.table_end_address() && fadt_table.x_dsdt > 0 {
 		PhysAddr(fadt_table.x_dsdt)
 	} else {

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -233,13 +233,14 @@ fn detect_from_acpi() -> Result<PhysAddr, ()> {
 			1 => {
 				// I/O APIC
 				let ioapic_record = unsafe { &*(current_address as *const IoApicRecord) };
+				let ioapic_addr = core::ptr::addr_of!(ioapic_record.address);
 				debug!("Found I/O APIC record: {}", ioapic_record);
 
 				unsafe {
 					IOAPIC_ADDRESS = virtualmem::allocate(BasePageSize::SIZE).unwrap();
 					debug!(
 						"Mapping IOAPIC at {:#X} to virtual address {:#X}",
-						ioapic_record.address, IOAPIC_ADDRESS
+						ioapic_addr.read_unaligned(), IOAPIC_ADDRESS
 					);
 
 					let mut flags = PageTableEntryFlags::empty();

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -240,7 +240,8 @@ fn detect_from_acpi() -> Result<PhysAddr, ()> {
 					IOAPIC_ADDRESS = virtualmem::allocate(BasePageSize::SIZE).unwrap();
 					debug!(
 						"Mapping IOAPIC at {:#X} to virtual address {:#X}",
-						ioapic_addr.read_unaligned(), IOAPIC_ADDRESS
+						ioapic_addr.read_unaligned(),
+						IOAPIC_ADDRESS
 					);
 
 					let mut flags = PageTableEntryFlags::empty();


### PR DESCRIPTION
- rename kernel target to support the latest toolchain
- minor changes to avoid rust-lang/rust#82523
- add latest supported toolchain as default toolchain