### PR TITLE
avoid exporting of macros

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -23,6 +23,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     steps:
+      - name: Install cargo-binutils
+        run: cargo install cargo-binutils
       - name: Checkout rusty-hermit
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/x86.yml
+++ b/.github/workflows/x86.yml
@@ -23,6 +23,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
+      - name: Install cargo-binutils
+        run: cargo install cargo-binutils
       - name: Checkout rusty-hermit
         uses: actions/checkout@v2
         with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,14 +58,12 @@ test:integration:
     - lscpu
     - kvm-ok
     - python3 --version
-    - cargo +nightly install --git https://github.com/hermitcore/uhyve.git --locked uhyve
     - HERMIT_LOG_LEVEL_FILTER=Debug cargo test --test '*' --no-fail-fast -Z build-std=core,alloc 
         -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi 
-        --target x86_64-unknown-none-hermitkernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --veryverbose
-    # 2 cores
+        --target x86_64-unknown-none-hermitkernel -- --veryverbose
     - HERMIT_LOG_LEVEL_FILTER=Debug cargo test --test '*' --no-fail-fast -Z build-std=core,alloc 
         -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi 
-        --target x86_64-unknown-none-hermitkernel -- --uhyve_path=$HOME/.cargo/bin/uhyve --num_cores 2
+        --target x86_64-unknown-none-hermitkernel -- --num_cores 2
         --veryverbose
   tags:
     - privileged
@@ -78,7 +76,6 @@ test:uhyve:
    script:
      - lscpu
      - kvm-ok
-     - cargo +nightly install --git https://github.com/hermitcore/uhyve.git --locked uhyve
      - uhyve -v -c 1 rusty-hermit/target/x86_64-unknown-hermit/debug/rusty_demo
      - uhyve -v -c 2 rusty-hermit/target/x86_64-unknown-hermit/debug/rusty_demo
      - uhyve -v -c 1 rusty-hermit/target/x86_64-unknown-hermit/release/rusty_demo
@@ -94,22 +91,25 @@ test:qemu:
    script:
      - lscpu
      - kvm-ok
-     - git clone https://github.com/hermitcore/rusty-loader.git $CI_BUILDS_DIR/loader
-     - cd $CI_BUILDS_DIR/loader
-     - make
-     - make release=1
-     - cd -
-     - qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio 
-        -kernel $CI_BUILDS_DIR/loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader 
-        -initrd rusty-hermit/target/x86_64-unknown-hermit/debug/rusty_demo  -enable-kvm
-     - qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio 
-        -kernel $CI_BUILDS_DIR/loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader 
-        -initrd rusty-hermit/target/x86_64-unknown-hermit/debug/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -enable-kvm
-     - qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio 
-        -kernel $CI_BUILDS_DIR/loader/target/x86_64-unknown-hermit-loader/release/rusty-loader 
-        -initrd rusty-hermit/target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -enable-kvm
-     - qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio 
-        -kernel $CI_BUILDS_DIR/loader/target/x86_64-unknown-hermit-loader/release/rusty-loader 
-        -initrd rusty-hermit/target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -enable-kvm
+     - qemu-system-x86_64 -smp 1
+        -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand
+        -display none -m 64M -serial stdio -enable-kvm
+        -kernel /usr/local/bin/rusty-loader
+        -initrd rusty-hermit/target/x86_64-unknown-hermit/debug/rusty_demo
+     - qemu-system-x86_64 -smp 2
+        -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand
+        -display none -m 64M -serial stdio -enable-kvm
+        -kernel /usr/local/bin/rusty-loader
+        -initrd rusty-hermit/target/x86_64-unknown-hermit/debug/rusty_demo
+     - qemu-system-x86_64 -smp 1
+        -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand
+        -display none -m 64M -serial stdio -enable-kvm
+        -kernel /usr/local/bin/rusty-loader
+        -initrd rusty-hermit/target/x86_64-unknown-hermit/release/rusty_demo
+     - qemu-system-x86_64 -smp 2
+        -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand
+        -display none -m 64M -serial stdio -enable-kvm
+        -kernel /usr/local/bin/rusty-loader
+        -initrd rusty-hermit/target/x86_64-unknown-hermit/release/rusty_demo
    tags:
      - privileged

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ variables:
     - docker version
     - docker login --username "${CI_REGISTRY_USER}" --password "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
   script:
