### PR TITLE
switch to intel syntax for assembly code

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2021-05-11"
+channel = "nightly-2021-05-19"
 components = [ "rustfmt", "rust-src", "llvm-tools-preview"]

--- a/src/arch/x86_64/kernel/start.s
+++ b/src/arch/x86_64/kernel/start.s
@@ -14,10 +14,10 @@
 .align 16
 _start:
 	// initialize stack pointer
-	mov $0x7ff0,%rax
-	add 0x38(%rdi),%rax
-	mov %rax, %rsp
-	mov %rsp, %rbp
+	mov rax, 0x7ff0
+	add rax, [rdi+0x38]
+	mov rsp, rax
+	mov rbp, rsp
 
 	call pre_init
 
@@ -26,7 +26,7 @@ l1:
 
 .align 16
 task_start:
-	mov %rdx, %rsp
+	mov rsp, rdx
 	sti
 	jmp task_entry
 	jmp l1

--- a/src/arch/x86_64/kernel/switch.s
+++ b/src/arch/x86_64/kernel/switch.s
@@ -16,58 +16,58 @@ switch_to_task:
 	// rsi = new_stack => stack pointer of the new task
 
 	pushfq
-	push %rax
-	push %rcx
-	push %rdx
-	push %rbx
-	push %rbp
-	push %rsi
-	push %rdi
-	push %r8
-	push %r9
-	push %r10
-	push %r11
-	push %r12
-	push %r13
-	push %r14
-	push %r15
+	push rax
+	push rcx
+	push rdx
+	push rbx
+	push rbp
+	push rsi
+	push rdi
+	push r8
+	push r9
+	push r10
+	push r11
+	push r12
+	push r13
+	push r14
+	push r15
     // push fs registers
-	mov $0xc0000100, %ecx
+	mov ecx, 0xc0000100
 	rdmsr
-	sub $8, %rsp
-	mov %edx, 4(%rsp)
-	mov %eax, (%rsp)
+	sub rsp, 8
+	mov [rsp+4], edx
+	mov [rsp], eax
 	// store the old stack pointer in the dereferenced first parameter\n\t\
 	// and load the new stack pointer in the second parameter.\n\t\
-	mov %rsp, (%rdi)
-	mov %rsi, %rsp
+	mov [rdi], rsp
+	mov rsp, rsi
 	// Set task switched flag
-	mov %cr0, %rax
-	or $8, %rax
-	mov %rax, %cr0
+	mov rax, cr0
+	or rax, 8
+	mov cr0, rax
 	// set stack pointer in TSS
 	call set_current_kernel_stack
 	// restore context
-	mov $0xc0000100, %ecx
-	mov 4(%rsp), %edx
-	mov (%rsp), %eax
-	add $8, %rsp
+	mov ecx, 0xc0000100
+	mov edx, [rsp+4]
+	mov eax, [rsp]
+	add rsp, 8
 	wrmsr
-	pop %r15
-	pop %r14
-	pop %r13
-	pop %r12
-	pop %r11
-	pop %r10
-	pop %r9
-	pop %r8
-	pop %rdi
-	pop %rsi
-	pop %rbp
-	pop %rbx
-	pop %rdx
-	pop %rcx
-	pop %rax
+	pop r15
+	pop r14
+	pop r13
+	pop r12
+	pop r11
+	pop r10
+	pop r9
+	pop r8
+	pop rdi
+	pop rsi
+	pop rbp
+	pop rbx
+	pop rdx
+	pop rcx
+	pop rax
 	popfq
 	ret
 
@@ -81,53 +81,53 @@ switch_to_fpu_owner:
 
 	// store context
 	pushfq
-	push %rax
-	push %rcx
-	push %rdx
-	push %rbx
-	push %rbp
-	push %rsi
-	push %rdi
-	push %r8
-	push %r9
-	push %r10
-	push %r11
-	push %r12
-	push %r13
-	push %r14
-	push %r15
+	push rax
+	push rcx
+	push rdx
+	push rbx
+	push rbp
+	push rsi
+	push rdi
+	push r8
+	push r9
+	push r10
+	push r11
+	push r12
+	push r13
+	push r14
+	push r15
 	// push fs registers
-	mov $0xc0000100, %ecx
+	mov ecx, 0xc0000100
 	rdmsr
-	sub $8, %rsp
-	mov %edx, 4(%rsp)
-	mov %eax, (%rsp)
+	sub rsp, 8
+	mov [rsp+4], edx
+	mov [rsp], eax
 	// store the old stack pointer in the dereferenced first parameter\n\t\
 	// and load the new stack pointer in the second parameter.\n\t\
-	mov %rsp, (%rdi)
-	mov %rsi, %rsp
+	mov [rdi], rsp
+	mov rsp, rsi
 	// set stack pointer in TSS
 	call set_current_kernel_stack
 	// restore context
-	mov $0xc0000100, %ecx
-	mov 4(%rsp), %edx
-	mov (%rsp), %eax
-	add $8, %rsp
+	mov ecx, 0xc0000100
+	mov edx, [rsp+4]
+	mov eax, [rsp]
+	add rsp, 8
 	wrmsr
