### PR TITLE
Rework Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,14 +58,12 @@ test:integration:
     - lscpu
     - kvm-ok
     - python3 --version
-    - cargo +nightly install --git https://github.com/hermitcore/uhyve.git --locked uhyve
     - HERMIT_LOG_LEVEL_FILTER=Debug cargo test --test '*' --no-fail-fast -Z build-std=core,alloc 
         -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi 
-        --target x86_64-unknown-none-hermitkernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --veryverbose
-    # 2 cores
+        --target x86_64-unknown-none-hermitkernel -- --veryverbose
     - HERMIT_LOG_LEVEL_FILTER=Debug cargo test --test '*' --no-fail-fast -Z build-std=core,alloc 
         -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi 
-        --target x86_64-unknown-none-hermitkernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --num_cores 2
+        --target x86_64-unknown-none-hermitkernel -- --num_cores 2
         --veryverbose
   tags:
     - privileged
@@ -78,7 +76,6 @@ test:uhyve:
    script:
      - lscpu
      - kvm-ok
-     - cargo +nightly install --git https://github.com/hermitcore/uhyve.git --locked uhyve
      - uhyve -v -c 1 rusty-hermit/target/x86_64-unknown-hermit/debug/rusty_demo
      - uhyve -v -c 2 rusty-hermit/target/x86_64-unknown-hermit/debug/rusty_demo
      - uhyve -v -c 1 rusty-hermit/target/x86_64-unknown-hermit/release/rusty_demo
@@ -94,22 +91,25 @@ test:qemu:
    script:
      - lscpu
      - kvm-ok
-     - git clone https://github.com/hermitcore/rusty-loader.git $CI_BUILDS_DIR/loader
-     - cd $CI_BUILDS_DIR/loader
-     - make
-     - make release=1
-     - cd -
-     - qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio 
-        -kernel $CI_BUILDS_DIR/loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader 
-        -initrd rusty-hermit/target/x86_64-unknown-hermit/debug/rusty_demo  -enable-kvm
-     - qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio 
-        -kernel $CI_BUILDS_DIR/loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader 
-        -initrd rusty-hermit/target/x86_64-unknown-hermit/debug/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -enable-kvm
-     - qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio 
-        -kernel $CI_BUILDS_DIR/loader/target/x86_64-unknown-hermit-loader/release/rusty-loader 
-        -initrd rusty-hermit/target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -enable-kvm
-     - qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio 
-        -kernel $CI_BUILDS_DIR/loader/target/x86_64-unknown-hermit-loader/release/rusty-loader 
-        -initrd rusty-hermit/target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -enable-kvm
+     - qemu-system-x86_64 -smp 1
+        -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand
+        -display none -m 64M -serial stdio -enable-kvm
+        -kernel /usr/local/bin/rusty-loader
+        -initrd rusty-hermit/target/x86_64-unknown-hermit/debug/rusty_demo
+     - qemu-system-x86_64 -smp 2
+        -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand
+        -display none -m 64M -serial stdio -enable-kvm
+        -kernel /usr/local/bin/rusty-loader
+        -initrd rusty-hermit/target/x86_64-unknown-hermit/debug/rusty_demo
+     - qemu-system-x86_64 -smp 1
+        -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand
+        -display none -m 64M -serial stdio -enable-kvm
+        -kernel /usr/local/bin/rusty-loader
+        -initrd rusty-hermit/target/x86_64-unknown-hermit/release/rusty_demo
+     - qemu-system-x86_64 -smp 2
+        -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand
+        -display none -m 64M -serial stdio -enable-kvm
+        -kernel /usr/local/bin/rusty-loader
+        -initrd rusty-hermit/target/x86_64-unknown-hermit/release/rusty_demo
    tags:
      - privileged

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ variables:
     - docker version
     - docker login --username "${CI_REGISTRY_USER}" --password "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
   script:
-    - docker build --no-cache -f ${DOCKER_FILE} -t ${DOCKER_IMAGE}:${DOCKER_TAG} .
+    - docker build -f ${DOCKER_FILE} -t ${DOCKER_IMAGE}:${DOCKER_TAG} .
     - docker push ${DOCKER_IMAGE}:${DOCKER_TAG}
   tags:
     - docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,71 @@
