### PR TITLE
Enforce clippy via bors

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -3,6 +3,7 @@ status = [
   "Tests (windows-latest, nightly)",
   "Tests (ubuntu-latest, nightly)",
   "Format check (ubuntu-latest, nightly)",
+  "Clippy",
   "ci/gitlab/git.rwth-aachen.de",
 ]
 delete_merged_branches = true


### PR DESCRIPTION
Now that we have a stable Clippy CI, we can enforce Clippy lints via bors.