### PR TITLE
TaskTLS: Copy memory on clone

### DIFF
--- a/src/arch/x86_64/kernel/scheduler.rs
+++ b/src/arch/x86_64/kernel/scheduler.rs
@@ -237,6 +237,7 @@ impl Clone for TaskStacks {
 	}
 }
 
+#[derive(Clone)]
 pub struct TaskTLS {
 	_block: Box<[u8]>,
 	thread_ptr: Box<*mut ()>,
@@ -296,12 +297,6 @@ impl TaskTLS {
 
 	fn thread_ptr(&self) -> &*mut () {
 		&*self.thread_ptr
-	}
-}
-
-impl Clone for TaskTLS {
-	fn clone(&self) -> Self {
-		Self::from_environment()
 	}
 }
 


### PR DESCRIPTION
This makes TaskTLS' Clone implementation copy modifications to TLS instead of creating a new one from scratch (introduced in fdf8bb7).

TaskTLS' are cloned in [`Task::clone`](https://github.com/hermitcore/libhermit-rs/blob/35d73d519885e72f27e7ba9f81266571163b3ed8/src/scheduler/task.rs#L429-L447) from [`PerCoreScheduler::clone_impl`](https://github.com/hermitcore/libhermit-rs/blob/35d73d519885e72f27e7ba9f81266571163b3ed8/src/scheduler/mod.rs#L160-L210) from [`sys_clone`](https://github.com/hermitcore/libhermit-rs/blob/35d73d519885e72f27e7ba9f81266571163b3ed8/src/syscalls/tasks.rs#L166-L183).

That system calls semantic should be the same as [`clone(2)`](https://www.man7.org/linux/man-pages/man2/clone.2.html#NOTES).