### PR TITLE
Fix clippy errors

### DIFF
--- a/src/drivers/net/rtl8139.rs
+++ b/src/drivers/net/rtl8139.rs
@@ -522,10 +522,7 @@ pub fn init_device(adapter: &pci::PciAdapter) -> Result<RTL8139Driver, DriverErr
 		// set each of the transmitter start address descriptors
 		outl(
 			iobase + TSAD0,
-			virt_to_phys(txbuffer + 0 * TX_BUF_LEN)
-				.as_u64()
-				.try_into()
-				.unwrap(),
+			virt_to_phys(txbuffer).as_u64().try_into().unwrap(),
 		);
 		outl(
 			iobase + TSAD1,

--- a/src/drivers/net/virtio_net.rs
+++ b/src/drivers/net/virtio_net.rs
@@ -246,14 +246,7 @@ impl RxQueues {
 				BuffSpec::Single(Bytes::new(mem::size_of::<VirtioNetHdr>() + 65550).unwrap())
 			};
 
-			let num_buff: u16 = if dev_cfg
-				.features
-				.is_feature(Features::VIRTIO_F_RING_INDIRECT_DESC)
-			{
-				vq.size().into()
-			} else {
-				vq.size().into()
-			};
+			let num_buff: u16 = vq.size().into();
 
 			for _ in 0..num_buff {
 				let buff_tkn = match vq.prep_buffer(Rc::clone(vq), None, Some(spec.clone())) {
@@ -288,14 +281,7 @@ impl RxQueues {
 				BuffSpec::Single(Bytes::new(mem::size_of::<VirtioNetHdr>() + 1514).unwrap())
 			};
 
-			let num_buff: u16 = if dev_cfg
-				.features
-				.is_feature(Features::VIRTIO_F_RING_INDIRECT_DESC)
-			{
-				vq.size().into()
-			} else {
-				vq.size().into()
-			};
+			let num_buff: u16 = vq.size().into();
 
 			for _ in 0..num_buff {
 				let buff_tkn = match vq.prep_buffer(Rc::clone(vq), None, Some(spec.clone())) {

--- a/src/drivers/net/virtio_net.rs
+++ b/src/drivers/net/virtio_net.rs
@@ -786,33 +786,27 @@ impl VirtioNetDriver {
 		mut caps_coll: UniCapsColl,
 		adapter: &PciAdapter,
 	) -> Result<Self, error::VirtioNetError> {
-		let com_cfg = loop {
-			match caps_coll.get_com_cfg() {
-				Some(com_cfg) => break com_cfg,
-				None => {
-					error!("No common config. Aborting!");
-					return Err(error::VirtioNetError::NoComCfg(adapter.device_id));
-				}
+		let com_cfg = match caps_coll.get_com_cfg() {
+			Some(com_cfg) => com_cfg,
+			None => {
+				error!("No common config. Aborting!");
+				return Err(error::VirtioNetError::NoComCfg(adapter.device_id));
 			}
 		};
 
-		let isr_stat = loop {
-			match caps_coll.get_isr_cfg() {
-				Some(isr_stat) => break isr_stat,
-				None => {
-					error!("No ISR status config. Aborting!");
-					return Err(error::VirtioNetError::NoIsrCfg(adapter.device_id));
-				}
+		let isr_stat = match caps_coll.get_isr_cfg() {
+			Some(isr_stat) => isr_stat,
+			None => {
+				error!("No ISR status config. Aborting!");
+				return Err(error::VirtioNetError::NoIsrCfg(adapter.device_id));
 			}
 		};
 
-		let notif_cfg = loop {
-			match caps_coll.get_notif_cfg() {
-				Some(notif_cfg) => break notif_cfg,
-				None => {
-					error!("No notif config. Aborting!");
-					return Err(error::VirtioNetError::NoNotifCfg(adapter.device_id));
-				}
+		let notif_cfg = match caps_coll.get_notif_cfg() {
+			Some(notif_cfg) => notif_cfg,
+			None => {
+				error!("No notif config. Aborting!");
+				return Err(error::VirtioNetError::NoNotifCfg(adapter.device_id));
 			}
 		};
 

--- a/src/drivers/virtio/virtqueue/packed.rs
+++ b/src/drivers/virtio/virtqueue/packed.rs
@@ -571,12 +571,7 @@ impl<'a> ReadCtrl<'a> {
 	) {
 		match (send_buff, recv_buff_spec) {
 			(Some(send_buff), Some((recv_buff, mut write_len))) => {
-				// This is perfectly fine as we operate on two different datastructures inside one datastructure
-				// we can have two mutable references via the same wrapping datastructure
-				let ctrl_desc = unsafe {
-					let raw_ref = &mut *((send_buff as *const Buffer) as *mut Buffer);
-					raw_ref.get_ctrl_desc_mut().unwrap()
-				};
+				let ctrl_desc = send_buff.get_ctrl_desc_mut().unwrap();
 
 				// This should read the descriptors inside the ctrl desc memory and update the memory
 				// accordingly
@@ -613,12 +608,7 @@ impl<'a> ReadCtrl<'a> {
 				}
 			}
 			(Some(send_buff), None) => {
-				// This is perfectly fine as we operate on two different datastructures inside one datastructure
-				// we can have two mutable references via the same wrapping datastructure
-				let ctrl_desc = unsafe {
-					let raw_ref = &mut *((send_buff as *const Buffer) as *mut Buffer);
-					raw_ref.get_ctrl_desc_mut().unwrap()
-				};
+				let ctrl_desc = send_buff.get_ctrl_desc_mut().unwrap();
 
 				// This should read the descriptors inside the ctrl desc memory and update the memory
 				// accordingly
@@ -638,12 +628,7 @@ impl<'a> ReadCtrl<'a> {
 				}
 			}
 			(None, Some((recv_buff, mut write_len))) => {
-				// This is perfectly fine as we operate on two different datastructures inside one datastructure
-				// we can have two mutable references via the same wrapping datastructure
-				let ctrl_desc = unsafe {
-					let raw_ref = &mut *((recv_buff as *const Buffer) as *mut Buffer);
-					raw_ref.get_ctrl_desc_mut().unwrap()
-				};
+				let ctrl_desc = recv_buff.get_ctrl_desc_mut().unwrap();
 
 				// This should read the descriptors inside the ctrl desc memory and update the memory
 				// accordingly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@
  * and Eric Kidd's toy OS (https://github.com/emk/toyos-rs).
  */
 
-#![warn(clippy::all)]
 #![allow(clippy::redundant_field_names)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::needless_range_loop)]


### PR DESCRIPTION
We currently set `clippy::all` to `warn`. Some lints from `clippy::all` are `deny` by default. This removes our relaxation and fixes all errors.

What do you think?