### PR TITLE
Revert "align TLS to 32 byte boundary"

### DIFF
--- a/src/arch/x86_64/kernel/scheduler.rs
+++ b/src/arch/x86_64/kernel/scheduler.rs
@@ -249,7 +249,7 @@ impl TaskTLS {
 		let tdata_size: usize = environment::get_tls_filesz();
 		// Yes, it does, so we have to allocate TLS memory.
 		// Allocate enough space for the given size and one more variable of type usize, which holds the tls_pointer.
-		let tls_allocation_size = align_up!(tls_size, 32) + mem::size_of::<usize>();
+		let tls_allocation_size = tls_size + mem::size_of::<usize>();
 		// We allocate in 128 byte granularity (= cache line size) to avoid false sharing
 		let memory_size = align_up!(tls_allocation_size, 128);
 		let layout =
@@ -257,7 +257,7 @@ impl TaskTLS {
 		let ptr = VirtAddr(unsafe { alloc(layout) as u64 });
 
 		// The tls_pointer is the address to the end of the TLS area requested by the task.
-		let tls_pointer = ptr + align_up!(tls_size, 32);
+		let tls_pointer = ptr + tls_size;
 
 		unsafe {
 			// Copy over TLS variables with their initial values.
@@ -271,7 +271,7 @@ impl TaskTLS {
 				ptr.as_mut_ptr::<u8>()
 					.offset(tdata_size.try_into().unwrap()),
 				0,
-				align_up!(tls_size, 32) - tdata_size,
+				tls_size - tdata_size,
 			);
 
 			// The x86-64 TLS specification also requires that the tls_pointer can be accessed at fs:0.


### PR DESCRIPTION
This reverts commit 1f63d3fe76cc6e1a50b8d1e39868d27a624ea921.

I found `PT_TLS.p_memsz` to automatically be correctly aligned to the usual `0x8`. I don't think, explicitly aligning again to `0x8` or `PT_TLS.p_align`  is necessary.

This fixes https://github.com/hermitcore/rusty-hermit/issues/170. :tada: 