### PR TITLE
Fix `Console` unsoundness

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -10,7 +10,7 @@ use crate::arch;
 use crate::synch::spinlock::SpinlockIrqSave;
 use core::fmt;
 
-pub struct Console;
+pub struct Console(());
 
 /// A collection of methods that are required to format
 /// a message to HermitCore's console.
@@ -37,7 +37,7 @@ impl Console {
 	}
 }
 
-pub static CONSOLE: SpinlockIrqSave<Console> = SpinlockIrqSave::new(Console);
+pub static CONSOLE: SpinlockIrqSave<Console> = SpinlockIrqSave::new(Console(()));
 
 #[cfg(not(target_os = "hermit"))]
 #[test]

--- a/src/console.rs
+++ b/src/console.rs
@@ -31,6 +31,12 @@ impl fmt::Write for Console {
 	}
 }
 
+impl Console {
+	pub fn write_all(&mut self, buf: &[u8]) {
+		arch::output_message_buf(buf)
+	}
+}
+
 pub static CONSOLE: SpinlockIrqSave<Console> = SpinlockIrqSave::new(Console);
 
 #[cfg(not(target_os = "hermit"))]


### PR DESCRIPTION
Fixes #238.

I also made the constructor of `Console` private. Where's the fun in locking a `Console`, when everyone can create new ones?