### PR TITLE
Fix switching to kernel stack

### DIFF
--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -145,7 +145,8 @@ pub fn has_ipdevice() -> bool {
 }
 
 #[cfg(not(feature = "newlib"))]
-pub fn __sys_uhyve_get_ip() -> [u8; 4] {
+#[allow(improper_ctypes_definitions)]
+extern "C" fn __sys_uhyve_get_ip() -> [u8; 4] {
 	unsafe { core::ptr::read_volatile(&(*BOOT_INFO).hcip) }
 }
 
@@ -156,7 +157,8 @@ pub fn sys_uhyve_get_ip() -> [u8; 4] {
 }
 
 #[cfg(not(feature = "newlib"))]
-pub fn __sys_uhyve_get_gateway() -> [u8; 4] {
+#[allow(improper_ctypes_definitions)]
+extern "C" fn __sys_uhyve_get_gateway() -> [u8; 4] {
 	unsafe { core::ptr::read_volatile(&(*BOOT_INFO).hcgateway) }
 }
 
@@ -167,7 +169,8 @@ pub fn sys_uhyve_get_gateway() -> [u8; 4] {
 }
 
 #[cfg(not(feature = "newlib"))]
-pub fn __sys_uhyve_get_mask() -> [u8; 4] {
+#[allow(improper_ctypes_definitions)]
+extern "C" fn __sys_uhyve_get_mask() -> [u8; 4] {
 	unsafe { core::ptr::read_volatile(&(*BOOT_INFO).hcmask) }
 }
 
@@ -178,7 +181,7 @@ pub fn sys_uhyve_get_mask() -> [u8; 4] {
 }
 
 #[cfg(feature = "newlib")]
-pub fn __sys_uhyve_get_ip(ip: *mut u8) {
+extern "C" fn __sys_uhyve_get_ip(ip: *mut u8) {
 	unsafe {
 		let data = core::ptr::read_volatile(&(*BOOT_INFO).hcip);
 		slice::from_raw_parts_mut(ip, 4).copy_from_slice(&data);
@@ -192,7 +195,7 @@ pub unsafe extern "C" fn sys_uhyve_get_ip(ip: *mut u8) {
 }
 
 #[cfg(feature = "newlib")]
-pub fn __sys_uhyve_get_gateway(gw: *mut u8) {
+extern "C" fn __sys_uhyve_get_gateway(gw: *mut u8) {
 	unsafe {
 		let data = core::ptr::read_volatile(&(*BOOT_INFO).hcgateway);
 		slice::from_raw_parts_mut(gw, 4).copy_from_slice(&data);
@@ -206,7 +209,7 @@ pub unsafe extern "C" fn sys_uhyve_get_gateway(gw: *mut u8) {
 }
 
 #[cfg(feature = "newlib")]
-pub fn __sys_uhyve_get_mask(mask: *mut u8) {
+extern "C" fn __sys_uhyve_get_mask(mask: *mut u8) {
 	unsafe {
 		let data = core::ptr::read_volatile(&(*BOOT_INFO).hcmask);
 		slice::from_raw_parts_mut(mask, 4).copy_from_slice(&data);

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -177,31 +177,46 @@ pub fn sys_uhyve_get_mask() -> [u8; 4] {
 	kernel_function!(uhyve_get_mask())
 }
 
+#[cfg(feature = "newlib")]
+pub fn __sys_uhyve_get_ip(ip: *mut u8) {
+	unsafe {
+		let data = core::ptr::read_volatile(&(*BOOT_INFO).hcip);
+		slice::from_raw_parts_mut(ip, 4).copy_from_slice(&data);
+	}
+}
+
 #[no_mangle]
 #[cfg(feature = "newlib")]
 pub unsafe extern "C" fn sys_uhyve_get_ip(ip: *mut u8) {
-	switch_to_kernel!();
-	let data = core::ptr::read_volatile(&(*BOOT_INFO).hcip);
-	slice::from_raw_parts_mut(ip, 4).copy_from_slice(&data);
-	switch_to_user!();
+	kernel_function!(__sys_uhyve_get_ip(ip))
+}
+
+#[cfg(feature = "newlib")]
+pub fn __sys_uhyve_get_gateway(gw: *mut u8) {
+	unsafe {
+		let data = core::ptr::read_volatile(&(*BOOT_INFO).hcgateway);
+		slice::from_raw_parts_mut(gw, 4).copy_from_slice(&data);
+	}
 }
 
 #[no_mangle]
 #[cfg(feature = "newlib")]
 pub unsafe extern "C" fn sys_uhyve_get_gateway(gw: *mut u8) {
-	switch_to_kernel!();
-	let data = core::ptr::read_volatile(&(*BOOT_INFO).hcgateway);
-	slice::from_raw_parts_mut(gw, 4).copy_from_slice(&data);
-	switch_to_user!();
+	kernel_function!(__sys_uhyve_get_gateway(gw))
+}
+
+#[cfg(feature = "newlib")]
+pub fn __sys_uhyve_get_mask(mask: *mut u8) {
+	unsafe {
+		let data = core::ptr::read_volatile(&(*BOOT_INFO).hcmask);
+		slice::from_raw_parts_mut(mask, 4).copy_from_slice(&data);
+	}
 }
 
 #[no_mangle]
 #[cfg(feature = "newlib")]
 pub unsafe extern "C" fn sys_uhyve_get_mask(mask: *mut u8) {
-	switch_to_kernel!();
-	let data = core::ptr::read_volatile(&(*BOOT_INFO).hcmask);
-	slice::from_raw_parts_mut(mask, 4).copy_from_slice(&data);
-	switch_to_user!();
+	kernel_function!(__sys_uhyve_get_mask(mask))
 }
 
 pub fn get_base_address() -> VirtAddr {

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -145,36 +145,36 @@ pub fn has_ipdevice() -> bool {
 }
 
 #[cfg(not(feature = "newlib"))]
-pub fn uhyve_get_ip() -> [u8; 4] {
+pub fn __sys_uhyve_get_ip() -> [u8; 4] {
 	unsafe { core::ptr::read_volatile(&(*BOOT_INFO).hcip) }
 }
 
 #[no_mangle]
 #[cfg(not(feature = "newlib"))]
 pub fn sys_uhyve_get_ip() -> [u8; 4] {
-	kernel_function!(uhyve_get_ip())
+	kernel_function!(__sys_uhyve_get_ip())
 }
 
 #[cfg(not(feature = "newlib"))]
-pub fn uhyve_get_gateway() -> [u8; 4] {
+pub fn __sys_uhyve_get_gateway() -> [u8; 4] {
 	unsafe { core::ptr::read_volatile(&(*BOOT_INFO).hcgateway) }
 }
 
 #[no_mangle]
 #[cfg(not(feature = "newlib"))]
 pub fn sys_uhyve_get_gateway() -> [u8; 4] {
-	kernel_function!(uhyve_get_gateway())
+	kernel_function!(__sys_uhyve_get_gateway())
 }
 
 #[cfg(not(feature = "newlib"))]
-pub fn uhyve_get_mask() -> [u8; 4] {
+pub fn __sys_uhyve_get_mask() -> [u8; 4] {
 	unsafe { core::ptr::read_volatile(&(*BOOT_INFO).hcmask) }
 }
 
 #[no_mangle]
 #[cfg(not(feature = "newlib"))]
 pub fn sys_uhyve_get_mask() -> [u8; 4] {
-	kernel_function!(uhyve_get_mask())
+	kernel_function!(__sys_uhyve_get_mask())
 }
 
 #[cfg(feature = "newlib")]

--- a/src/arch/x86_64/kernel/scheduler.rs
+++ b/src/arch/x86_64/kernel/scheduler.rs
@@ -359,10 +359,9 @@ extern "C" fn task_start(_f: extern "C" fn(usize), _arg: usize, _user_stack: u64
 extern "C" fn task_entry(func: extern "C" fn(usize), arg: usize) -> ! {
 	// Call the actual entry point of the task.
 	func(arg);
-	switch_to_kernel!();
 
 	// Exit task
-	core_scheduler().exit(0)
+	crate::sys_thread_exit(0)
 }
 
 impl TaskFrame for Task {

--- a/src/drivers/net/mod.rs
+++ b/src/drivers/net/mod.rs
@@ -70,7 +70,8 @@ pub fn netwakeup() {
 	NET_SEM.release();
 }
 
-pub fn netwait_and_wakeup(handles: &[usize], millis: Option<u64>) {
+#[allow(improper_ctypes_definitions)]
+pub extern "C" fn netwait_and_wakeup(handles: &[usize], millis: Option<u64>) {
 	// do we have to wakeup a thread?
 	if !handles.is_empty() {
 		let mut guard = NIC_QUEUE.lock();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -40,40 +40,31 @@ macro_rules! println {
 
 #[macro_export]
 macro_rules! kernel_function {
-	($f:ident($($x:tt)*)) => {{
-		use $crate::arch::{irq, kernel::percore, mm::VirtAddr};
+	($f:ident()) => {
+		$crate::arch::switch::kernel_function0($f)
+	};
 
-		#[allow(clippy::diverging_sub_expression)]
-		#[allow(unused_unsafe)]
-		#[allow(unused_variables)]
-		#[allow(unreachable_code)]
-		unsafe {
-			irq::disable();
-			let user_stack_pointer;
-			// Store the user stack pointer and switch to the kernel stack
-			// FIXME: Actually switch stacks https://github.com/hermitcore/libhermit-rs/issues/234
-			asm!(
-				"mov {}, rsp",
-				// "mov rsp, {}",
-				out(reg) user_stack_pointer,
-				// in(reg) get_kernel_stack(),
-				options(nomem, preserves_flags),
-			);
-			percore::core_scheduler().set_current_user_stack(VirtAddr(user_stack_pointer));
-			irq::enable();
+	($f:ident($arg1:expr)) => {
+		$crate::arch::switch::kernel_function1($f, $arg1)
+	};
 
-			let ret = $f($($x)*);
+	($f:ident($arg1:expr, $arg2:expr)) => {
+		$crate::arch::switch::kernel_function2($f, $arg1, $arg2)
+	};
 
-			irq::disable();
-			// Switch to the user stack
-			asm!(
-				"mov rsp, {}",
-				in(reg) percore::core_scheduler().get_current_user_stack().0,
-				options(nomem, preserves_flags),
-			);
-			irq::enable();
+	($f:ident($arg1:expr, $arg2:expr, $arg3:expr)) => {
+		$crate::arch::switch::kernel_function3($f, $arg1, $arg2, $arg3)
+	};
 
-			ret
-		}
-	}};
+	($f:ident($arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr)) => {
+		$crate::arch::switch::kernel_function4($f, $arg1, $arg2, $arg3, $arg4)
+	};
+
+	($f:ident($arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr, $arg5:expr)) => {
+		$crate::arch::switch::kernel_function5($f, $arg1, $arg2, $arg3, $arg4, $arg5)
+	};
+
+	($f:ident($arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr, $arg5:expr, $arg6:expr)) => {
+		$crate::arch::switch::kernel_function6($f, $arg1, $arg2, $arg3, $arg4, $arg5, $arg6)
+	};
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -39,48 +39,6 @@ macro_rules! println {
 }
 
 #[macro_export]
-macro_rules! switch_to_kernel {
-	() => {{
-		use $crate::arch::{irq, kernel::percore, mm::VirtAddr};
-
-		irq::disable();
-		unsafe {
-			let user_stack_pointer;
-			// Store the user stack pointer and switch to the kernel stack
-			// FIXME: Actually switch stacks https://github.com/hermitcore/libhermit-rs/issues/234
-			asm!(
-				"mov {}, rsp",
-				// "mov rsp, {}",
-				out(reg) user_stack_pointer,
-				// in(reg) percore::get_kernel_stack(),
-				options(nomem, preserves_flags),
-			);
-			percore::core_scheduler().set_current_user_stack(VirtAddr(user_stack_pointer));
-		}
-		irq::enable();
-	}}
-}
-
-#[cfg(feature = "newlib")]
-#[macro_export]
-macro_rules! switch_to_user {
-	() => {{
-		use $crate::arch::{irq, kernel::percore};
-
-		irq::disable();
-		unsafe {
-			// Switch to the user stack
-			asm!(
-				"mov rsp, {}",
-				in(reg) percore::core_scheduler().get_current_user_stack().0,
-				options(nomem, preserves_flags),
-			);
-		}
-		irq::enable();
-	}}
-}
-
-#[macro_export]
 macro_rules! kernel_function {
 	($f:ident($($x:tt)*)) => {{
 		use $crate::arch::{irq, kernel::percore, mm::VirtAddr};

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -320,16 +320,6 @@ impl PerCoreScheduler {
 		irqsave(|| self.current_task.borrow_mut().last_wakeup_reason = reason);
 	}
 
-	#[inline]
-	pub fn get_current_user_stack(&self) -> VirtAddr {
-		self.current_task.borrow().user_stack_pointer
-	}
-
-	#[inline]
-	pub fn set_current_user_stack(&mut self, addr: VirtAddr) {
-		self.current_task.borrow_mut().user_stack_pointer = addr;
-	}
-
 	#[cfg(target_arch = "x86_64")]
 	#[inline]
 	pub fn get_current_kernel_stack(&self) -> VirtAddr {

--- a/src/syscalls/condvar.rs
+++ b/src/syscalls/condvar.rs
@@ -30,19 +30,21 @@ impl CondQueue {
 	}
 }
 
-unsafe fn __sys_destroy_queue(ptr: usize) -> i32 {
-	let id = ptr as *mut usize;
-	if id.is_null() {
-		debug!("sys_wait: invalid address to condition variable");
-		return -1;
-	}
+extern "C" fn __sys_destroy_queue(ptr: usize) -> i32 {
+	unsafe {
+		let id = ptr as *mut usize;
+		if id.is_null() {
+			debug!("sys_wait: invalid address to condition variable");
+			return -1;
+		}
 
-	if *id != 0 {
-		let cond = Box::from_raw((*id) as *mut CondQueue);
-		mem::drop(cond);
-	}
+		if *id != 0 {
+			let cond = Box::from_raw((*id) as *mut CondQueue);
+			mem::drop(cond);
+		}
 
-	0
+		0
+	}
 }
 
 #[no_mangle]
@@ -50,38 +52,40 @@ pub unsafe fn sys_destroy_queue(ptr: usize) -> i32 {
 	kernel_function!(__sys_destroy_queue(ptr))
 }
 
-unsafe fn __sys_notify(ptr: usize, count: i32) -> i32 {
-	let id = ptr as *const usize;
+extern "C" fn __sys_notify(ptr: usize, count: i32) -> i32 {
+	unsafe {
+		let id = ptr as *const usize;
 
-	if id.is_null() {
-		// invalid argument
-		debug!("sys_notify: invalid address to condition variable");
-		return -1;
-	}
-
-	if *id == 0 {
-		debug!("sys_notify: invalid reference to condition variable");
-		return -1;
-	}
-
-	let cond = &mut *((*id) as *mut CondQueue);
-
-	if count < 0 {
-		// Wake up all task that has been waiting for this condition variable
-		while cond.counter.load(Ordering::SeqCst) > 0 {
-			cond.counter.fetch_sub(1, Ordering::SeqCst);
-			cond.sem1.release();
-			cond.sem2.acquire(None);
+		if id.is_null() {
+			// invalid argument
+			debug!("sys_notify: invalid address to condition variable");
+			return -1;
 		}
-	} else {
-		for _ in 0..count {
-			cond.counter.fetch_sub(1, Ordering::SeqCst);
-			cond.sem1.release();
-			cond.sem2.acquire(None);
-		}
-	}
 
-	0
+		if *id == 0 {
+			debug!("sys_notify: invalid reference to condition variable");
+			return -1;
+		}
+
+		let cond = &mut *((*id) as *mut CondQueue);
+
+		if count < 0 {
+			// Wake up all task that has been waiting for this condition variable
+			while cond.counter.load(Ordering::SeqCst) > 0 {
+				cond.counter.fetch_sub(1, Ordering::SeqCst);
+				cond.sem1.release();
+				cond.sem2.acquire(None);
+			}
+		} else {
+			for _ in 0..count {
+				cond.counter.fetch_sub(1, Ordering::SeqCst);
+				cond.sem1.release();
+				cond.sem2.acquire(None);
+			}
+		}
+
+		0
+	}
 }
 
 #[no_mangle]
@@ -89,20 +93,22 @@ pub unsafe fn sys_notify(ptr: usize, count: i32) -> i32 {
 	kernel_function!(__sys_notify(ptr, count))
 }
 
-unsafe fn __sys_init_queue(ptr: usize) -> i32 {
-	let id = ptr as *mut usize;
-	if id.is_null() {
-		debug!("sys_init_queue: invalid address to condition variable");
-		return -1;
-	}
+extern "C" fn __sys_init_queue(ptr: usize) -> i32 {
+	unsafe {
+		let id = ptr as *mut usize;
+		if id.is_null() {
+			debug!("sys_init_queue: invalid address to condition variable");
+			return -1;
+		}
 
-	if *id == 0 {
-		debug!("Create condition variable queue");
-		let queue = Box::new(CondQueue::new());
-		*id = Box::into_raw(queue) as usize;
-	}
+		if *id == 0 {
+			debug!("Create condition variable queue");
+			let queue = Box::new(CondQueue::new());
+			*id = Box::into_raw(queue) as usize;
+		}
 
-	0
+		0
+	}
 }
 
 #[no_mangle]
@@ -110,28 +116,30 @@ pub unsafe fn sys_init_queue(ptr: usize) -> i32 {
 	kernel_function!(__sys_init_queue(ptr))
 }
 
-unsafe fn __sys_add_queue(ptr: usize, timeout_ns: i64) -> i32 {
-	let id = ptr as *mut usize;
-	if id.is_null() {
-		debug!("sys_add_queue: invalid address to condition variable");
-		return -1;
-	}
+extern "C" fn __sys_add_queue(ptr: usize, timeout_ns: i64) -> i32 {
+	unsafe {
+		let id = ptr as *mut usize;
+		if id.is_null() {
+			debug!("sys_add_queue: invalid address to condition variable");
+			return -1;
+		}
 
-	if *id == 0 {
-		debug!("Create condition variable queue");
-		let queue = Box::new(CondQueue::new());
-		*id = Box::into_raw(queue) as usize;
-	}
+		if *id == 0 {
+			debug!("Create condition variable queue");
+			let queue = Box::new(CondQueue::new());
+			*id = Box::into_raw(queue) as usize;
+		}
 
-	if timeout_ns <= 0 {
-		let cond = &mut *((*id) as *mut CondQueue);
-		cond.counter.fetch_add(1, Ordering::SeqCst);
+		if timeout_ns <= 0 {
+			let cond = &mut *((*id) as *mut CondQueue);
+			cond.counter.fetch_add(1, Ordering::SeqCst);
 
-		0
-	} else {
-		error!("Conditional variables with timeout is currently not supported");
+			0
+		} else {
+			error!("Conditional variables with timeout is currently not supported");
 
-		-1
+			-1
+		}
 	}
 }
 
@@ -140,23 +148,25 @@ pub unsafe fn sys_add_queue(ptr: usize, timeout_ns: i64) -> i32 {
 	kernel_function!(__sys_add_queue(ptr, timeout_ns))
 }
 
-unsafe fn __sys_wait(ptr: usize) -> i32 {
-	let id = ptr as *mut usize;
-	if id.is_null() {
-		debug!("sys_wait: invalid address to condition variable");
-		return -1;
+extern "C" fn __sys_wait(ptr: usize) -> i32 {
+	unsafe {
+		let id = ptr as *mut usize;
+		if id.is_null() {
+			debug!("sys_wait: invalid address to condition variable");
+			return -1;
+		}
+
+		if *id == 0 {
+			error!("sys_wait: Unable to determine condition variable");
+			return -1;
+		}
+
+		let cond = &mut *((*id) as *mut CondQueue);
+		cond.sem1.acquire(None);
+		cond.sem2.release();
+
+		0
 	}
-
-	if *id == 0 {
-		error!("sys_wait: Unable to determine condition variable");
-		return -1;
-	}
-
-	let cond = &mut *((*id) as *mut CondQueue);
-	cond.sem1.acquire(None);
-	cond.sem2.release();
-
-	0
 }
 
 #[no_mangle]

--- a/src/syscalls/lwip.rs
+++ b/src/syscalls/lwip.rs
@@ -14,7 +14,7 @@ use crate::synch::spinlock::SpinlockIrqSaveGuard;
 /// a message from the kernel.
 static mut CONSOLE_GUARD: Option<SpinlockIrqSaveGuard<console::Console>> = None;
 
-fn __sys_lwip_get_errno() -> i32 {
+extern "C" fn __sys_lwip_get_errno() -> i32 {
 	core_scheduler().get_lwip_errno()
 }
 
@@ -23,7 +23,7 @@ pub extern "C" fn sys_lwip_get_errno() -> i32 {
 	kernel_function!(__sys_lwip_get_errno())
 }
 
-fn __sys_lwip_set_errno(errno: i32) {
+extern "C" fn __sys_lwip_set_errno(errno: i32) {
 	core_scheduler().set_lwip_errno(errno);
 }
 
@@ -32,7 +32,7 @@ pub extern "C" fn sys_lwip_set_errno(errno: i32) {
 	kernel_function!(__sys_lwip_set_errno(errno))
 }
 
-fn __sys_acquire_putchar_lock() {
+extern "C" fn __sys_acquire_putchar_lock() {
 	unsafe {
 		assert!(CONSOLE_GUARD.is_none());
 		CONSOLE_GUARD = Some(console::CONSOLE.lock());
@@ -44,7 +44,7 @@ pub extern "C" fn sys_acquire_putchar_lock() {
 	kernel_function!(__sys_acquire_putchar_lock())
 }
 
-fn __sys_putchar(character: u8) {
+extern "C" fn __sys_putchar(character: u8) {
 	arch::output_message_byte(character);
 }
 
@@ -53,7 +53,7 @@ pub extern "C" fn sys_putchar(character: u8) {
 	kernel_function!(__sys_putchar(character))
 }
 
-fn __sys_release_putchar_lock() {
+extern "C" fn __sys_release_putchar_lock() {
 	unsafe {
 		assert!(CONSOLE_GUARD.is_some());
 		drop(CONSOLE_GUARD.take());

--- a/src/syscalls/lwip.rs
+++ b/src/syscalls/lwip.rs
@@ -41,7 +41,7 @@ fn __sys_acquire_putchar_lock() {
 
 #[no_mangle]
 pub extern "C" fn sys_acquire_putchar_lock() {
-	kernel_function!(sys_acquire_putchar_lock())
+	kernel_function!(__sys_acquire_putchar_lock())
 }
 
 fn __sys_putchar(character: u8) {

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -77,20 +77,21 @@ pub extern "C" fn sys_malloc(size: usize, align: usize) -> *mut u8 {
 #[cfg(target_os = "hermit")]
 #[no_mangle]
 pub extern "C" fn sys_realloc(ptr: *mut u8, size: usize, align: usize, new_size: usize) -> *mut u8 {
-	unsafe { __sys_realloc(ptr, size, align, new_size) }
+	__sys_realloc(ptr, size, align, new_size)
 }
 
 #[cfg(target_os = "hermit")]
 #[no_mangle]
 pub extern "C" fn sys_free(ptr: *mut u8, size: usize, align: usize) {
-	unsafe { __sys_free(ptr, size, align) }
+	__sys_free(ptr, size, align)
 }
 
 pub fn get_application_parameters() -> (i32, *const *const u8, *const *const u8) {
 	unsafe { SYS.get_application_parameters() }
 }
 
-fn __sys_get_mac_address() -> Result<[u8; 6], ()> {
+#[allow(improper_ctypes_definitions)]
+extern "C" fn __sys_get_mac_address() -> Result<[u8; 6], ()> {
 	unsafe { SYS.get_mac_address() }
 }
 
@@ -99,7 +100,8 @@ pub fn sys_get_mac_address() -> Result<[u8; 6], ()> {
 	kernel_function!(__sys_get_mac_address())
 }
 
-fn __sys_get_mtu() -> Result<u16, ()> {
+#[allow(improper_ctypes_definitions)]
+extern "C" fn __sys_get_mtu() -> Result<u16, ()> {
 	unsafe { SYS.get_mtu() }
 }
 
@@ -108,7 +110,8 @@ pub fn sys_get_mtu() -> Result<u16, ()> {
 	kernel_function!(__sys_get_mtu())
 }
 
-fn __sys_get_tx_buffer(len: usize) -> Result<(*mut u8, usize), ()> {
+#[allow(improper_ctypes_definitions)]
+extern "C" fn __sys_get_tx_buffer(len: usize) -> Result<(*mut u8, usize), ()> {
 	unsafe { SYS.get_tx_buffer(len) }
 }
 
@@ -117,7 +120,8 @@ pub fn sys_get_tx_buffer(len: usize) -> Result<(*mut u8, usize), ()> {
 	kernel_function!(__sys_get_tx_buffer(len))
 }
 
-fn __sys_send_tx_buffer(handle: usize, len: usize) -> Result<(), ()> {
+#[allow(improper_ctypes_definitions)]
+extern "C" fn __sys_send_tx_buffer(handle: usize, len: usize) -> Result<(), ()> {
 	unsafe { SYS.send_tx_buffer(handle, len) }
 }
 
@@ -126,7 +130,8 @@ pub fn sys_send_tx_buffer(handle: usize, len: usize) -> Result<(), ()> {
 	kernel_function!(__sys_send_tx_buffer(handle, len))
 }
 
-fn __sys_receive_rx_buffer() -> Result<(&'static [u8], usize), ()> {
+#[allow(improper_ctypes_definitions)]
+extern "C" fn __sys_receive_rx_buffer() -> Result<(&'static [u8], usize), ()> {
 	unsafe { SYS.receive_rx_buffer() }
 }
 
@@ -135,7 +140,8 @@ pub fn sys_receive_rx_buffer() -> Result<(&'static [u8], usize), ()> {
 	kernel_function!(__sys_receive_rx_buffer())
 }
 
-fn __sys_rx_buffer_consumed(handle: usize) -> Result<(), ()> {
+#[allow(improper_ctypes_definitions)]
+extern "C" fn __sys_rx_buffer_consumed(handle: usize) -> Result<(), ()> {
 	unsafe { SYS.rx_buffer_consumed(handle) }
 }
 
@@ -145,7 +151,8 @@ pub fn sys_rx_buffer_consumed(handle: usize) -> Result<(), ()> {
 }
 
 #[cfg(not(feature = "newlib"))]
-fn __sys_netwait(handle: usize, millis: Option<u64>) {
+#[allow(improper_ctypes_definitions)]
+extern "C" fn __sys_netwait(handle: usize, millis: Option<u64>) {
 	netwait(handle, millis)
 }
 
@@ -156,8 +163,8 @@ pub fn sys_netwait(handle: usize, millis: Option<u64>) {
 }
 
 #[cfg(not(feature = "newlib"))]
-#[no_mangle]
-fn __sys_netwait_and_wakeup(handles: &[usize], millis: Option<u64>) {
+#[allow(improper_ctypes_definitions)]
+extern "C" fn __sys_netwait_and_wakeup(handles: &[usize], millis: Option<u64>) {
 	netwait_and_wakeup(handles, millis);
 }
 
@@ -167,7 +174,7 @@ pub fn sys_netwait_and_wakeup(handles: &[usize], millis: Option<u64>) {
 	kernel_function!(__sys_netwait_and_wakeup(handles, millis));
 }
 
-pub fn __sys_shutdown(arg: i32) -> ! {
+pub extern "C" fn __sys_shutdown(arg: i32) -> ! {
 	// print some performance statistics
 	crate::arch::kernel::print_statistics();
 
@@ -179,7 +186,7 @@ pub extern "C" fn sys_shutdown(arg: i32) -> ! {
 	kernel_function!(__sys_shutdown(arg))
 }
 
-fn __sys_unlink(name: *const u8) -> i32 {
+extern "C" fn __sys_unlink(name: *const u8) -> i32 {
 	unsafe { SYS.unlink(name) }
 }
 
@@ -188,7 +195,7 @@ pub extern "C" fn sys_unlink(name: *const u8) -> i32 {
 	kernel_function!(__sys_unlink(name))
 }
 
-fn __sys_open(name: *const u8, flags: i32, mode: i32) -> i32 {
+extern "C" fn __sys_open(name: *const u8, flags: i32, mode: i32) -> i32 {
 	unsafe { SYS.open(name, flags, mode) }
 }
 
@@ -197,7 +204,7 @@ pub extern "C" fn sys_open(name: *const u8, flags: i32, mode: i32) -> i32 {
 	kernel_function!(__sys_open(name, flags, mode))
 }
 
-fn __sys_close(fd: i32) -> i32 {
+extern "C" fn __sys_close(fd: i32) -> i32 {
 	unsafe { SYS.close(fd) }
 }
 
@@ -206,7 +213,7 @@ pub extern "C" fn sys_close(fd: i32) -> i32 {
 	kernel_function!(__sys_close(fd))
 }
 
-fn __sys_read(fd: i32, buf: *mut u8, len: usize) -> isize {
+extern "C" fn __sys_read(fd: i32, buf: *mut u8, len: usize) -> isize {
 	unsafe { SYS.read(fd, buf, len) }
 }
 #[no_mangle]
@@ -214,7 +221,7 @@ pub extern "C" fn sys_read(fd: i32, buf: *mut u8, len: usize) -> isize {
 	kernel_function!(__sys_read(fd, buf, len))
 }
 
-fn __sys_write(fd: i32, buf: *const u8, len: usize) -> isize {
+extern "C" fn __sys_write(fd: i32, buf: *const u8, len: usize) -> isize {
 	unsafe { SYS.write(fd, buf, len) }
 }
 
@@ -223,7 +230,7 @@ pub extern "C" fn sys_write(fd: i32, buf: *const u8, len: usize) -> isize {
 	kernel_function!(__sys_write(fd, buf, len))
 }
 
-fn __sys_lseek(fd: i32, offset: isize, whence: i32) -> isize {
+extern "C" fn __sys_lseek(fd: i32, offset: isize, whence: i32) -> isize {
 	unsafe { SYS.lseek(fd, offset, whence) }
 }
 
@@ -232,7 +239,7 @@ pub extern "C" fn sys_lseek(fd: i32, offset: isize, whence: i32) -> isize {
 	kernel_function!(__sys_lseek(fd, offset, whence))
 }
 
-fn __sys_stat(file: *const u8, st: usize) -> i32 {
+extern "C" fn __sys_stat(file: *const u8, st: usize) -> i32 {
 	unsafe { SYS.stat(file, st) }
 }
 

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -157,8 +157,14 @@ pub fn sys_netwait(handle: usize, millis: Option<u64>) {
 
 #[cfg(not(feature = "newlib"))]
 #[no_mangle]
+fn __sys_netwait_and_wakeup(handles: &[usize], millis: Option<u64>) {
+	netwait_and_wakeup(handles, millis);
+}
+
+#[cfg(not(feature = "newlib"))]
+#[no_mangle]
 pub fn sys_netwait_and_wakeup(handles: &[usize], millis: Option<u64>) {
-	kernel_function!(netwait_and_wakeup(handles, millis));
+	kernel_function!(__sys_netwait_and_wakeup(handles, millis));
 }
 
 pub fn __sys_shutdown(arg: i32) -> ! {

--- a/src/syscalls/processor.rs
+++ b/src/syscalls/processor.rs
@@ -8,7 +8,7 @@
 use crate::arch::get_processor_count;
 use core::convert::TryInto;
 
-fn __sys_get_processor_count() -> usize {
+extern "C" fn __sys_get_processor_count() -> usize {
 	get_processor_count().try_into().unwrap()
 }
 
@@ -18,7 +18,7 @@ pub extern "C" fn sys_get_processor_count() -> usize {
 	kernel_function!(__sys_get_processor_count())
 }
 
-fn __sys_get_processor_frequency() -> u16 {
+extern "C" fn __sys_get_processor_frequency() -> u16 {
 	crate::arch::processor::get_frequency()
 }
 

--- a/src/syscalls/random.rs
+++ b/src/syscalls/random.rs
@@ -18,15 +18,17 @@ fn generate_park_miller_lehmer_random_number() -> u32 {
 	random
 }
 
-fn __sys_rand32() -> Option<u32> {
+#[allow(improper_ctypes_definitions)]
+extern "C" fn __sys_rand32() -> Option<u32> {
 	arch::processor::generate_random_number32()
 }
 
-fn __sys_rand64() -> Option<u64> {
+#[allow(improper_ctypes_definitions)]
+extern "C" fn __sys_rand64() -> Option<u64> {
 	arch::processor::generate_random_number64()
 }
 
-fn __sys_rand() -> u32 {
+extern "C" fn __sys_rand() -> u32 {
 	generate_park_miller_lehmer_random_number()
 }
 
@@ -55,7 +57,7 @@ pub extern "C" fn sys_rand() -> u32 {
 	kernel_function!(__sys_rand())
 }
 
-fn __sys_srand(seed: u32) {
+extern "C" fn __sys_srand(seed: u32) {
 	*(PARK_MILLER_LEHMER_SEED.lock()) = seed;
 }
 

--- a/src/syscalls/recmutex.rs
+++ b/src/syscalls/recmutex.rs
@@ -9,7 +9,7 @@ use crate::errno::*;
 use crate::synch::recmutex::RecursiveMutex;
 use alloc::boxed::Box;
 
-fn __sys_recmutex_init(recmutex: *mut *mut RecursiveMutex) -> i32 {
+extern "C" fn __sys_recmutex_init(recmutex: *mut *mut RecursiveMutex) -> i32 {
 	if recmutex.is_null() {
 		return -EINVAL;
 	}
@@ -28,7 +28,7 @@ pub extern "C" fn sys_recmutex_init(recmutex: *mut *mut RecursiveMutex) -> i32 {
 	kernel_function!(__sys_recmutex_init(recmutex))
 }
 
-fn __sys_recmutex_destroy(recmutex: *mut RecursiveMutex) -> i32 {
+extern "C" fn __sys_recmutex_destroy(recmutex: *mut RecursiveMutex) -> i32 {
 	if recmutex.is_null() {
 		return -EINVAL;
 	}
@@ -47,7 +47,7 @@ pub extern "C" fn sys_recmutex_destroy(recmutex: *mut RecursiveMutex) -> i32 {
 	kernel_function!(__sys_recmutex_destroy(recmutex))
 }
 
-fn __sys_recmutex_lock(recmutex: *mut RecursiveMutex) -> i32 {
+extern "C" fn __sys_recmutex_lock(recmutex: *mut RecursiveMutex) -> i32 {
 	if recmutex.is_null() {
 		return -EINVAL;
 	}
@@ -63,7 +63,7 @@ pub extern "C" fn sys_recmutex_lock(recmutex: *mut RecursiveMutex) -> i32 {
 	kernel_function!(__sys_recmutex_lock(recmutex))
 }
 
-fn __sys_recmutex_unlock(recmutex: *mut RecursiveMutex) -> i32 {
+extern "C" fn __sys_recmutex_unlock(recmutex: *mut RecursiveMutex) -> i32 {
 	if recmutex.is_null() {
 		return -EINVAL;
 	}

--- a/src/syscalls/semaphore.rs
+++ b/src/syscalls/semaphore.rs
@@ -9,7 +9,7 @@ use crate::errno::*;
 use crate::synch::semaphore::Semaphore;
 use alloc::boxed::Box;
 
-fn __sys_sem_init(sem: *mut *mut Semaphore, value: u32) -> i32 {
+extern "C" fn __sys_sem_init(sem: *mut *mut Semaphore, value: u32) -> i32 {
 	if sem.is_null() {
 		return -EINVAL;
 	}
@@ -27,7 +27,7 @@ pub extern "C" fn sys_sem_init(sem: *mut *mut Semaphore, value: u32) -> i32 {
 	kernel_function!(__sys_sem_init(sem, value))
 }
 
-fn __sys_sem_destroy(sem: *mut Semaphore) -> i32 {
+extern "C" fn __sys_sem_destroy(sem: *mut Semaphore) -> i32 {
 	if sem.is_null() {
 		return -EINVAL;
 	}
@@ -45,7 +45,7 @@ pub extern "C" fn sys_sem_destroy(sem: *mut Semaphore) -> i32 {
 	kernel_function!(__sys_sem_destroy(sem))
 }
 
-fn __sys_sem_post(sem: *const Semaphore) -> i32 {
+extern "C" fn __sys_sem_post(sem: *const Semaphore) -> i32 {
 	if sem.is_null() {
 		return -EINVAL;
 	}
@@ -61,7 +61,7 @@ pub extern "C" fn sys_sem_post(sem: *const Semaphore) -> i32 {
 	kernel_function!(__sys_sem_post(sem))
 }
 
-fn __sys_sem_trywait(sem: *const Semaphore) -> i32 {
+extern "C" fn __sys_sem_trywait(sem: *const Semaphore) -> i32 {
 	if sem.is_null() {
 		return -EINVAL;
 	}
@@ -80,7 +80,7 @@ pub extern "C" fn sys_sem_trywait(sem: *const Semaphore) -> i32 {
 	kernel_function!(__sys_sem_trywait(sem))
 }
 
-fn __sys_sem_timedwait(sem: *const Semaphore, ms: u32) -> i32 {
+extern "C" fn __sys_sem_timedwait(sem: *const Semaphore, ms: u32) -> i32 {
 	if sem.is_null() {
 		return -EINVAL;
 	}
@@ -101,7 +101,7 @@ pub extern "C" fn sys_sem_timedwait(sem: *const Semaphore, ms: u32) -> i32 {
 	kernel_function!(__sys_sem_timedwait(sem, ms))
 }
 
-fn __sys_sem_cancelablewait(sem: *const Semaphore, ms: u32) -> i32 {
+extern "C" fn __sys_sem_cancelablewait(sem: *const Semaphore, ms: u32) -> i32 {
 	sys_sem_timedwait(sem, ms)
 }
 

--- a/src/syscalls/spinlock.rs
+++ b/src/syscalls/spinlock.rs
@@ -19,7 +19,7 @@ pub struct SpinlockIrqSaveContainer<'a> {
 	guard: Option<SpinlockIrqSaveGuard<'a, ()>>,
 }
 
-fn __sys_spinlock_init(lock: *mut *mut SpinlockContainer<'_>) -> i32 {
+extern "C" fn __sys_spinlock_init(lock: *mut *mut SpinlockContainer<'_>) -> i32 {
 	if lock.is_null() {
 		return -EINVAL;
 	}
@@ -39,7 +39,7 @@ pub extern "C" fn sys_spinlock_init(lock: *mut *mut SpinlockContainer<'_>) -> i3
 	kernel_function!(__sys_spinlock_init(lock))
 }
 
-fn __sys_spinlock_destroy(lock: *mut SpinlockContainer<'_>) -> i32 {
+extern "C" fn __sys_spinlock_destroy(lock: *mut SpinlockContainer<'_>) -> i32 {
 	if lock.is_null() {
 		return -EINVAL;
 	}
@@ -56,7 +56,7 @@ pub extern "C" fn sys_spinlock_destroy(lock: *mut SpinlockContainer<'_>) -> i32 
 	kernel_function!(__sys_spinlock_destroy(lock))
 }
 
-fn __sys_spinlock_lock(lock: *mut SpinlockContainer<'_>) -> i32 {
+extern "C" fn __sys_spinlock_lock(lock: *mut SpinlockContainer<'_>) -> i32 {
 	if lock.is_null() {
 		return -EINVAL;
 	}
@@ -75,7 +75,7 @@ pub extern "C" fn sys_spinlock_lock(lock: *mut SpinlockContainer<'_>) -> i32 {
 	kernel_function!(__sys_spinlock_lock(lock))
 }
 
-fn __sys_spinlock_unlock(lock: *mut SpinlockContainer<'_>) -> i32 {
+extern "C" fn __sys_spinlock_unlock(lock: *mut SpinlockContainer<'_>) -> i32 {
 	if lock.is_null() {
 		return -EINVAL;
 	}
@@ -94,7 +94,7 @@ pub extern "C" fn sys_spinlock_unlock(lock: *mut SpinlockContainer<'_>) -> i32 {
 	kernel_function!(__sys_spinlock_unlock(lock))
 }
 
-fn __sys_spinlock_irqsave_init(lock: *mut *mut SpinlockIrqSaveContainer<'_>) -> i32 {
+extern "C" fn __sys_spinlock_irqsave_init(lock: *mut *mut SpinlockIrqSaveContainer<'_>) -> i32 {
 	if lock.is_null() {
 		return -EINVAL;
 	}
@@ -114,7 +114,7 @@ pub extern "C" fn sys_spinlock_irqsave_init(lock: *mut *mut SpinlockIrqSaveConta
 	kernel_function!(__sys_spinlock_irqsave_init(lock))
 }
 
-fn __sys_spinlock_irqsave_destroy(lock: *mut SpinlockIrqSaveContainer<'_>) -> i32 {
+extern "C" fn __sys_spinlock_irqsave_destroy(lock: *mut SpinlockIrqSaveContainer<'_>) -> i32 {
 	if lock.is_null() {
 		return -EINVAL;
 	}
@@ -131,7 +131,7 @@ pub extern "C" fn sys_spinlock_irqsave_destroy(lock: *mut SpinlockIrqSaveContain
 	kernel_function!(__sys_spinlock_irqsave_destroy(lock))
 }
 
-fn __sys_spinlock_irqsave_lock(lock: *mut SpinlockIrqSaveContainer<'_>) -> i32 {
+extern "C" fn __sys_spinlock_irqsave_lock(lock: *mut SpinlockIrqSaveContainer<'_>) -> i32 {
 	if lock.is_null() {
 		return -EINVAL;
 	}
@@ -150,7 +150,7 @@ pub extern "C" fn sys_spinlock_irqsave_lock(lock: *mut SpinlockIrqSaveContainer<
 	kernel_function!(__sys_spinlock_irqsave_lock(lock))
 }
 
-fn __sys_spinlock_irqsave_unlock(lock: *mut SpinlockIrqSaveContainer<'_>) -> i32 {
+extern "C" fn __sys_spinlock_irqsave_unlock(lock: *mut SpinlockIrqSaveContainer<'_>) -> i32 {
 	if lock.is_null() {
 		return -EINVAL;
 	}

--- a/src/syscalls/system.rs
+++ b/src/syscalls/system.rs
@@ -23,7 +23,7 @@
 
 use crate::arch;
 
-fn __sys_getpagesize() -> i32 {
+extern "C" fn __sys_getpagesize() -> i32 {
 	arch::x86_64::mm::paging::get_application_page_size() as i32
 }
 

--- a/src/syscalls/timer.rs
+++ b/src/syscalls/timer.rs
@@ -46,7 +46,7 @@ fn microseconds_to_timeval(microseconds: u64, result: &mut timeval) {
 	result.tv_usec = (microseconds % 1_000_000) as i64;
 }
 
-fn __sys_clock_getres(clock_id: u64, res: *mut timespec) -> i32 {
+extern "C" fn __sys_clock_getres(clock_id: u64, res: *mut timespec) -> i32 {
 	assert!(
 		!res.is_null(),
 		"sys_clock_getres called with a zero res parameter"
@@ -71,7 +71,7 @@ pub extern "C" fn sys_clock_getres(clock_id: u64, res: *mut timespec) -> i32 {
 	kernel_function!(__sys_clock_getres(clock_id, res))
 }
 
-fn __sys_clock_gettime(clock_id: u64, tp: *mut timespec) -> i32 {
+extern "C" fn __sys_clock_gettime(clock_id: u64, tp: *mut timespec) -> i32 {
 	assert!(
 		!tp.is_null(),
 		"sys_clock_gettime called with a zero tp parameter"
@@ -104,7 +104,7 @@ pub extern "C" fn sys_clock_gettime(clock_id: u64, tp: *mut timespec) -> i32 {
 	kernel_function!(__sys_clock_gettime(clock_id, tp))
 }
 
-fn __sys_clock_nanosleep(
+extern "C" fn __sys_clock_nanosleep(
 	clock_id: u64,
 	flags: i32,
 	rqtp: *const timespec,
@@ -153,7 +153,7 @@ pub extern "C" fn sys_clock_nanosleep(
 	kernel_function!(__sys_clock_nanosleep(clock_id, flags, rqtp, rmtp))
 }
 
-fn __sys_clock_settime(_clock_id: u64, _tp: *const timespec) -> i32 {
+extern "C" fn __sys_clock_settime(_clock_id: u64, _tp: *const timespec) -> i32 {
 	// We don't support setting any clocks yet.
 	debug!("sys_clock_settime is unimplemented, returning -EINVAL");
 	-EINVAL
@@ -164,7 +164,7 @@ pub extern "C" fn sys_clock_settime(clock_id: u64, tp: *const timespec) -> i32 {
 	kernel_function!(__sys_clock_settime(clock_id, tp))
 }
 
-fn __sys_gettimeofday(tp: *mut timeval, tz: usize) -> i32 {
+extern "C" fn __sys_gettimeofday(tp: *mut timeval, tz: usize) -> i32 {
 	if let Some(result) = unsafe { tp.as_mut() } {
 		// Return the current time based on the wallclock time when we were booted up
 		// plus the current timer ticks.
@@ -186,7 +186,11 @@ pub extern "C" fn sys_gettimeofday(tp: *mut timeval, tz: usize) -> i32 {
 }
 
 #[no_mangle]
-fn __sys_setitimer(_which: i32, _value: *const itimerval, _ovalue: *mut itimerval) -> i32 {
+extern "C" fn __sys_setitimer(
+	_which: i32,
+	_value: *const itimerval,
+	_ovalue: *mut itimerval,
+) -> i32 {
 	debug!("Called sys_setitimer, which is unimplemented and always returns 0");
 	0
 }


### PR DESCRIPTION
This fixes https://github.com/hermitcore/libhermit-rs/issues/234 introduced in https://github.com/hermitcore/libhermit-rs/commit/41cf625c33801690f5be566db67e3eec5b372feb.

As described in https://github.com/hermitcore/libhermit-rs/issues/234, the issue with the old implementation was inlining resulting in wrongly managing stack space after the switch, potentially resulting in a page fault, when writing before the new stack:

```rust
fn sys_foo() {
    // reserves stack space for `a` (`rsp -= 16`)

    switch_rsp();

    // use reserved stack space (`[rsp + 16]`), even though rsp is not the same anymore
    let a = [0_u8; 16];
}
```

To my knowledge, inlining can only be really prevented, by explicitly `call`ing the function in assembly.

I fixed this issue in five steps:

1. Remove `switch_to_kernel!`, `switch_to_user!`, migrate uses to `kernel_function!`
2. Fix a potential stack overflow caused by a typo (unrelated)
3. Improve consistency of kernel functions by adding the prefix `__sys_` to all functions.
4. Make all `__sys_`-functions `extern "C"` to allow calling in assembly.
5. Reimplement `kernel_function!` and call kernel function in assembly.