### PR TITLE
determine Local APIC and IO-APIC by the MultiProcessor Specification

### DIFF
--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::unaligned_references)]
+#![allow(unaligned_references)]
 
 use crate::arch;
 #[cfg(feature = "acpi")]

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -355,9 +355,7 @@ fn detect_from_mp() -> Result<PhysAddr, ()> {
 		Err(())
 	}?;
 
-	info!("Found MP config at {:#x}", unsafe {
-		ptr::read_unaligned(&mp_float.mp_config)
-	});
+	info!("Found MP config at {:#x}", { mp_float.mp_config });
 	info!(
 		"System uses Multiprocessing Specification 1.{}",
 		mp_float.version

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -410,7 +410,7 @@ fn detect_from_mp() -> Result<PhysAddr, ()> {
 		addr += mem::size_of::<ApicConfigTable>();
 		for _i in 0..mp_config.entry_count {
 			match unsafe { *(addr as *const u8) } {
-				// cpu entry
+				// CPU entry
 				0 => {
 					let cpu_entry: &ApicProcessorEntry =
 						unsafe { &*(addr as *const ApicProcessorEntry) };
@@ -419,7 +419,7 @@ fn detect_from_mp() -> Result<PhysAddr, ()> {
 					}
 					addr += mem::size_of::<ApicProcessorEntry>();
 				}
-				// IO_APIC
+				// IO-APIC entry
 				2 => {
 					let io_entry: &ApicIoEntry = unsafe { &*(addr as *const ApicIoEntry) };
 					let ioapic = io_entry.addr;

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -1,5 +1,3 @@
-#![allow(unaligned_references)]
-
 use crate::arch;
 #[cfg(feature = "acpi")]
 use crate::arch::x86_64::kernel::acpi;
@@ -357,7 +355,9 @@ fn detect_from_mp() -> Result<PhysAddr, ()> {
 		Err(())
 	}?;
 
-	info!("Found MP config at 0x{:x}", mp_float.mp_config);
+	info!("Found MP config at {:#x}", unsafe {
+		ptr::read_unaligned(&mp_float.mp_config)
+	});
 	info!(
 		"System uses Multiprocessing Specification 1.{}",
 		mp_float.version

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unaligned_references)]
+
 use crate::arch;
 #[cfg(feature = "acpi")]
 use crate::arch::x86_64::kernel::acpi;
@@ -347,18 +349,15 @@ fn search_mp_floating(start: PhysAddr, end: PhysAddr) -> Result<&'static ApicMP,
 
 /// Helper function to detect APIC by the Multiprocessor Specification
 fn detect_from_mp() -> Result<PhysAddr, ()> {
-	let mp_float = if let Ok(mpf) = search_mp_floating(PhysAddr(0xF0000u64), PhysAddr(0x100000u64))
-	{
+	let mp_float = if let Ok(mpf) = search_mp_floating(PhysAddr(0x9F000u64), PhysAddr(0xA0000u64)) {
 		Ok(mpf)
-	} else if let Ok(mpf) = search_mp_floating(PhysAddr(0x9F000u64), PhysAddr(0xA0000u64)) {
+	} else if let Ok(mpf) = search_mp_floating(PhysAddr(0xF0000u64), PhysAddr(0x100000u64)) {
 		Ok(mpf)
 	} else {
 		Err(())
 	}?;
 
-	info!("Found MP config at 0x{:x}", unsafe {
-		ptr::read_unaligned(&mp_float.mp_config)
-	});
+	info!("Found MP config at 0x{:x}", unsafe { mp_float.mp_config });
 	info!(
 		"System uses Multiprocessing Specification 1.{}",
 		mp_float.version

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -357,7 +357,7 @@ fn detect_from_mp() -> Result<PhysAddr, ()> {
 		Err(())
 	}?;
 
-	info!("Found MP config at 0x{:x}", unsafe { mp_float.mp_config });
+	info!("Found MP config at 0x{:x}", mp_float.mp_config);
 	info!(
 		"System uses Multiprocessing Specification 1.{}",
 		mp_float.version


### PR DESCRIPTION
If the ACPI detections fails of is disabled, RustyHermit uses the (old) MultiProcessor Specification to detect the Local APIC and the IO-APIC.