### PR TITLE
Strongly link panic and oom handlers

### DIFF
--- a/src/runtime_glue.rs
+++ b/src/runtime_glue.rs
@@ -16,7 +16,6 @@ use core::panic::PanicInfo;
 
 // see https://users.rust-lang.org/t/psa-breaking-change-panic-fmt-language-item-removed-in-favor-of-panic-implementation/17875
 #[cfg(target_os = "hermit")]
-#[linkage = "weak"]
 #[panic_handler]
 fn panic(info: &PanicInfo<'_>) -> ! {
 	print!("[{}][!!!PANIC!!!] ", arch::percore::core_id());
@@ -40,7 +39,6 @@ fn panic(info: &PanicInfo<'_>) -> ! {
 	}
 }
 
-#[linkage = "weak"]
 #[alloc_error_handler]
 fn rust_oom(layout: Layout) -> ! {
 	println!(


### PR DESCRIPTION
Depends on https://github.com/hermitcore/rusty-hermit/pull/139.

Having weak linkage on the handlers does no harm but is not necessary after the before mentioned PR.