-    - docker build --no-cache -f ${DOCKER_FILE} -t ${DOCKER_IMAGE}:${DOCKER_TAG} .
+    - docker build -f ${DOCKER_FILE} -t ${DOCKER_IMAGE}:${DOCKER_TAG} .
     - docker push ${DOCKER_IMAGE}:${DOCKER_TAG}
   tags:
     - docker

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-hermit"
-version = "0.3.53"
+version = "0.3.54"
 authors = [
 	"Stefan Lankes <slankes@eonerc.rwth-aachen.de>",
 	"Colin Finck <colin.finck@rwth-aachen.de>",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,71 @@
-FROM ubuntu:latest
+# Derived from rust:bullseye
+FROM buildpack-deps:bullseye as hermit-toolchain
 
-ENV DEBIAN_FRONTEND=noninteractive
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    # Manually sync this with rust-toolchain.toml!
+    RUST_VERSION=nightly-2021-12-04 \
+    RUST_COMPONENTS="clippy llvm-tools-preview rustfmt rust-src"
 
-RUN apt-get update && \
-    apt-get -y install cpu-checker util-linux apt-transport-https curl wget binutils build-essential gcc libtool bsdmainutils pkg-config libssl-dev git qemu-kvm qemu-system-x86 nasm seabios qemu-utils fdisk grub-pc grub-pc-bin grub-imageboot grub-legacy-ec2 multiboot kpartx gzip python3 && \
-    apt-get clean
+RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338' ;; \
+        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='67777ac3bc17277102f2ed73fd5f14c51f4ca5963adadf7f174adf4ebc38747b' ;; \
+        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='32a1532f7cef072a667bac53f1a5542c99666c4071af0c9549795bbdb2069ec1' ;; \
+        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='e50d1deb99048bc5782a0200aa33e4eea70747d49dffdc9d06812fd22a372515' ;; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
+    url="https://static.rust-lang.org/rustup/archive/1.24.3/${rustArch}/rustup-init"; \
+    wget "$url"; \
+    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path \
+        --profile minimal \
+        --default-toolchain $RUST_VERSION \
+        --default-host ${rustArch} \
+        --component $RUST_COMPONENTS \
+    ; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;
 
-# Install Rust toolchain
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly --profile minimal
-RUN /root/.cargo/bin/rustup component add llvm-tools-preview
-RUN /root/.cargo/bin/cargo install cargo-download
-RUN /root/.cargo/bin/cargo install cargo-binutils
+# Build dependencies with stable toolchain channel
+FROM rust:bullseye as stable-deps
+RUN set -eux; \
+    cargo install cargo-binutils; \
+    cargo install cargo-download;
 
+# Build dependencies with nightly toolchain channel
+FROM rustlang/rust:nightly as nightly-deps
+RUN set -eux; \
+    cargo install --git https://github.com/hermitcore/uhyve.git --locked uhyve;
 
-ENV PATH="/root/.cargo/bin:/root/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin/:${PATH}"
-ENV EDITOR=vim
+# Build dependencies with libhermit-rs' toolchain channel
+FROM hermit-toolchain as hermit-deps
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+        nasm \
+    ; \
+	rm -rf /var/lib/apt/lists/*; \
+    git clone https://github.com/hermitcore/rusty-loader.git; \
+    make -C rusty-loader release=1;
 
-# Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
-
+# Install dependencies
+FROM hermit-toolchain as ci-runner
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+        # For kvm-ok:
+		cpu-checker \
+        qemu-system-x86 \
+    ; \
+	rm -rf /var/lib/apt/lists/*;
+COPY --from=stable-deps $CARGO_HOME/bin/rust-objcopy $CARGO_HOME/bin/rust-objcopy
+COPY --from=stable-deps $CARGO_HOME/bin/cargo-download $CARGO_HOME/bin/cargo-download
+COPY --from=nightly-deps $CARGO_HOME/bin/uhyve $CARGO_HOME/bin/uhyve
+COPY --from=hermit-deps rusty-loader/target/x86_64-unknown-hermit-loader/release/rusty-loader /usr/local/bin/rusty-loader

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,8 +1,9 @@
 [toolchain]
+# Manually sync this with Dockerfile!
 channel = "nightly-2021-12-04"
 components = [
-    "rust-src",
+    "clippy",
     "llvm-tools-preview",
     "rustfmt",
-    "clippy",
+    "rust-src",
 ]

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::unaligned_references)]
+#![allow(unaligned_references)]
 
 use crate::arch;
 #[cfg(feature = "acpi")]

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -355,9 +355,7 @@ fn detect_from_mp() -> Result<PhysAddr, ()> {
 		Err(())
 	}?;
 
-	info!("Found MP config at {:#x}", unsafe {
-		ptr::read_unaligned(&mp_float.mp_config)
-	});
+	info!("Found MP config at {:#x}", { mp_float.mp_config });
 	info!(
 		"System uses Multiprocessing Specification 1.{}",
 		mp_float.version

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -410,7 +410,7 @@ fn detect_from_mp() -> Result<PhysAddr, ()> {
 		addr += mem::size_of::<ApicConfigTable>();
 		for _i in 0..mp_config.entry_count {
 			match unsafe { *(addr as *const u8) } {
-				// cpu entry
+				// CPU entry
 				0 => {
 					let cpu_entry: &ApicProcessorEntry =
 						unsafe { &*(addr as *const ApicProcessorEntry) };
@@ -419,7 +419,7 @@ fn detect_from_mp() -> Result<PhysAddr, ()> {
 					}
 					addr += mem::size_of::<ApicProcessorEntry>();
 				}
-				// IO_APIC
+				// IO-APIC entry
 				2 => {
 					let io_entry: &ApicIoEntry = unsafe { &*(addr as *const ApicIoEntry) };
 					let ioapic = io_entry.addr;

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -1,5 +1,3 @@
-#![allow(unaligned_references)]
-
 use crate::arch;
 #[cfg(feature = "acpi")]
 use crate::arch::x86_64::kernel::acpi;
@@ -357,7 +355,9 @@ fn detect_from_mp() -> Result<PhysAddr, ()> {
 		Err(())
 	}?;
 
-	info!("Found MP config at 0x{:x}", mp_float.mp_config);
+	info!("Found MP config at {:#x}", unsafe {
+		ptr::read_unaligned(&mp_float.mp_config)
+	});
 	info!(
 		"System uses Multiprocessing Specification 1.{}",
 		mp_float.version

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unaligned_references)]
+
 use crate::arch;
 #[cfg(feature = "acpi")]
 use crate::arch::x86_64::kernel::acpi;
@@ -347,18 +349,15 @@ fn search_mp_floating(start: PhysAddr, end: PhysAddr) -> Result<&'static ApicMP,
 
 /// Helper function to detect APIC by the Multiprocessor Specification
 fn detect_from_mp() -> Result<PhysAddr, ()> {
-	let mp_float = if let Ok(mpf) = search_mp_floating(PhysAddr(0xF0000u64), PhysAddr(0x100000u64))
-	{
+	let mp_float = if let Ok(mpf) = search_mp_floating(PhysAddr(0x9F000u64), PhysAddr(0xA0000u64)) {
 		Ok(mpf)
-	} else if let Ok(mpf) = search_mp_floating(PhysAddr(0x9F000u64), PhysAddr(0xA0000u64)) {
+	} else if let Ok(mpf) = search_mp_floating(PhysAddr(0xF0000u64), PhysAddr(0x100000u64)) {
 		Ok(mpf)
 	} else {
 		Err(())
 	}?;
 
-	info!("Found MP config at 0x{:x}", unsafe {
-		ptr::read_unaligned(&mp_float.mp_config)
-	});
+	info!("Found MP config at 0x{:x}", unsafe { mp_float.mp_config });
 	info!(
 		"System uses Multiprocessing Specification 1.{}",
 		mp_float.version

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -357,7 +357,7 @@ fn detect_from_mp() -> Result<PhysAddr, ()> {
 		Err(())
 	}?;
 
-	info!("Found MP config at 0x{:x}", unsafe { mp_float.mp_config });
+	info!("Found MP config at 0x{:x}", mp_float.mp_config);
 	info!(
 		"System uses Multiprocessing Specification 1.{}",
 		mp_float.version

--- a/src/arch/x86_64/kernel/gdt.rs
+++ b/src/arch/x86_64/kernel/gdt.rs
@@ -108,7 +108,7 @@ pub fn add_current_core() {
 			let tss_descriptor: Descriptor64 =
 				<DescriptorBuilder as GateDescriptorBuilder<u64>>::tss_descriptor(
 					base,
-					base + mem::size_of::<TaskStateSegment>() as u64 - 1,
+					mem::size_of::<TaskStateSegment>() as u64 - 1,
 					true,
 				)
 				.present()

--- a/src/console.rs
+++ b/src/console.rs
@@ -8,6 +8,7 @@ pub struct Console(());
 /// a message to HermitCore's console.
 impl fmt::Write for Console {
 	/// Print a string of characters.
+	#[inline]
 	fn write_str(&mut self, s: &str) -> fmt::Result {
 		if !s.is_empty() {
 			let buf = s.as_bytes();
@@ -16,14 +17,10 @@ impl fmt::Write for Console {
 
 		Ok(())
 	}
-
-	/// Print a single character.
-	fn write_char(&mut self, c: char) -> fmt::Result {
-		self.write_str(c.encode_utf8(&mut [0; 4]))
-	}
 }
 
 impl Console {
+	#[inline]
 	pub fn write_all(&mut self, buf: &[u8]) {
 		arch::output_message_buf(buf)
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ mod syscalls;
 mod util;
 
 #[doc(hidden)]
-pub fn _print(args: ::core::fmt::Arguments<'_>) {
+fn _print(args: ::core::fmt::Arguments<'_>) {
 	use core::fmt::Write;
 	crate::console::CONSOLE.lock().write_fmt(args).unwrap();
 }
@@ -331,7 +331,9 @@ fn synch_all_cores() {
 fn boot_processor_main() -> ! {
 	// Initialize the kernel and hardware.
 	arch::message_output_init();
-	logging::init();
+	unsafe {
+		logging::init();
+	}
 
 	info!("Welcome to HermitCore-rs {}", env!("CARGO_PKG_VERSION"));
 	info!("Kernel starts at {:#x}", environment::get_base_address());

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,4 +1,4 @@
-use log::{set_logger, set_max_level, LevelFilter, Metadata, Record};
+use log::{set_logger_racy, set_max_level, LevelFilter, Metadata, Record};
 
 /// Data structure to filter kernel messages
 struct KernelLogger;
@@ -24,8 +24,8 @@ impl log::Log for KernelLogger {
 	}
 }
 
-pub fn init() {
-	set_logger(&KernelLogger).expect("Can't initialize logger");
+pub unsafe fn init() {
+	set_logger_racy(&KernelLogger).expect("Can't initialize logger");
 	// Determines LevelFilter at compile time
 	let log_level: Option<&'static str> = option_env!("HERMIT_LOG_LEVEL_FILTER");
 	let max_level: LevelFilter = match log_level {
@@ -56,7 +56,7 @@ macro_rules! infoheader {
 
 #[macro_export]
 macro_rules! infoentry {
-	($str:expr, $rhs:expr) => ($crate::infoentry!($str, "{}", $rhs));
+	($str:expr, $rhs:expr) => (crate::infoentry!($str, "{}", $rhs));
 	($str:expr, $($arg:tt)+) => (::log::info!("{:25}{}", concat!($str, ":"), format_args!($($arg)+)));
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -18,16 +18,14 @@ macro_rules! align_up {
 /// for HermitCore.
 #[macro_export]
 macro_rules! print {
-	($($arg:tt)+) => ({
-		$crate::_print(format_args!($($arg)*));
-	});
+	($($arg:tt)*) => ($crate::_print(::core::format_args!($($arg)*)));
 }
 
 /// Print formatted text to our console, followed by a newline.
 #[macro_export]
 macro_rules! println {
 	() => ($crate::print!("\n"));
-	($($arg:tt)+) => ($crate::print!("{}\n", format_args!($($arg)+)));
+	($($arg:tt)*) => ($crate::print!("{}\n", ::core::format_args!($($arg)*)));
 }
 
 /// Runs `f` on the kernel stack.


### PR DESCRIPTION
- inline wrapper functions
- don't use a thread-safe version to initialize the kernel logger
  because at this stage the kernel doesn't provide threads