### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -71,9 +71,9 @@ pub use crate::arch::x86_64::kernel::{
 };
 
 #[cfg(test)]
-pub fn switch_to_task(_old_stack: *mut usize, _new_stack: usize) {}
+pub unsafe fn switch_to_task(_old_stack: *mut usize, _new_stack: usize) {}
 #[cfg(test)]
-pub fn switch_to_fpu_owner(_old_stack: *mut usize, _new_stack: usize) {}
+pub unsafe fn switch_to_fpu_owner(_old_stack: *mut usize, _new_stack: usize) {}
 
 #[cfg(not(test))]
 extern "C" {

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -593,9 +593,9 @@ pub fn boot_application_processors() {
 		// Set entry point
 		debug!(
 			"Set entry point for application processor to 0x{:x}",
-			_start as u64
+			_start as usize
 		);
-		*((SMP_BOOT_CODE_ADDRESS + SMP_BOOT_CODE_OFFSET_ENTRY).as_mut_ptr()) = _start as u64;
+		*((SMP_BOOT_CODE_ADDRESS + SMP_BOOT_CODE_OFFSET_ENTRY).as_mut_ptr()) = _start as usize;
 		*((SMP_BOOT_CODE_ADDRESS + SMP_BOOT_CODE_OFFSET_BOOTINFO).as_mut_ptr()) = BOOT_INFO as u64;
 	}
 

--- a/src/arch/x86_64/kernel/fuse.rs
+++ b/src/arch/x86_64/kernel/fuse.rs
@@ -110,6 +110,12 @@ impl Fuse {
 	}
 }
 
