### PR TITLE
Enable bench_black_box for basic_math test

### DIFF
--- a/tests/basic_math.rs
+++ b/tests/basic_math.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![feature(bench_black_box)]
 #![no_std]
 #![no_main]
 #![test_runner(common::test_case_runner)]


### PR DESCRIPTION
Fixes
```
error[E0658]: use of unstable library feature 'bench_black_box'
  --> tests/basic_math.rs:18:5
   |
18 | use core::hint::black_box;
   |     ^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #64102 <https://github.com/rust-lang/rust/issues/64102> for more information
   = help: add `#![feature(bench_black_box)]` to the crate attributes to enable
```
when building tests.