-FROM ubuntu:latest
+# Derived from rust:bullseye
+FROM buildpack-deps:bullseye as hermit-toolchain
 
-ENV DEBIAN_FRONTEND=noninteractive
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    # Manually sync this with rust-toolchain.toml!
+    RUST_VERSION=nightly-2021-12-04 \
+    RUST_COMPONENTS="clippy llvm-tools-preview rustfmt rust-src"
 
-RUN apt-get update && \
-    apt-get -y install cpu-checker util-linux apt-transport-https curl wget binutils build-essential gcc libtool bsdmainutils pkg-config libssl-dev git qemu-kvm qemu-system-x86 nasm seabios qemu-utils fdisk grub-pc grub-pc-bin grub-imageboot grub-legacy-ec2 multiboot kpartx gzip python3 && \
-    apt-get clean
+RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338' ;; \
+        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='67777ac3bc17277102f2ed73fd5f14c51f4ca5963adadf7f174adf4ebc38747b' ;; \
+        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='32a1532f7cef072a667bac53f1a5542c99666c4071af0c9549795bbdb2069ec1' ;; \
+        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='e50d1deb99048bc5782a0200aa33e4eea70747d49dffdc9d06812fd22a372515' ;; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
+    url="https://static.rust-lang.org/rustup/archive/1.24.3/${rustArch}/rustup-init"; \
+    wget "$url"; \
+    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path \
+        --profile minimal \
+        --default-toolchain $RUST_VERSION \
+        --default-host ${rustArch} \
+        --component $RUST_COMPONENTS \
+    ; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;
 
-# Install Rust toolchain
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly --profile minimal
-RUN /root/.cargo/bin/rustup component add llvm-tools-preview
-RUN /root/.cargo/bin/cargo install cargo-download
-RUN /root/.cargo/bin/cargo install cargo-binutils
+# Build dependencies with stable toolchain channel
+FROM rust:bullseye as stable-deps
+RUN set -eux; \
+    cargo install cargo-binutils; \
+    cargo install cargo-download;
 
+# Build dependencies with nightly toolchain channel
+FROM rustlang/rust:nightly as nightly-deps
+RUN set -eux; \
+    cargo install --git https://github.com/hermitcore/uhyve.git --locked uhyve;
 
-ENV PATH="/root/.cargo/bin:/root/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin/:${PATH}"
-ENV EDITOR=vim
+# Build dependencies with libhermit-rs' toolchain channel
+FROM hermit-toolchain as hermit-deps
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+        nasm \
+    ; \
+	rm -rf /var/lib/apt/lists/*; \
+    git clone https://github.com/hermitcore/rusty-loader.git; \
+    make -C rusty-loader release=1;
 
-# Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
-
+# Install dependencies
+FROM hermit-toolchain as ci-runner
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+        # For kvm-ok:
+		cpu-checker \
+        qemu-system-x86 \
+    ; \
+	rm -rf /var/lib/apt/lists/*;
+COPY --from=stable-deps $CARGO_HOME/bin/rust-objcopy $CARGO_HOME/bin/rust-objcopy
+COPY --from=stable-deps $CARGO_HOME/bin/cargo-download $CARGO_HOME/bin/cargo-download
+COPY --from=nightly-deps $CARGO_HOME/bin/uhyve $CARGO_HOME/bin/uhyve
+COPY --from=hermit-deps rusty-loader/target/x86_64-unknown-hermit-loader/release/rusty-loader /usr/local/bin/rusty-loader

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,8 +1,9 @@
 [toolchain]
+# Manually sync this with Dockerfile!
 channel = "nightly-2021-12-04"
 components = [
-    "rust-src",
+    "clippy",
     "llvm-tools-preview",
     "rustfmt",
-    "clippy",
+    "rust-src",
 ]


### PR DESCRIPTION
This rewrites the Dockerfile and moves all dependencies into the docker image, where dependencies are compiled modularly on their respective toolchains.

Note that this moves the base image from `ubuntu:latest` to `debian:bullseye`.