### PR TITLE
virtqueue: Fix using send buffer as recieve buffer

### DIFF
--- a/src/drivers/virtio/virtqueue/mod.rs
+++ b/src/drivers/virtio/virtqueue/mod.rs
@@ -795,7 +795,7 @@ impl Transfer {
 					.buff_tkn
 					.as_ref()
 					.unwrap()
-					.send_buff
+					.recv_buff
 					.as_ref()
 					.map(Buffer::scat_cpy);
 
@@ -843,7 +843,7 @@ impl Transfer {
 					.buff_tkn
 					.as_ref()
 					.unwrap()
-					.send_buff
+					.recv_buff
 					.as_ref()
 					.map(Buffer::cpy);
 


### PR DESCRIPTION
While working on more clippy lints, I noticed something that seems to by an issue caused by copy-pasting.

We surely don't want to treat send buffers as receive buffers, right?