### PR TITLE
Don't override nightly for clippy CI

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -17,8 +17,6 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
-          override: true
           components: rust-src, clippy
       - uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
We want to use clippy from the nightly specified in `toolchain.toml` instead of using the latest nightly.