-	pop %r15
-	pop %r14
-	pop %r13
-	pop %r12
-	pop %r11
-	pop %r10
-	pop %r9
-	pop %r8
-	pop %rdi
-	pop %rsi
-	pop %rbp
-	pop %rbx
-	pop %rdx
-	pop %rcx
-	pop %rax
+	pop r15
+	pop r14
+	pop r13
+	pop r12
+	pop r11
+	pop r10
+	pop r9
+	pop r8
+	pop rdi
+	pop rsi
+	pop rbp
+	pop rbx
+	pop rdx
+	pop rcx
+	pop rax
 	popfq
 	ret

--- a/src/arch/x86_64/kernel/switch_fsgsbase.s
+++ b/src/arch/x86_64/kernel/switch_fsgsbase.s
@@ -16,52 +16,52 @@ switch_to_task:
 	// rsi = new_stack => stack pointer of the new task
 
 	pushfq
-	push %rax
-	push %rcx
-	push %rdx
-	push %rbx
-	push %rbp
-	push %rsi
-	push %rdi
-	push %r8
-	push %r9
-	push %r10
-	push %r11
-	push %r12
-	push %r13
-	push %r14
-	push %r15
+	push rax
+	push rcx
+	push rdx
+	push rbx
+	push rbp
+	push rsi
+	push rdi
+	push r8
+	push r9
+	push r10
+	push r11
+	push r12
+	push r13
+	push r14
+	push r15
     // push fs registers
-	rdfsbaseq %rax
-	push %rax
+	rdfsbaseq rax
+	push rax
 	// store the old stack pointer in the dereferenced first parameter\n\t\
 	// and load the new stack pointer in the second parameter.\n\t\
-	mov %rsp, (%rdi)
-	mov %rsi, %rsp
+	mov [rdi], rsp
+	mov rsp, rsi
 	// Set task switched flag
-	mov %cr0, %rax
-	or $8, %rax
-	mov %rax, %cr0
+	mov rax, cr0
+	or rax, 8
+	mov cr0, rax
 	// set stack pointer in TSS
 	call set_current_kernel_stack
 	// restore context
-	pop %rax
-	wrfsbaseq %rax
-	pop %r15
-	pop %r14
-	pop %r13
-	pop %r12
-	pop %r11
-	pop %r10
-	pop %r9
-	pop %r8
-	pop %rdi
-	pop %rsi
-	pop %rbp
-	pop %rbx
-	pop %rdx
-	pop %rcx
-	pop %rax
+	pop rax
+	wrfsbaseq rax
+	pop r15
+	pop r14
+	pop r13
+	pop r12
+	pop r11
+	pop r10
+	pop r9
+	pop r8
+	pop rdi
+	pop rsi
+	pop rbp
+	pop rbx
+	pop rdx
+	pop rcx
+	pop rax
 	popfq
 	ret
 
@@ -75,47 +75,47 @@ switch_to_fpu_owner:
 
 	// store context
 	pushfq
-	push %rax
-	push %rcx
-	push %rdx
-	push %rbx
-	push %rbp
-	push %rsi
-	push %rdi
-	push %r8
-	push %r9
-	push %r10
-	push %r11
-	push %r12
-	push %r13
-	push %r14
-	push %r15
+	push rax
+	push rcx
+	push rdx
+	push rbx
+	push rbp
+	push rsi
+	push rdi
+	push r8
+	push r9
+	push r10
+	push r11
+	push r12
+	push r13
+	push r14
+	push r15
 	// push fs registers
-	rdfsbaseq %rax
-	push %rax
+	rdfsbaseq rax
+	push rax
 	// store the old stack pointer in the dereferenced first parameter\n\t\
 	// and load the new stack pointer in the second parameter.\n\t\
-	mov %rsp, (%rdi)
-	mov %rsi, %rsp
+	mov [rdi], rsp
+	mov rsp, rsi
 	// set stack pointer in TSS
 	call set_current_kernel_stack
 	// restore context
-	pop %rax
-	wrfsbaseq %rax
-	pop %r15
-	pop %r14
-	pop %r13
-	pop %r12
-	pop %r11
-	pop %r10
-	pop %r9
-	pop %r8
-	pop %rdi
-	pop %rsi
-	pop %rbp
-	pop %rbx
-	pop %rdx
-	pop %rcx
-	pop %rax
+	pop rax
+	wrfsbaseq rax
+	pop r15
+	pop r14
+	pop r13
+	pop r12
+	pop r11
+	pop r10
+	pop r9
+	pop r8
+	pop rdi
+	pop rsi
+	pop rbp
+	pop rbx
+	pop rdx
+	pop rcx
+	pop rax
 	popfq
 	ret


### PR DESCRIPTION
global_asm switch per default to the intel syntax, because the behaviour is than similiar to inline assembly. libhermit-rs follow this step and switch to the same default syntax.

See also rust-lang/rust#84107