### PR TITLE
Make msb helper function portable

### DIFF
--- a/src/arch/aarch64/kernel/processor.rs
+++ b/src/arch/aarch64/kernel/processor.rs
@@ -33,21 +33,6 @@ pub fn generate_random_number() -> Option<u32> {
 	None
 }
 
-/// Search the most significant bit
-#[inline(always)]
-pub fn msb(value: u64) -> Option<u64> {
-	if value > 0 {
-		let ret: u64;
-		let u64_bits = 64;
-		unsafe {
-			asm!("clz $0, $1; sub $0, $2, $0" : "=r"(ret) : "r"(value), "r"(u64_bits - 1) : "cc" : "volatile");
-		}
-		Some(ret)
-	} else {
-		None
-	}
-}
-
 /// The halt function stops the processor until the next interrupt arrives
 pub fn halt() {
 	unsafe {

--- a/src/arch/x86_64/kernel/processor.rs
+++ b/src/arch/x86_64/kernel/processor.rs
@@ -960,20 +960,6 @@ pub fn supports_fsgs() -> bool {
 	unsafe { SUPPORTS_FSGS }
 }
 
-/// Search the most significant bit
-#[inline(always)]
-pub fn msb(value: u64) -> Option<u64> {
-	if value > 0 {
-		let ret;
-		unsafe {
-			asm!("bsr {}, {}", out(reg) ret, in(reg) value, options(pure, nomem, nostack));
-		}
-		Some(ret)
-	} else {
-		None
-	}
-}
-
 /// The halt function stops the processor until the next interrupt arrives
 pub fn halt() {
 	unsafe {


### PR DESCRIPTION
`NonZeroU64::leading_zeros` has recently been stabilized.

Now we can make our `msb` helper function portable, resulting in the same `x86_64` assembly: [Compiler Explorer](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(fontScale:14,fontUsePx:'0',j:1,lang:rust,selection:(endColumn:8,endLineNumber:3,positionColumn:8,positionLineNumber:3,selectionStartColumn:5,selectionStartLineNumber:3,startColumn:5,startLineNumber:3),source:'%23!!%5Bfeature(asm)%5D%0A%0Ause+std::num::NonZeroU64%3B%0A%0Apub+fn+old_msb(n:+u64)+-%3E+Option%3Cu64%3E+%7B%0A%09if+n+%3E+0+%7B%0A%09%09let+ret%3B%0A%09%09unsafe+%7B%0A%09%09%09asm!!(%22bsr+%7B%7D,+%7B%7D%22,+out(reg)+ret,+in(reg)+n,+options(pure,+nomem,+nostack))%3B%0A%09%09%7D%0A%09%09Some(ret)%0A%09%7D+else+%7B%0A%09%09None%0A%09%7D%0A%7D%0A%0Apub+fn+new_msb(n:+u64)+-%3E+Option%3Cu32%3E+%7B%0A++++NonZeroU64::new(n).map(%7Cn%7C+63+-+n.leading_zeros())%0A%7D%0A'),l:'5',n:'0',o:'Rust+source+%231',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:nightly,filters:(b:'0',binary:'1',commentOnly:'0',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'0',trim:'1'),fontScale:14,fontUsePx:'0',j:2,lang:rust,libs:!(),options:'-C+opt-level%3D3',selection:(endColumn:1,endLineNumber:1,positionColumn:1,positionLineNumber:1,selectionStartColumn:1,selectionStartLineNumber:1,startColumn:1,startLineNumber:1),source:1),l:'5',n:'0',o:'rustc+nightly+(Editor+%231,+Compiler+%232)+Rust',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4)