### PR TITLE
Bump x86 from 0.40.0 to 0.41.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "9.1.1"
+version = "10.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1733f6f80c9c24268736a501cd00d41a9849b4faa7a9f9334c096e5d10553206"
+checksum = "929f54e29691d4e6a9cc558479de70db7aa3d98cd6fe7ab86d7507aa2886b9d2"
 dependencies = [
  "bitflags",
 ]
@@ -210,9 +210,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "x86"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d51a8a099ea6b47826796377591d2ed47116c7f0454f0d08d1d9872944880"
+checksum = "edcf43654d533a571fe7f7116373098a95ebc01279efdc5038fc45d3b220cb5a"
 dependencies = [
  "bit_field",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,12 +60,12 @@ scopeguard = { version = "1.1", default-features = false }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 multiboot = "0.6"
-x86 = { version = "0.40", default-features = false }
+x86 = { version = "0.41", default-features = false }
 
 [dev-dependencies]
 float-cmp = "0.8"
 num-traits = { version = "0.2", default-features = false }
-x86 = { version = "0.40", default-features = false }
+x86 = { version = "0.41", default-features = false }
 
 # The development profile, used for `cargo build`.
 [profile.dev]


### PR DESCRIPTION
- Bumps x86 from 0.40.0 to 0.41.0.
- The new version breaks the interface and requires source code modifications.
- see https://github.com/gz/rust-cpuid/blob/aaaa6e6fc07d04850f6119732b950d3a8383173b/CHANGELOG.md