### PR TITLE
RxQueues::get_next: Explicitly bind transfer

### DIFF
--- a/src/drivers/net/virtio_net.rs
+++ b/src/drivers/net/virtio_net.rs
@@ -310,7 +310,9 @@ impl RxQueues {
 	}
 
 	fn get_next(&mut self) -> Option<Transfer> {
-		self.poll_queue.borrow_mut().pop_front().or_else(|| {
+		let transfer = self.poll_queue.borrow_mut().pop_front();
+
+		transfer.or_else(|| {
 			// Check if any not yet provided transfers are in the queue.
 			self.poll();
 


### PR DESCRIPTION
Workaround for #209. Introduced in https://github.com/hermitcore/libhermit-rs/commit/a9fc0530473911d00caf2357a6dad69e034e92b6.