### PR TITLE
Fixup: Relay bigger types over pointers for affected kernel functions

### DIFF
--- a/src/arch/x86_64/kernel/switch.rs
+++ b/src/arch/x86_64/kernel/switch.rs
@@ -176,6 +176,10 @@ macro_rules! kernel_function_impl {
                     "mov rsp, {kernel_stack_ptr}",
                     "sti",
 
+					// To make sure, Rust manages the stack in `f` correctly,
+					// we keep all arguments and return values in registers
+					// until we switch the stack back. Thus follows the sizing
+					// requirements for arguments and return types.
                     "call {f}",
 
                     // Switch back to user stack

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -38,6 +38,21 @@ macro_rules! println {
 	($($arg:tt)+) => ($crate::print!("{}\n", format_args!($($arg)+)));
 }
 
+/// Runs `f` on the kernel stack.
+///
+/// All arguments and return values have to fit into registers:
+///
+/// ```
+/// assert!(mem::size_of::<T>() <= mem::size_of::<usize>());
+/// ```
+///
+/// When working with bigger types, manually route the data over pointers:
+///
+/// ```
+/// f(&arg1, &mut ret);
+/// // instead of
+/// let ret = f(arg);
+/// ```
 #[macro_export]
 macro_rules! kernel_function {
 	($f:ident()) => {

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -110,14 +110,15 @@ pub fn sys_get_mtu() -> Result<u16, ()> {
 	kernel_function!(__sys_get_mtu())
 }
 
-#[allow(improper_ctypes_definitions)]
-extern "C" fn __sys_get_tx_buffer(len: usize) -> Result<(*mut u8, usize), ()> {
-	unsafe { SYS.get_tx_buffer(len) }
+extern "C" fn __sys_get_tx_buffer(len: usize, ret: &mut Result<(*mut u8, usize), ()>) {
+	*ret = unsafe { SYS.get_tx_buffer(len) };
 }
 
 #[no_mangle]
 pub fn sys_get_tx_buffer(len: usize) -> Result<(*mut u8, usize), ()> {
-	kernel_function!(__sys_get_tx_buffer(len))
+	let mut ret = Err(());
+	kernel_function!(__sys_get_tx_buffer(len, &mut ret));
+	ret
 }
 
 #[allow(improper_ctypes_definitions)]
@@ -130,14 +131,15 @@ pub fn sys_send_tx_buffer(handle: usize, len: usize) -> Result<(), ()> {
 	kernel_function!(__sys_send_tx_buffer(handle, len))
 }
 
-#[allow(improper_ctypes_definitions)]
-extern "C" fn __sys_receive_rx_buffer() -> Result<(&'static [u8], usize), ()> {
-	unsafe { SYS.receive_rx_buffer() }
+extern "C" fn __sys_receive_rx_buffer(ret: &mut Result<(&'static [u8], usize), ()>) {
+	*ret = unsafe { SYS.receive_rx_buffer() };
 }
 
 #[no_mangle]
 pub fn sys_receive_rx_buffer() -> Result<(&'static [u8], usize), ()> {
-	kernel_function!(__sys_receive_rx_buffer())
+	let mut ret = Err(());
+	kernel_function!(__sys_receive_rx_buffer(&mut ret));
+	ret
 }
 
 #[allow(improper_ctypes_definitions)]
@@ -151,27 +153,25 @@ pub fn sys_rx_buffer_consumed(handle: usize) -> Result<(), ()> {
 }
 
 #[cfg(not(feature = "newlib"))]
-#[allow(improper_ctypes_definitions)]
-extern "C" fn __sys_netwait(handle: usize, millis: Option<u64>) {
-	netwait(handle, millis)
+extern "C" fn __sys_netwait(handle: usize, millis: &Option<u64>) {
+	netwait(handle, *millis)
 }
 
 #[cfg(not(feature = "newlib"))]
 #[no_mangle]
 pub fn sys_netwait(handle: usize, millis: Option<u64>) {
-	kernel_function!(__sys_netwait(handle, millis));
+	kernel_function!(__sys_netwait(handle, &millis));
 }
 
 #[cfg(not(feature = "newlib"))]
-#[allow(improper_ctypes_definitions)]
-extern "C" fn __sys_netwait_and_wakeup(handles: &[usize], millis: Option<u64>) {
-	netwait_and_wakeup(handles, millis);
+extern "C" fn __sys_netwait_and_wakeup(handles: &&[usize], millis: &Option<u64>) {
+	netwait_and_wakeup(*handles, *millis);
 }
 
 #[cfg(not(feature = "newlib"))]
 #[no_mangle]
 pub fn sys_netwait_and_wakeup(handles: &[usize], millis: Option<u64>) {
-	kernel_function!(__sys_netwait_and_wakeup(handles, millis));
+	kernel_function!(__sys_netwait_and_wakeup(&handles, &millis));
 }
 
 pub extern "C" fn __sys_shutdown(arg: i32) -> ! {

--- a/src/syscalls/random.rs
+++ b/src/syscalls/random.rs
@@ -23,9 +23,8 @@ extern "C" fn __sys_rand32() -> Option<u32> {
 	arch::processor::generate_random_number32()
 }
 
-#[allow(improper_ctypes_definitions)]
-extern "C" fn __sys_rand64() -> Option<u64> {
-	arch::processor::generate_random_number64()
+extern "C" fn __sys_rand64(ret: &mut Option<u64>) {
+	*ret = arch::processor::generate_random_number64();
 }
 
 extern "C" fn __sys_rand() -> u32 {
@@ -47,7 +46,9 @@ pub fn sys_secure_rand32() -> Option<u32> {
 #[cfg(not(feature = "newlib"))]
 #[no_mangle]
 pub fn sys_secure_rand64() -> Option<u64> {
-	kernel_function!(__sys_rand64())
+	let mut ret = None;
+	kernel_function!(__sys_rand64(&mut ret));
+	ret
 }
 
 /// The function computes a sequence of pseudo-random integers


### PR DESCRIPTION
Fixes https://github.com/hermitcore/libhermit-rs/issues/250.

This also improves documentation regarding the design of `kernel_function!`.

Supersedes https://github.com/hermitcore/libhermit-rs/pull/251.