### PR TITLE
Remove unintended dereference

### DIFF
--- a/src/arch/x86_64/kernel/acpi.rs
+++ b/src/arch/x86_64/kernel/acpi.rs
@@ -9,7 +9,7 @@ use crate::arch::x86_64::mm::paging::{BasePageSize, PageSize, PageTableEntryFlag
 use crate::arch::x86_64::mm::{paging, virtualmem};
 use crate::arch::x86_64::mm::{PhysAddr, VirtAddr};
 use crate::x86::io::*;
-use core::{mem, slice, str};
+use core::{mem, ptr, slice, str};
 
 /// Memory at this physical address is supposed to contain a pointer to the Extended BIOS Data Area (EBDA).
 const EBDA_PTR_LOCATION: PhysAddr = PhysAddr(0x0000_040E);
@@ -411,8 +411,7 @@ fn parse_fadt(fadt: AcpiTable<'_>) {
 	}
 
 	// Map the "Differentiated System Description Table" (DSDT).
-	// TODO: This must not require "unsafe", see https://github.com/rust-lang/rust/issues/46043#issuecomment-393072398
-	let x_dsdt_field_address = unsafe { &fadt_table.x_dsdt as *const _ as usize };
+	let x_dsdt_field_address = ptr::addr_of!(fadt_table.x_dsdt) as usize;
 	let dsdt_address = if x_dsdt_field_address < fadt.table_end_address() && fadt_table.x_dsdt > 0 {
 		PhysAddr(fadt_table.x_dsdt)
 	} else {

--- a/src/arch/x86_64/kernel/acpi.rs
+++ b/src/arch/x86_64/kernel/acpi.rs
@@ -412,8 +412,7 @@ fn parse_fadt(fadt: AcpiTable<'_>) {
 
 	// Map the "Differentiated System Description Table" (DSDT).
 	// TODO: This must not require "unsafe", see https://github.com/rust-lang/rust/issues/46043#issuecomment-393072398
-	let x_dsdt = core::ptr::addr_of!(fadt_table.x_dsdt);
-	let x_dsdt_field_address = unsafe { x_dsdt.read_unaligned() as usize };
+	let x_dsdt_field_address = unsafe { &fadt_table.x_dsdt as *const _ as usize };
 	let dsdt_address = if x_dsdt_field_address < fadt.table_end_address() && fadt_table.x_dsdt > 0 {
 		PhysAddr(fadt_table.x_dsdt)
 	} else {

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -237,16 +237,17 @@ fn detect_from_acpi() -> Result<PhysAddr, ()> {
 
 				unsafe {
 					IOAPIC_ADDRESS = virtualmem::allocate(BasePageSize::SIZE).unwrap();
+					let record_addr = ioapic_record.address;
 					debug!(
 						"Mapping IOAPIC at {:#X} to virtual address {:#X}",
-						ioapic_record.address, IOAPIC_ADDRESS
+						record_addr, IOAPIC_ADDRESS
 					);
 
 					let mut flags = PageTableEntryFlags::empty();
 					flags.device().writable().execute_disable();
 					paging::map::<BasePageSize>(
 						IOAPIC_ADDRESS,
-						PhysAddr(ioapic_record.address.into()),
+						PhysAddr(record_addr.into()),
 						1,
 						flags,
 					);

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -233,15 +233,13 @@ fn detect_from_acpi() -> Result<PhysAddr, ()> {
 			1 => {
 				// I/O APIC
 				let ioapic_record = unsafe { &*(current_address as *const IoApicRecord) };
-				let ioapic_addr = core::ptr::addr_of!(ioapic_record.address);
 				debug!("Found I/O APIC record: {}", ioapic_record);
 
 				unsafe {
 					IOAPIC_ADDRESS = virtualmem::allocate(BasePageSize::SIZE).unwrap();
 					debug!(
 						"Mapping IOAPIC at {:#X} to virtual address {:#X}",
-						ioapic_addr.read_unaligned(),
-						IOAPIC_ADDRESS
+						ioapic_record.address, IOAPIC_ADDRESS
 					);
 
 					let mut flags = PageTableEntryFlags::empty();


### PR DESCRIPTION
87a9d3f9ef7acfd9e8f2188f27457e275ea9a925 was wrong.

Instead of calculating an address at one place in `acpi`, it read from that address.
The warning in `apic` was due to an implicit borrow and can be resolved by an explicit copy into a let binding.