### PR TITLE
[DO NOT MERGE] Stack switch: Mark output stack as early-clobber

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -44,7 +44,7 @@ macro_rules! switch_to_kernel {
 			// Store the user stack pointer and switch to the kernel stack
 			llvm_asm!(
 				"mov %rsp, $0; mov $1, %rsp"
-				: "=r"(user_stack_pointer) : "r"(get_kernel_stack()) :: "volatile"
+				: "=&r"(user_stack_pointer) : "r"(get_kernel_stack()) :: "volatile"
 			);
 			core_scheduler().set_current_user_stack(user_stack_pointer);
 		}
@@ -81,7 +81,7 @@ macro_rules! kernel_function {
 			// Store the user stack pointer and switch to the kernel stack
 			llvm_asm!(
 				"mov %rsp, $0; mov $1, %rsp"
-				: "=r"(user_stack_pointer)
+				: "=&r"(user_stack_pointer)
 				: "r"(get_kernel_stack())
 				:: "volatile"
 			);


### PR DESCRIPTION
This is a demonstration of #234.

See [Output constraints — LLVM Language Reference Manual — LLVM 12 documentation](https://llvm.org/docs/LangRef.html#output-constraints).