### PR TITLE
CI: Add clippy workflow

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,26 @@
+name: Clippy
+
+on:
+  push:
+    branches:
+      - master
+      - staging
+      - trying
+  pull_request:
+
+jobs:
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: rust-src, clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings


### PR DESCRIPTION
Now that clippy warnings are fixed, we can enforce clippy checks via CI.