+impl Default for Fuse {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
 struct FuseFile {
 	fuse_nid: Option<u64>,
 	fuse_fh: Option<u64>,

--- a/src/arch/x86_64/kernel/fuse.rs
+++ b/src/arch/x86_64/kernel/fuse.rs
@@ -654,7 +654,7 @@ fn str_into_u8buf(s: &str, u8buf: &mut [u8]) {
 // TODO: max path length?
 const MAX_PATH_LEN: usize = 256;
 fn str_to_path(s: &str) -> [u8; MAX_PATH_LEN] {
-	let mut buf = [0 as u8; MAX_PATH_LEN];
+	let mut buf = [0; MAX_PATH_LEN];
 	str_into_u8buf(s, &mut buf);
 	buf
 }

--- a/src/arch/x86_64/kernel/scheduler.rs
+++ b/src/arch/x86_64/kernel/scheduler.rs
@@ -369,8 +369,8 @@ impl TaskFrame for Task {
 			if let Some(tls) = &self.tls {
 				(*state).fs = tls.get_fs().as_u64();
 			}
-			(*state).rip = task_start as u64;
-			(*state).rdi = func as u64;
+			(*state).rip = task_start as usize as u64;
+			(*state).rdi = func as usize as u64;
 			(*state).rsi = arg as u64;
 
 			// per default we disable interrupts

--- a/src/arch/x86_64/mm/physicalmem.rs
+++ b/src/arch/x86_64/mm/physicalmem.rs
@@ -5,8 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use core::convert::TryInto;
 use core::sync::atomic::{AtomicUsize, Ordering};
+use core::{alloc::AllocError, convert::TryInto};
 use multiboot::information::{MemoryType, Multiboot};
 
 use crate::arch::x86_64::kernel::{get_limit, get_mbinfo};
@@ -98,7 +98,7 @@ pub fn total_memory_size() -> usize {
 	TOTAL_MEMORY.load(Ordering::SeqCst)
 }
 
-pub fn allocate(size: usize) -> Result<PhysAddr, ()> {
+pub fn allocate(size: usize) -> Result<PhysAddr, AllocError> {
 	assert!(size > 0);
 	assert_eq!(
 		size % BasePageSize::SIZE,
@@ -117,7 +117,7 @@ pub fn allocate(size: usize) -> Result<PhysAddr, ()> {
 	))
 }
 
-pub fn allocate_aligned(size: usize, alignment: usize) -> Result<PhysAddr, ()> {
+pub fn allocate_aligned(size: usize, alignment: usize) -> Result<PhysAddr, AllocError> {
 	assert!(size > 0);
 	assert!(alignment > 0);
 	assert_eq!(

--- a/src/arch/x86_64/mm/virtualmem.rs
+++ b/src/arch/x86_64/mm/virtualmem.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use core::convert::TryInto;
+use core::{alloc::AllocError, convert::TryInto};
 
 use crate::arch::x86_64::mm::paging::{BasePageSize, PageSize};
 use crate::arch::x86_64::mm::VirtAddr;
@@ -23,7 +23,7 @@ pub fn init() {
 	KERNEL_FREE_LIST.lock().list.push_back(entry);
 }
 
-pub fn allocate(size: usize) -> Result<VirtAddr, ()> {
+pub fn allocate(size: usize) -> Result<VirtAddr, AllocError> {
 	assert!(size > 0);
 	assert_eq!(
 		size % BasePageSize::SIZE,
@@ -42,7 +42,7 @@ pub fn allocate(size: usize) -> Result<VirtAddr, ()> {
 	))
 }
 
-pub fn allocate_aligned(size: usize, alignment: usize) -> Result<VirtAddr, ()> {
+pub fn allocate_aligned(size: usize, alignment: usize) -> Result<VirtAddr, AllocError> {
 	assert!(size > 0);
 	assert!(alignment > 0);
 	assert_eq!(

--- a/src/drivers/net/mod.rs
+++ b/src/drivers/net/mod.rs
@@ -114,10 +114,7 @@ pub fn netwait(handle: usize, millis: Option<u64>) {
 	if is_polling {
 		set_polling_mode(true);
 	} else {
-		let wakeup_time = match millis {
-			Some(ms) => Some(crate::arch::processor::get_timer_ticks() + ms * 1000),
-			_ => None,
-		};
+		let wakeup_time = millis.map(|ms| crate::arch::processor::get_timer_ticks() + ms * 1000);
 		let mut guard = NIC_QUEUE.lock();
 		let core_scheduler = core_scheduler();
 

--- a/src/drivers/net/mod.rs
+++ b/src/drivers/net/mod.rs
@@ -85,7 +85,7 @@ pub fn netwait_and_wakeup(handles: &[usize], millis: Option<u64>) {
 	let mut reset_nic = false;
 
 	// check if the driver should be in the polling mode
-	while POLLING.swap(false, Ordering::SeqCst) == true {
+	while POLLING.swap(false, Ordering::SeqCst) {
 		reset_nic = true;
 
 		let core_scheduler = core_scheduler();

--- a/src/drivers/net/virtio_net.rs
+++ b/src/drivers/net/virtio_net.rs
@@ -915,7 +915,7 @@ impl VirtioNetDriver {
 							error!("Device features set, does not satisfy minimal features needed. Aborting!");
 							return Err(VirtioNetError::FailFeatureNeg(self.dev_cfg.dev_id));
 						} else {
-							feats = match Features::into_features(dev_feats & drv_feats) {
+							feats = match Features::from_set(dev_feats & drv_feats) {
 								Some(feats) => feats,
 								None => {
 									error!("Feature negotiation failed with minimal feature set. Aborting!");
@@ -1551,7 +1551,7 @@ mod constants {
 		/// INFO: In case the FEATURES enum is changed, this function MUST also be adjusted to the new set!
 		//
 		// Really UGLY function, but currently the most convenienvt one to reduce the set of features for the driver easily!
-		pub fn into_features(feat_set: FeatureSet) -> Option<Vec<Features>> {
+		pub fn from_set(feat_set: FeatureSet) -> Option<Vec<Features>> {
 			let mut vec_of_feats: Vec<Features> = Vec::new();
 			let feats = feat_set.0;
 

--- a/src/drivers/net/virtio_net.rs
+++ b/src/drivers/net/virtio_net.rs
@@ -984,7 +984,7 @@ impl VirtioNetDriver {
 
 	/// Negotiates a subset of features, understood and wanted by both the OS
 	/// and the device.
-	fn negotiate_features(&mut self, wanted_feats: &Vec<Features>) -> Result<(), VirtioNetError> {
+	fn negotiate_features(&mut self, wanted_feats: &[Features]) -> Result<(), VirtioNetError> {
 		let mut drv_feats = FeatureSet::new(0);
 
 		for feat in wanted_feats.iter() {
@@ -995,7 +995,7 @@ impl VirtioNetDriver {
 
 		// Checks if the selected feature set is compatible with requirements for
 		// features according to Virtio spec. v1.1 - 5.1.3.1.
-		match FeatureSet::check_features(&wanted_feats) {
+		match FeatureSet::check_features(wanted_feats) {
 			Ok(_) => {
 				info!("Feature set wanted by network driver are in conformance with specification.")
 			}
@@ -1757,7 +1757,7 @@ mod constants {
 		/// wraps the u64 indicating the feature set.
 		///
 		/// INFO: Iterates twice over the vector of features.
-		pub fn check_features(feats: &Vec<Features>) -> Result<(), VirtioNetError> {
+		pub fn check_features(feats: &[Features]) -> Result<(), VirtioNetError> {
 			let mut feat_bits = 0u64;
 
 			for feat in feats.iter() {
@@ -1906,9 +1906,8 @@ mod constants {
 
 		/// Sets features contained in feats to true.
 		///
-		/// WARN: Features should be checked before using this function via the
-		/// `FeatureSet::check_features(feats: Vec<Features>) -> Result<(), VirtioNetError>` function.
-		pub fn set_features(&mut self, feats: &Vec<Features>) {
+		/// WARN: Features should be checked before using this function via the [`check_features`] function.
+		pub fn set_features(&mut self, feats: &[Features]) {
 			for feat in feats {
 				self.0 |= *feat;
 			}

--- a/src/drivers/net/virtio_net.rs
+++ b/src/drivers/net/virtio_net.rs
@@ -1050,8 +1050,6 @@ impl VirtioNetDriver {
 					VqIndex::from(self.num_vqs),
 					self.dev_cfg.features.into(),
 				))));
-
-				self.ctrl_vq.0.as_ref().unwrap().enable_notifs();
 			} else {
 				self.ctrl_vq = CtrlQueue(Some(Rc::new(Virtq::new(
 					&mut self.com_cfg,
@@ -1061,9 +1059,9 @@ impl VirtioNetDriver {
 					VqIndex::from(self.num_vqs),
 					self.dev_cfg.features.into(),
 				))));
-
-				self.ctrl_vq.0.as_ref().unwrap().enable_notifs();
 			}
+
+			self.ctrl_vq.0.as_ref().unwrap().enable_notifs();
 		}
 
 		// If device does not take care of MAC address, the driver has to create one

--- a/src/drivers/net/virtio_net.rs
+++ b/src/drivers/net/virtio_net.rs
@@ -877,7 +877,7 @@ impl VirtioNetDriver {
 
 		let mut min_feat_set = FeatureSet::new(0);
 		min_feat_set.set_features(&min_feats);
-		let mut feats: Vec<Features> = Vec::from(min_feats);
+		let mut feats: Vec<Features> = min_feats;
 
 		// If wanted, push new features into feats here:
 		//

--- a/src/drivers/net/virtio_net.rs
+++ b/src/drivers/net/virtio_net.rs
@@ -324,23 +324,12 @@ impl RxQueues {
 	}
 
 	fn get_next(&mut self) -> Option<Transfer> {
-		let transfer = match self.poll_queue.borrow_mut().pop_front() {
-			Some(transfer) => Some(transfer),
-			None => None,
-		};
+		self.poll_queue.borrow_mut().pop_front().or_else(|| {
+			// Check if any not yet provided transfers are in the queue.
+			self.poll();
 
-		match transfer {
-			Some(transfer) => Some(transfer),
-			None => {
-				// Check if any not yet provided transfers are in the queue.
-				self.poll();
-
-				match self.poll_queue.borrow_mut().pop_front() {
-					Some(transfer) => Some(transfer),
-					None => None,
-				}
-			}
-		}
+			self.poll_queue.borrow_mut().pop_front()
+		})
 	}
 
 	fn poll(&self) {

--- a/src/drivers/virtio/depr/virtio.rs
+++ b/src/drivers/virtio/depr/virtio.rs
@@ -5,6 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+#![allow(clippy::vec_box)]
+
 use crate::arch::kernel::pci::{self, PciAdapter};
 
 use crate::arch::mm::paging;

--- a/src/drivers/virtio/depr/virtio.rs
+++ b/src/drivers/virtio/depr/virtio.rs
@@ -14,10 +14,10 @@ use crate::config::VIRTIO_MAX_QUEUE_SIZE;
 use alloc::boxed::Box;
 use alloc::rc::Rc;
 use alloc::vec::Vec;
-use core::cell::RefCell;
 use core::convert::TryInto;
 use core::hint::spin_loop;
 use core::sync::atomic::{fence, Ordering};
+use core::{cell::RefCell, ptr};
 
 use self::consts::*;
 
@@ -502,7 +502,7 @@ struct VirtqDescriptorChain(Vec<VirtqDescriptor>);
 // Two descriptor chains are equal, if memory address of vec is equal.
 impl PartialEq for VirtqDescriptorChain {
 	fn eq(&self, other: &Self) -> bool {
-		&self.0 as *const _ == &other.0 as *const _
+		ptr::eq(&self.0, &other.0)
 	}
 }
 

--- a/src/drivers/virtio/depr/virtio.rs
+++ b/src/drivers/virtio/depr/virtio.rs
@@ -128,8 +128,8 @@ impl<'a> Virtq<'a> {
 		let desc_table = desc_table.into_boxed_slice();
 		// We need to be careful not to overflow the stack here. Use into_boxed_slice to get safe heap mem of desired sizes
 		// init it as u16 to make casting to first to u16 elements easy. Need to divide by 2 compared to size in spec
-		let avail_mem_box = vec![0 as u16; (6 + 2 * vqsize) >> 1].into_boxed_slice(); // has to be 2 byte aligned
-		let used_mem_box = vec![0 as u16; (6 + 8 * vqsize) >> 1].into_boxed_slice(); // has to be 4 byte aligned
+		let avail_mem_box = vec![0; (6 + 2 * vqsize) >> 1].into_boxed_slice(); // has to be 2 byte aligned
+		let used_mem_box = vec![0; (6 + 8 * vqsize) >> 1].into_boxed_slice(); // has to be 4 byte aligned
 
 		// Leak memory so it wont get deallocated
 		// TODO: create appropriate mem-owner-model. Pin these?

--- a/src/drivers/virtio/depr/virtio_net.rs
+++ b/src/drivers/virtio/depr/virtio_net.rs
@@ -399,7 +399,7 @@ impl<'a> VirtioNetDriver<'a> {
 		let mut buffers = &mut self.tx_buffers;
 
 		// do we have free buffers?
-		if buffers.iter().position(|b| !b.in_use).is_none() {
+		if !buffers.iter().any(|b| !b.in_use) {
 			// if not, check if we are able to free used elements
 			self.check_used_elements();
 		}

--- a/src/drivers/virtio/mod.rs
+++ b/src/drivers/virtio/mod.rs
@@ -79,13 +79,13 @@ pub mod features {
 
 	impl PartialEq<Features> for u64 {
 		fn eq(&self, other: &Features) -> bool {
-			*self == u64::from(*other)
+			self == other
 		}
 	}
 
 	impl PartialEq<u64> for Features {
 		fn eq(&self, other: &u64) -> bool {
-			u64::from(*self) == *other
+			self == other
 		}
 	}
 

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -253,7 +253,7 @@ impl Eq for PciCapRaw {}
 // In order to compare two PciCapRaw structs PartialEq is needed
 impl PartialEq for PciCapRaw {
 	fn eq(&self, other: &Self) -> bool {
-		if self.cap_vndr == other.cap_vndr
+		self.cap_vndr == other.cap_vndr
 			&& self.cap_next == other.cap_next
 			&& self.cap_len == other.cap_len
 			&& self.cfg_type == other.cfg_type
@@ -261,11 +261,6 @@ impl PartialEq for PciCapRaw {
 			&& self.id == other.id
 			&& self.offset == other.offset
 			&& self.length == other.length
-		{
-			true
-		} else {
-			false
-		}
 	}
 }
 

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -666,7 +666,7 @@ impl NotifCfg {
 		// See Virtio specification v1.1. - 4.1.4.4
 		//
 		// Base address here already includes offset!
-		let base_addr = VirtMemAddr::from(cap.bar.mem_addr + cap.offset);
+		let base_addr = cap.bar.mem_addr + cap.offset;
 
 		Some(NotifCfg {
 			base_addr: base_addr,

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -714,7 +714,7 @@ impl NotifCtrl {
 		if self.f_notif_data {
 			unsafe {
 				let notif_area = core::slice::from_raw_parts_mut(self.notif_addr as *mut u8, 4);
-				let mut notif_data = notif_data.into_iter();
+				let mut notif_data = notif_data.iter();
 
 				for byte in notif_area {
 					*byte = *notif_data.next().unwrap();
@@ -723,7 +723,7 @@ impl NotifCtrl {
 		} else {
 			unsafe {
 				let notif_area = core::slice::from_raw_parts_mut(self.notif_addr as *mut u8, 2);
-				let mut notif_data = notif_data.into_iter();
+				let mut notif_data = notif_data.iter();
 
 				for byte in notif_area {
 					*byte = *notif_data.next().unwrap();

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -1080,11 +1080,9 @@ fn read_caps(adapter: &PciAdapter, bars: Vec<PciBar>) -> Result<Vec<PciCap>, Pci
 						Some(bar) => {
 							// Drivers MUST ignore BAR values different then specified in Virtio spec v1.1. - 4.1.4
 							// See Virtio specification v1.1. - 4.1.4.1
-							if bar.index <= 5 {
-								if bar.index == cap_raw.bar_index {
-									// Need to clone here as every PciCap carrys it's bar
-									break bar.clone();
-								}
+							if bar.index <= 5 && bar.index == cap_raw.bar_index {
+								// Need to clone here as every PciCap carrys it's bar
+								break bar.clone();
 							}
 						}
 						None => {

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -422,12 +422,11 @@ impl<'a> VqCfgHandler<'a> {
 	pub fn set_vq_size(&mut self, size: u16) -> u16 {
 		self.raw.queue_select = self.vq_index;
 
-		if self.raw.queue_size < size {
-			self.raw.queue_size
-		} else {
+		if self.raw.queue_size >= size {
 			self.raw.queue_size = size;
-			self.raw.queue_size
 		}
+
+		self.raw.queue_size
 	}
 
 	pub fn set_ring_addr(&mut self, addr: PhysAddr) {

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -1076,8 +1076,7 @@ fn read_caps(adapter: &PciAdapter, bars: Vec<PciBar>) -> Result<Vec<PciCap>, Pci
 							// Drivers MUST ignore BAR values different then specified in Virtio spec v1.1. - 4.1.4
 							// See Virtio specification v1.1. - 4.1.4.1
 							if bar.index <= 5 && bar.index == cap_raw.bar_index {
-								// Need to clone here as every PciCap carrys it's bar
-								break bar.clone();
+								break *bar;
 							}
 						}
 						None => {

--- a/src/drivers/virtio/virtqueue/mod.rs
+++ b/src/drivers/virtio/virtqueue/mod.rs
@@ -16,6 +16,7 @@
 //! use the respective virtqueue structs directly.
 #![allow(dead_code)]
 #![allow(unused)]
+#![allow(clippy::type_complexity)]
 
 pub mod packed;
 pub mod split;

--- a/src/drivers/virtio/virtqueue/mod.rs
+++ b/src/drivers/virtio/virtqueue/mod.rs
@@ -144,7 +144,7 @@ impl Virtq {
 	///
 	/// Structures provided to the Queue must pass this test, otherwise the queue
 	/// currently panics.
-	pub fn check_bounds<T: AsSliceU8>(data: Box<T>) -> bool {
+	pub fn check_bounds<T: AsSliceU8>(data: &T) -> bool {
 		let slice = data.as_slice_u8();
 
 		let start_virt = (&slice[0] as *const u8) as usize;

--- a/src/drivers/virtio/virtqueue/mod.rs
+++ b/src/drivers/virtio/virtqueue/mod.rs
@@ -48,9 +48,9 @@ impl From<u16> for VqIndex {
 	}
 }
 
-impl Into<u16> for VqIndex {
-	fn into(self) -> u16 {
-		self.0
+impl From<VqIndex> for u16 {
+	fn from(i: VqIndex) -> Self {
+		i.0
 	}
 }
 

--- a/src/drivers/virtio/virtqueue/mod.rs
+++ b/src/drivers/virtio/virtqueue/mod.rs
@@ -2829,7 +2829,7 @@ impl BitAnd<DescrFlags> for u16 {
 
 impl PartialEq<DescrFlags> for u16 {
 	fn eq(&self, other: &DescrFlags) -> bool {
-		*self == u16::from(*other)
+		self == other
 	}
 }
 

--- a/src/drivers/virtio/virtqueue/mod.rs
+++ b/src/drivers/virtio/virtqueue/mod.rs
@@ -788,7 +788,7 @@ impl Transfer {
 		match &self.transfer_tkn.as_ref().unwrap().state {
 			TransferState::Finished => {
 				// Unwrapping is okay here, as TransferToken must hold a BufferToken
-				let send_data = match &self
+				let send_data = self
 					.transfer_tkn
 					.as_ref()
 					.unwrap()
@@ -796,12 +796,10 @@ impl Transfer {
 					.as_ref()
 					.unwrap()
 					.send_buff
-				{
-					Some(buff) => Some(buff.scat_cpy()),
-					None => None,
-				};
+					.as_ref()
+					.map(Buffer::scat_cpy);
 
-				let recv_data = match &self
+				let recv_data = self
 					.transfer_tkn
 					.as_ref()
 					.unwrap()
@@ -809,10 +807,8 @@ impl Transfer {
 					.as_ref()
 					.unwrap()
 					.send_buff
-				{
-					Some(buff) => Some(buff.scat_cpy()),
-					None => None,
-				};
+					.as_ref()
+					.map(Buffer::scat_cpy);
 
 				Ok((send_data, recv_data))
 			}
@@ -840,7 +836,7 @@ impl Transfer {
 		match &self.transfer_tkn.as_ref().unwrap().state {
 			TransferState::Finished => {
 				// Unwrapping is okay here, as TransferToken must hold a BufferToken
-				let send_data = match &self
+				let send_data = self
 					.transfer_tkn
 					.as_ref()
 					.unwrap()
@@ -848,12 +844,10 @@ impl Transfer {
 					.as_ref()
 					.unwrap()
 					.send_buff
-				{
-					Some(buff) => Some(buff.cpy()),
-					None => None,
-				};
+					.as_ref()
+					.map(Buffer::cpy);
 
-				let recv_data = match &self
+				let recv_data = self
 					.transfer_tkn
 					.as_ref()
 					.unwrap()
@@ -861,10 +855,8 @@ impl Transfer {
 					.as_ref()
 					.unwrap()
 					.send_buff
-				{
-					Some(buff) => Some(buff.cpy()),
-					None => None,
-				};
+					.as_ref()
+					.map(Buffer::cpy);
 
 				Ok((send_data, recv_data))
 			}

--- a/src/drivers/virtio/virtqueue/packed.rs
+++ b/src/drivers/virtio/virtqueue/packed.rs
@@ -24,10 +24,10 @@ use alloc::boxed::Box;
 use alloc::collections::VecDeque;
 use alloc::rc::Rc;
 use alloc::vec::Vec;
-use core::cell::RefCell;
 use core::convert::TryFrom;
 use core::ops::Deref;
 use core::sync::atomic::{fence, Ordering};
+use core::{cell::RefCell, ptr};
 
 /// A newtype of bool used for convenience in context with
 /// packed queues wrap counter.
@@ -126,7 +126,7 @@ impl DescriptorRing {
 		// Descriptor ID's run from 1 to size_of_queue. In order to index directly into the
 		// refernece ring via an ID it is much easier to simply have an array of size = size_of_queue + 1
 		// and do not care about the first element beeing unused.
-		let tkn_ref_ring = vec![0usize as *mut TransferToken; size + 1].into_boxed_slice();
+		let tkn_ref_ring = vec![ptr::null_mut(); size + 1].into_boxed_slice();
 
 		DescriptorRing {
 			ring,

--- a/src/drivers/virtio/virtqueue/packed.rs
+++ b/src/drivers/virtio/virtqueue/packed.rs
@@ -54,11 +54,7 @@ impl WrapCount {
 	/// If WrapCount(true) returns WrapCount(false),
 	/// if WrapCount(false) returns WrapCount(true).
 	fn wrap(&mut self) {
-		if self.0 == false {
-			self.0 = true;
-		} else {
-			self.0 = false;
-		}
+		self.0 = !self.0
 	}
 
 	/// Creates avail and used flags inside u16 in accordance to the
@@ -67,7 +63,7 @@ impl WrapCount {
 	/// I.e.: Set avail flag to match the WrapCount and the used flag
 	/// to NOT match the WrapCount.
 	fn as_flags_avail(&self) -> u16 {
-		if self.0 == true {
+		if self.0 {
 			1 << 7
 		} else {
 			1 << 15
@@ -80,7 +76,7 @@ impl WrapCount {
 	/// I.e.: Set avail flag to match the WrapCount and the used flag
 	/// to also match the WrapCount.
 	fn as_flags_used(&self) -> u16 {
-		if self.0 == true {
+		if self.0 {
 			1 << 7 | 1 << 15
 		} else {
 			0

--- a/src/drivers/virtio/virtqueue/packed.rs
+++ b/src/drivers/virtio/virtqueue/packed.rs
@@ -626,7 +626,7 @@ impl<'a> ReadCtrl<'a> {
 					)
 				};
 
-				let mut desc_iter = desc_slice.into_iter();
+				let mut desc_iter = desc_slice.iter();
 
 				for desc in send_buff.as_mut_slice() {
 					// Unwrapping is fine here, as lists must be of same size and same ordering

--- a/src/drivers/virtio/virtqueue/packed.rs
+++ b/src/drivers/virtio/virtqueue/packed.rs
@@ -835,6 +835,7 @@ impl<'a> WriteCtrl<'a> {
 	}
 }
 
+#[derive(Clone, Copy)]
 #[repr(C, align(16))]
 struct Descriptor {
 	address: u64,

--- a/src/drivers/virtio/virtqueue/split.rs
+++ b/src/drivers/virtio/virtqueue/split.rs
@@ -334,7 +334,7 @@ impl SplitVq {
 			let mut index = index.iter();
 			// Even on 64bit systems this is fine, as we have a queue_size < 2^15!
 			let det_notif_data: u16 = (next_off as u16) >> 1;
-			let flags = (det_notif_data | (u16::from(next_wrap) << 15)).to_le_bytes();
+			let flags = (det_notif_data | (next_wrap << 15)).to_le_bytes();
 			let mut flags = flags.iter();
 			let mut notif_data: [u8; 4] = [0, 0, 0, 0];
 

--- a/src/drivers/virtio/virtqueue/split.rs
+++ b/src/drivers/virtio/virtqueue/split.rs
@@ -150,45 +150,41 @@ impl DescrRing {
 						0,
 					)
 				}
-			} else {
-				if len > 1 {
-					let next_index = {
-						let (desc, _) = desc_lst[desc_cnt + 1];
-						desc.id.as_ref().unwrap().0 - 1
-					};
+			} else if len > 1 {
+				let next_index = {
+					let (desc, _) = desc_lst[desc_cnt + 1];
+					desc.id.as_ref().unwrap().0 - 1
+				};
 
-					if is_write {
-						Descriptor::new(
-							paging::virt_to_phys(VirtAddr::from(desc.ptr as u64)).into(),
-							desc.len as u32,
-							DescrFlags::VIRTQ_DESC_F_WRITE | DescrFlags::VIRTQ_DESC_F_NEXT,
-							next_index,
-						)
-					} else {
-						Descriptor::new(
-							paging::virt_to_phys(VirtAddr::from(desc.ptr as u64)).into(),
-							desc.len as u32,
-							DescrFlags::VIRTQ_DESC_F_NEXT.into(),
-							next_index,
-						)
-					}
+				if is_write {
+					Descriptor::new(
+						paging::virt_to_phys(VirtAddr::from(desc.ptr as u64)).into(),
+						desc.len as u32,
+						DescrFlags::VIRTQ_DESC_F_WRITE | DescrFlags::VIRTQ_DESC_F_NEXT,
+						next_index,
+					)
 				} else {
-					if is_write {
-						Descriptor::new(
-							paging::virt_to_phys(VirtAddr::from(desc.ptr as u64)).into(),
-							desc.len as u32,
-							DescrFlags::VIRTQ_DESC_F_WRITE.into(),
-							0,
-						)
-					} else {
-						Descriptor::new(
-							paging::virt_to_phys(VirtAddr::from(desc.ptr as u64)).into(),
-							desc.len as u32,
-							0,
-							0,
-						)
-					}
+					Descriptor::new(
+						paging::virt_to_phys(VirtAddr::from(desc.ptr as u64)).into(),
+						desc.len as u32,
+						DescrFlags::VIRTQ_DESC_F_NEXT.into(),
+						next_index,
+					)
 				}
+			} else if is_write {
+				Descriptor::new(
+					paging::virt_to_phys(VirtAddr::from(desc.ptr as u64)).into(),
+					desc.len as u32,
+					DescrFlags::VIRTQ_DESC_F_WRITE.into(),
+					0,
+				)
+			} else {
+				Descriptor::new(
+					paging::virt_to_phys(VirtAddr::from(desc.ptr as u64)).into(),
+					desc.len as u32,
+					0,
+					0,
+				)
 			};
 
 			self.descr_table.raw[write_indx] = descriptor;

--- a/src/drivers/virtio/virtqueue/split.rs
+++ b/src/drivers/virtio/virtqueue/split.rs
@@ -23,10 +23,10 @@ use alloc::boxed::Box;
 use alloc::collections::VecDeque;
 use alloc::rc::Rc;
 use alloc::vec::Vec;
-use core::cell::RefCell;
 use core::convert::TryFrom;
 use core::ops::Deref;
 use core::sync::atomic::{fence, Ordering};
+use core::{cell::RefCell, ptr};
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -454,7 +454,7 @@ impl SplitVq {
 
 		let descr_ring = DescrRing {
 			read_idx: 0,
-			ref_ring: vec![0 as *mut TransferToken; size as usize].into_boxed_slice(),
+			ref_ring: vec![ptr::null_mut(); size as usize].into_boxed_slice(),
 			descr_table,
 			avail_ring,
 			used_ring,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 #![allow(clippy::single_match)]
 #![allow(clippy::cognitive_complexity)]
 #![allow(clippy::forget_copy)]
+#![allow(clippy::missing_safety_doc)]
 #![allow(incomplete_features)]
 #![feature(abi_x86_interrupt)]
 #![feature(allocator_api)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -73,6 +73,7 @@ macro_rules! kernel_function {
 		use crate::arch::kernel::percore::*;
 
 		#[allow(unused)]
+		#[allow(clippy::diverging_sub_expression)]
 		unsafe {
 			crate::arch::irq::disable();
 			let user_stack_pointer;

--- a/src/mm/freelist.rs
+++ b/src/mm/freelist.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use alloc::collections::linked_list::LinkedList;
-use core::cmp::Ordering;
+use core::{alloc::AllocError, cmp::Ordering};
 
 pub struct FreeListEntry {
 	pub start: usize,
@@ -30,7 +30,7 @@ impl FreeList {
 		}
 	}
 
-	pub fn allocate(&mut self, size: usize, alignment: Option<usize>) -> Result<usize, ()> {
+	pub fn allocate(&mut self, size: usize, alignment: Option<usize>) -> Result<usize, AllocError> {
 		trace!(
 			"Allocating {} bytes from Free List {:#X}",
 			size,
@@ -85,7 +85,7 @@ impl FreeList {
 			cursor.move_next();
 		}
 
-		Err(())
+		Err(AllocError)
 	}
 
 	pub fn deallocate(&mut self, address: usize, size: usize) {

--- a/src/mm/hole.rs
+++ b/src/mm/hole.rs
@@ -80,6 +80,7 @@ impl HoleList {
 	}
 
 	/// Returns information about the first hole for test purposes.
+	#[cfg(not(target_os = "hermit"))]
 	#[cfg(test)]
 	pub fn first_hole(&self) -> Option<(usize, usize)> {
 		self.first

--- a/src/synch/semaphore.rs
+++ b/src/synch/semaphore.rs
@@ -80,10 +80,7 @@ impl Semaphore {
 		let core_scheduler = core_scheduler();
 		core_scheduler.set_current_task_wakeup_reason(WakeupReason::Custom);
 
-		let wakeup_time = match time {
-			Some(ms) => Some(crate::arch::processor::get_timer_ticks() + ms * 1000),
-			_ => None,
-		};
+		let wakeup_time = time.map(|ms| crate::arch::processor::get_timer_ticks() + ms * 1000);
 
 		// Loop until we have acquired the semaphore.
 		loop {

--- a/src/syscalls/fs.rs
+++ b/src/syscalls/fs.rs
@@ -99,8 +99,9 @@ impl Filesystem {
 		&'a self,
 		path: &'b str,
 	) -> Result<(&'a (dyn PosixFileSystem + Send), &'b str), FileError> {
+		let mut pathsplit = path.splitn(3, '/');
+
 		if path.starts_with('/') {
-			let mut pathsplit = path.splitn(3, '/');
 			pathsplit.next(); // empty, since first char is /
 
 			let mount = pathsplit.next().unwrap();
@@ -114,7 +115,6 @@ impl Filesystem {
 				mount
 			);
 		} else {
-			let mut pathsplit = path.splitn(3, '/');
 			let mount = if !is_uhyve() {
 				option_env!("HERMIT_WD").unwrap_or("root")
 			} else {

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -6,6 +6,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+#![allow(clippy::result_unit_err)]
+
 #[cfg(not(feature = "newlib"))]
 use crate::drivers::net::*;
 use crate::environment;


### PR DESCRIPTION
These are a bunch of fixes for clippy warnings.

In some circumstances, where fixing is not straightforward, I allowed the lints instead.

Together with the other clippy PRs, there shouldn't be any clippy warnings now, so we can enable those in CI in the future.

What do you think?