### PR TITLE
synchronize aarch64 port to x86 port

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,14 +48,13 @@ name = "measure_startup_time"
 harness = false
 
 [features]
-default = ["pci", "acpi", "fsgsbase", "smp", "aarch64-qemu-stdout"]
+default = ["pci", "acpi", "fsgsbase", "smp"]
 vga = []
 newlib = []
 pci = []
 acpi = []
 smp = []
 fsgsbase = []
-aarch64-qemu-stdout = []	# Doesn't do anything on x86 
 
 [dependencies]
 bitflags = "1.3"

--- a/src/arch/aarch64/kernel/irq.rs
+++ b/src/arch/aarch64/kernel/irq.rs
@@ -83,3 +83,48 @@ pub extern "C" fn irq_install_handler(irq_number: u32, handler: usize) {
 	info!("Install handler for interrupt {}", irq_number);
 	// TODO
 }
+
+#[no_mangle]
+pub extern "C" fn do_fiq(_: *const u8) {
+	debug!("Receive fast interrupt\n");
+
+	loop {
+		crate::arch::processor::halt()
+	}
+}
+
+#[no_mangle]
+pub extern "C" fn do_irq(_: *const u8) {
+	debug!("Receive interrupt\n");
+
+	loop {
+		crate::arch::processor::halt()
+	}
+}
+
+#[no_mangle]
+pub extern "C" fn do_sync(_: *const u8) {
+	debug!("Receive synchronous exception\n");
+
+	loop {
+		crate::arch::processor::halt()
+	}
+}
+
+#[no_mangle]
+pub extern "C" fn do_bad_mode(_: *const u8, reason: u32) {
+	error!("Receive unhandled exception: {}\n", reason);
+
+	loop {
+		crate::arch::processor::halt()
+	}
+}
+
+#[no_mangle]
+pub extern "C" fn do_error(_: *const u8) {
+	error!("Receive error interrupt\n");
+
+	loop {
+		crate::arch::processor::halt()
+	}
+}

--- a/src/arch/aarch64/kernel/irq.rs
+++ b/src/arch/aarch64/kernel/irq.rs
@@ -6,7 +6,11 @@ const IRQ_FLAG_A: usize = 1 << 8;
 #[inline]
 pub fn enable() {
 	unsafe {
-		llvm_asm!("msr daifclr, 0b111" ::: "memory" : "volatile");
+		asm!(
+			"msr daifclr, {mask}",
+			mask = const 0b111,
+			options(nostack, nomem),
+		);
 	}
 }
 
@@ -16,15 +20,24 @@ pub fn enable() {
 /// This is important, because another CPU could call wakeup_core right when we decide to wait for the next interrupt.
 #[inline]
 pub fn enable_and_wait() {
-	// TODO
-	unsafe { llvm_asm!("msr daifclr, 0b111; wfi" :::: "volatile") };
+	unsafe {
+		asm!(
+			"msr daifclr, {mask}; wfi",
+			mask = const 0b111,
+			options(nostack, nomem),
+		);
+	}
 }
 
 /// Disable Interrupts
 #[inline]
 pub fn disable() {
 	unsafe {
-		llvm_asm!("msr daifset, 0b111" ::: "memory" : "volatile");
+		asm!(
+			"msr daifset, {mask}",
+			mask = const 0b111,
+			options(nostack, nomem),
+		);
 	}
 }
 
@@ -38,7 +51,11 @@ pub fn disable() {
 pub fn nested_disable() -> bool {
 	let flags: usize;
 	unsafe {
-		llvm_asm!("mrs $0, daif" : "=r"(flags) :: "memory" : "volatile");
+		asm!(
+			"mrs {}, daif",
+			out(reg) flags,
+			options(nostack, nomem),
+		);
 	}
 
 	let mut was_enabled = true;

--- a/src/arch/aarch64/kernel/mod.rs
+++ b/src/arch/aarch64/kernel/mod.rs
@@ -101,7 +101,6 @@ pub fn message_output_init() {
 		COM1.port_address = core::ptr::read_volatile(&(*BOOT_INFO).uartport);
 	}
 
-	#[cfg(not(feature = "aarch64-qemu-stdout"))]
 	if environment::is_single_kernel() {
 		// We can only initialize the serial port here, because VGA requires processor
 		// configuration first.
@@ -112,11 +111,6 @@ pub fn message_output_init() {
 }
 
 pub fn output_message_byte(byte: u8) {
-	#[cfg(feature = "aarch64-qemu-stdout")]
-	unsafe {
-		core::ptr::write_volatile(0x3F20_1000 as *mut u8, byte);
-	}
-	#[cfg(not(feature = "aarch64-qemu-stdout"))]
 	if environment::is_single_kernel() {
 		// Output messages to the serial port.
 		unsafe {

--- a/src/arch/aarch64/kernel/processor.rs
+++ b/src/arch/aarch64/kernel/processor.rs
@@ -39,9 +39,16 @@ pub fn run_on_hypervisor() -> bool {
 pub fn msb(value: u64) -> Option<u64> {
 	if value > 0 {
 		let ret: u64;
-		let u64_bits = 64;
+
 		unsafe {
-			llvm_asm!("clz $0, $1; sub $0, $2, $0" : "=r"(ret) : "r"(value), "r"(u64_bits - 1) : "cc" : "volatile");
+			asm!(
+				"clz {0}, {1}",
+				"sub {0}, {2}, {0}",
+				out(reg) ret,
+				in(reg) value,
+				const 64 - 1,
+				options(nostack, nomem),
+			);
 		}
 		Some(ret)
 	} else {
@@ -52,7 +59,7 @@ pub fn msb(value: u64) -> Option<u64> {
 /// The halt function stops the processor until the next interrupt arrives
 pub fn halt() {
 	unsafe {
-		llvm_asm!("wfi" :::: "volatile");
+		asm!("wfi", options(nostack, nomem),);
 	}
 }
 

--- a/src/arch/aarch64/kernel/serial.rs
+++ b/src/arch/aarch64/kernel/serial.rs
@@ -16,7 +16,7 @@ impl SerialPort {
 		if byte == b'\n' {
 			unsafe {
 				asm!(
-					"str x8, [{port}]",
+					"strb w8, [{port}]",
 					port = in(reg) port,
 					in("x8") b'\r',
 					options(nostack),
@@ -26,7 +26,7 @@ impl SerialPort {
 
 		unsafe {
 			asm!(
-				"str x8, [{port}]",
+				"strb w8, [{port}]",
 				port = in(reg) port,
 				in("x8") byte,
 				options(nostack),

--- a/src/arch/aarch64/kernel/serial.rs
+++ b/src/arch/aarch64/kernel/serial.rs
@@ -1,7 +1,5 @@
-use core::ptr;
-
 pub struct SerialPort {
-	port_address: u32,
+	pub port_address: u32,
 }
 
 impl SerialPort {
@@ -17,16 +15,26 @@ impl SerialPort {
 		// LF newline characters need to be extended to CRLF over a real serial port.
 		if byte == b'\n' {
 			unsafe {
-				core::ptr::write_volatile(port, b'\r');
+				asm!(
+					"str x8, [{port}]",
+					port = in(reg) port,
+					in("x8") b'\r',
+					options(nostack),
+				);
 			}
 		}
 
 		unsafe {
-			core::ptr::write_volatile(port, byte);
+			asm!(
+				"str x8, [{port}]",
+				port = in(reg) port,
+				in("x8") byte,
+				options(nostack),
+			);
 		}
 	}
 
-	pub fn init(&self, baudrate: u32) {
+	pub fn init(&self, _baudrate: u32) {
 		// We don't do anything here (yet).
 	}
 }

--- a/src/arch/aarch64/kernel/start.rs
+++ b/src/arch/aarch64/kernel/start.rs
@@ -13,25 +13,33 @@ extern "C" {
 #[naked]
 pub unsafe extern "C" fn _start() -> ! {
 	asm!(
-		"mov x1, x0",
-		"add x1, x1, {current_stack_address_offset}",
-		"ldr x2, [x1]",   /* Previous version subtracted 0x10 from End, so I'm doing this too. Not sure why though. COMMENT from SL: This is a habit of mine. I always start 0x10 bytes before the end of the stack. */
-		"mov x3, {stack_top_offset}",
-		"add x2, x2, x3",
-		"mov sp, x2",
-		/* Set exception table */
-		"adrp x4, {vector_table}",
-		"add  x4, x4, #:lo12:{vector_table}",
-		"msr vbar_el1, x4",
-		"adrp x4, {pre_init}",
-		"add  x4, x4, #:lo12:{pre_init}",
-		"br x4",
-		current_stack_address_offset = const BootInfo::current_stack_address_offset(),
-		stack_top_offset = const KERNEL_STACK_SIZE - TaskStacks::MARKER_SIZE,
-		vector_table = sym vector_table,
-		pre_init = sym pre_init,
-		options(noreturn),
-	)
+		 "mov x1, x0",
+		 "add x1, x1, {current_stack_address_offset}",
+		 "ldr x2, [x1]",   /* Previous version subtracted 0x10 from End, so I'm doing this too. Not sure why though. COMMENT from SL: This is a habit of mine. I always start 0x10 bytes before the end of the stack. */
+		 "mov x3, {stack_top_offset}",
+		 "add x2, x2, x3",
+		 "mov sp, x2",
+		 /* reset thread id registers */
+		 "msr tpidr_el1, xzr",
+		 /* set system control register */
+		 "ldr x3, ={sctlr}",
+		 "msr sctlr_el1, x3",
+		 /* Reset debug controll register */
+		 "msr mdscr_el1, xzr",
+		 /* set exception table */
+		 "adrp x4, {vector_table}",
+		 "add  x4, x4, #:lo12:{vector_table}",
+		 "msr vbar_el1, x4",
+		 "adrp x4, {pre_init}",
+		 "add  x4, x4, #:lo12:{pre_init}",
+		 "br x4",
+		 current_stack_address_offset = const BootInfo::current_stack_address_offset(),
+		 stack_top_offset = const KERNEL_STACK_SIZE - TaskStacks::MARKER_SIZE,
+		 sctlr = const 0x4D5D91Cisize,
+		 vector_table = sym vector_table,
+		 pre_init = sym pre_init,
+		 options(noreturn),
+	 )
 }
 
 #[inline(never)]

--- a/src/arch/aarch64/kernel/start.rs
+++ b/src/arch/aarch64/kernel/start.rs
@@ -13,33 +13,33 @@ extern "C" {
 #[naked]
 pub unsafe extern "C" fn _start() -> ! {
 	asm!(
-		 "mov x1, x0",
-		 "add x1, x1, {current_stack_address_offset}",
-		 "ldr x2, [x1]",   /* Previous version subtracted 0x10 from End, so I'm doing this too. Not sure why though. COMMENT from SL: This is a habit of mine. I always start 0x10 bytes before the end of the stack. */
-		 "mov x3, {stack_top_offset}",
-		 "add x2, x2, x3",
-		 "mov sp, x2",
-		 /* reset thread id registers */
-		 "msr tpidr_el1, xzr",
-		 /* set system control register */
-		 "ldr x3, ={sctlr}",
-		 "msr sctlr_el1, x3",
-		 /* Reset debug controll register */
-		 "msr mdscr_el1, xzr",
-		 /* set exception table */
-		 "adrp x4, {vector_table}",
-		 "add  x4, x4, #:lo12:{vector_table}",
-		 "msr vbar_el1, x4",
-		 "adrp x4, {pre_init}",
-		 "add  x4, x4, #:lo12:{pre_init}",
-		 "br x4",
-		 current_stack_address_offset = const BootInfo::current_stack_address_offset(),
-		 stack_top_offset = const KERNEL_STACK_SIZE - TaskStacks::MARKER_SIZE,
-		 sctlr = const 0x4D5D91Cisize,
-		 vector_table = sym vector_table,
-		 pre_init = sym pre_init,
-		 options(noreturn),
-	 )
+		"mov x1, x0",
+		"add x1, x1, {current_stack_address_offset}",
+		"ldr x2, [x1]",   /* Previous version subtracted 0x10 from End, so I'm doing this too. Not sure why though. COMMENT from SL: This is a habit of mine. I always start 0x10 bytes before the end of the stack. */
+		"mov x3, {stack_top_offset}",
+		"add x2, x2, x3",
+		"mov sp, x2",
+		/* reset thread id registers */
+		"msr tpidr_el1, xzr",
+		/* set system control register */
+		"ldr x3, ={sctlr}",
+		"msr sctlr_el1, x3",
+		/* Reset debug controll register */
+		"msr mdscr_el1, xzr",
+		/* set exception table */
+		"adrp x4, {vector_table}",
+		"add  x4, x4, #:lo12:{vector_table}",
+		"msr vbar_el1, x4",
+		"adrp x4, {pre_init}",
+		"add  x4, x4, #:lo12:{pre_init}",
+		"br x4",
+		current_stack_address_offset = const BootInfo::current_stack_address_offset(),
+		stack_top_offset = const KERNEL_STACK_SIZE - TaskStacks::MARKER_SIZE,
+		sctlr = const 0x4D5D91Cisize,
+		vector_table = sym vector_table,
+		pre_init = sym pre_init,
+		options(noreturn),
+	)
 }
 
 #[inline(never)]

--- a/src/arch/aarch64/kernel/start.rs
+++ b/src/arch/aarch64/kernel/start.rs
@@ -8,35 +8,58 @@ extern "C" {
 	static vector_table: u8;
 }
 
+/*
+ * Memory types available.
+ */
+#[allow(non_upper_case_globals)]
+const MT_DEVICE_nGnRnE: u64 = 0;
+#[allow(non_upper_case_globals)]
+const MT_DEVICE_nGnRE: u64 = 1;
+const MT_DEVICE_GRE: u64 = 2;
+const MT_NORMAL_NC: u64 = 3;
+const MT_NORMAL: u64 = 4;
+
+fn mair(attr: u64, mt: u64) -> u64 {
+	attr << (mt * 8)
+}
+
+/*
+ * TCR flags
+ */
+const TCR_IRGN_WBWA: u64 = ((1) << 8) | ((1) << 24);
+const TCR_ORGN_WBWA: u64 = ((1) << 10) | ((1) << 26);
+const TCR_SHARED: u64 = ((3) << 12) | ((3) << 28);
+const TCR_TBI0: u64 = 1 << 37;
+const TCR_TBI1: u64 = 1 << 38;
+const TCR_ASID16: u64 = 1 << 36;
+const TCR_TG1_16K: u64 = 1 << 30;
+const TCR_TG1_4K: u64 = 0 << 30;
+const TCR_FLAGS: u64 = TCR_IRGN_WBWA | TCR_ORGN_WBWA | TCR_SHARED;
+
+/// Number of virtual address bits for 4KB page
+const VA_BITS: u64 = 48;
+
+fn tcr_size(x: u64) -> u64 {
+	((64 - x) << 16) | (64 - x)
+}
+
 /// Entrypoint - Initialize Stack pointer and Exception Table
 #[no_mangle]
 #[naked]
 pub unsafe extern "C" fn _start() -> ! {
 	asm!(
+		/* determine stack address */
 		"mov x1, x0",
 		"add x1, x1, {current_stack_address_offset}",
 		"ldr x2, [x1]",   /* Previous version subtracted 0x10 from End, so I'm doing this too. Not sure why though. COMMENT from SL: This is a habit of mine. I always start 0x10 bytes before the end of the stack. */
 		"mov x3, {stack_top_offset}",
 		"add x2, x2, x3",
 		"mov sp, x2",
-		/* reset thread id registers */
-		"msr tpidr_el1, xzr",
-		/* set system control register */
-		"ldr x3, ={sctlr}",
-		"msr sctlr_el1, x3",
-		/* Reset debug controll register */
-		"msr mdscr_el1, xzr",
-		/* set exception table */
-		"adrp x4, {vector_table}",
-		"add  x4, x4, #:lo12:{vector_table}",
-		"msr vbar_el1, x4",
 		"adrp x4, {pre_init}",
 		"add  x4, x4, #:lo12:{pre_init}",
 		"br x4",
 		current_stack_address_offset = const BootInfo::current_stack_address_offset(),
 		stack_top_offset = const KERNEL_STACK_SIZE - TaskStacks::MARKER_SIZE,
-		sctlr = const 0x4D5D91Cisize,
-		vector_table = sym vector_table,
 		pre_init = sym pre_init,
 		options(noreturn),
 	)
@@ -47,6 +70,147 @@ pub unsafe extern "C" fn _start() -> ! {
 unsafe fn pre_init(boot_info: &'static mut BootInfo) -> ! {
 	BOOT_INFO = boot_info as *mut BootInfo;
 
+	/* disable interrupts */
+	asm!(
+		"msr daifset, {mask}",
+		mask = const 0b111,
+		options(nostack, nomem),
+	);
+
+	/* reset thread id registers */
+	asm!(
+		"msr tpidr_el0, xzr",
+		"msr tpidr_el1, xzr",
+		options(nostack, nomem),
+	);
+
+	/*
+	 * Disable the MMU. We may have entered the kernel with it on and
+	 * will need to update the tables later. If this has been set up
+	 * with anything other than a VA == PA map then this will fail,
+	 * but in this case the code to find where we are running from
+	 * would have also failed.
+	 */
+	asm!(
+		"dsb sy",
+		"mrs x2, sctlr_el1",
+		"bic x2, x2, {one}",
+		"msr sctlr_el1, x2",
+		"isb",
+		one = const 0x1,
+		out("x2") _,
+		options(nostack, nomem),
+	);
+
+	asm!("ic iallu", "tlbi vmalle1is", "dsb ish", options(nostack),);
+
+	/*
+	 * Setup memory attribute type tables
+	 *
+	 * Memory regioin attributes for LPAE:
+	 *
+	 *   n = AttrIndx[2:0]
+	 *                      n       MAIR
+	 *   DEVICE_nGnRnE      000     00000000 (0x00)
+	 *   DEVICE_nGnRE       001     00000100 (0x04)
+	 *   DEVICE_GRE         010     00001100 (0x0c)
+	 *   NORMAL_NC          011     01000100 (0x44)
+	 *   NORMAL             100     11111111 (0xff)
+	 */
+	let mair_el1 = mair(0x00, MT_DEVICE_nGnRnE)
+		| mair(0x04, MT_DEVICE_nGnRE)
+		| mair(0x0c, MT_DEVICE_GRE)
+		| mair(0x44, MT_NORMAL_NC)
+		| mair(0xff, MT_NORMAL);
+	asm!(
+		"msr mair_el1, {0}",
+		in(reg) mair_el1,
+		options(nostack, nomem),
+	);
+
+	/*
+	 * Setup translation control register (TCR)
+	 */
+
+	// determine physical address size
+	asm!(
+		"mrs x0, id_aa64mmfr0_el1",
+		"and x0, x0, 0xF",
+		"lsl x0, x0, 32",
+		"orr x0, x0, {tcr_bits}",
+		"mrs x1, id_aa64mmfr0_el1",
+		"bfi x0, x1, #32, #3",
+		"msr tcr_el1, x0",
+		tcr_bits = in(reg) tcr_size(VA_BITS) | TCR_TG1_4K | TCR_FLAGS,
+		out("x0") _,
+		out("x1") _,
+		options(nostack, nomem),
+	);
+
+	/*
+	 * Enable FP/ASIMD in Architectural Feature Access Control Register,
+	 */
+	asm!(
+		"msr cpacr_el1, {mask}",
+		mask = in(reg) 3 << 20,
+		options(nostack, nomem),
+	);
+
+	/*
+	 * Reset debug control register
+	 */
+	asm!("msr mdscr_el1, xzr", options(nostack, nomem),);
+
+	/* set exception table */
+	asm!(
+		"adrp x4, {vector_table}",
+		"add  x4, x4, #:lo12:{vector_table}",
+		"msr vbar_el1, x4",
+		vector_table = sym vector_table,
+		out("x4") _,
+		options(nostack, nomem),
+	);
+
+	/* Memory barrier */
+	asm!("dsb sy", options(nostack),);
+
+	let sctrl_el1: u64 = 0
+	 | (1 << 26) 	    /* UCI     	Enables EL0 access in AArch64 for DC CVAU, DC CIVAC,
+				 				    DC CVAC and IC IVAU instructions */
+	 | (0 << 25)		/* EE      	Explicit data accesses at EL1 and Stage 1 translation
+	 			 				    table walks at EL1 & EL0 are little-endian */
+	 | (0 << 24)		/* EOE     	Explicit data accesses at EL0 are little-endian */
+	 | (1 << 23)
+	 | (1 << 22)
+	 | (1 << 20)
+	 | (0 << 19)		/* WXN     	Regions with write permission are not forced to XN */
+	 | (1 << 18)		/* nTWE     WFE instructions are executed as normal */
+	 | (0 << 17)
+	 | (1 << 16)		/* nTWI    	WFI instructions are executed as normal */
+	 | (1 << 15)		/* UCT     	Enables EL0 access in AArch64 to the CTR_EL0 register */
+	 | (1 << 14)		/* DZE     	Execution of the DC ZVA instruction is allowed at EL0 */
+	 | (0 << 13)
+	 | (1 << 12)		/* I       	Instruction caches enabled at EL0 and EL1 */
+	 | (1 << 11)
+	 | (0 << 10)
+	 | (0 << 9)			/* UMA      Disable access to the interrupt masks from EL0 */
+	 | (1 << 8)			/* SED      The SETEND instruction is available */
+	 | (0 << 7)			/* ITD      The IT instruction functionality is available */
+	 | (0 << 6)			/* THEE    	ThumbEE is disabled */
+	 | (0 << 5)			/* CP15BEN  CP15 barrier operations disabled */
+	 | (1 << 4)			/* SA0     	Stack Alignment check for EL0 enabled */
+	 | (1 << 3)			/* SA      	Stack Alignment check enabled */
+	 | (1 << 2)			/* C       	Data and unified enabled */
+	 | (0 << 1)			/* A       	Alignment fault checking disabled */
+	 | (0 << 0)			/* M       	MMU enable */
+	;
+
+	asm!(
+		"msr sctlr_el1, {0}",
+		in(reg) sctrl_el1,
+		options(nostack),
+	);
+
 	if boot_info.cpu_online == 0 {
 		crate::boot_processor_main()
 	} else {
@@ -54,7 +218,7 @@ unsafe fn pre_init(boot_info: &'static mut BootInfo) -> ! {
 		{
 			error!("SMP support deactivated");
 			loop {
-				//processor::halt();
+				crate::arch::processor::halt()
 			}
 		}
 		#[cfg(feature = "smp")]

--- a/src/arch/aarch64/kernel/start.s
+++ b/src/arch/aarch64/kernel/start.s
@@ -70,7 +70,7 @@ b       do_bad_mode
 .endm
 
 /*
- * SYNC & IRQ exception handler.
+ * SYNC exception handler.
  */
 .align 6
 el1_sync:
@@ -82,6 +82,9 @@ el1_sync:
 .size el1_sync, .-el1_sync
 .type el1_sync, @function
 
+/*
+ * IRQ handler.
+ */
 .align 6
 el1_irq:
       trap_entry 1
@@ -103,6 +106,9 @@ el1_irq:
 .size el1_irq, .-el1_irq
 .type el1_irq, @function
 
+/*
+ * FIQ handler.
+ */
 .align 6
 el1_fiq:
       trap_entry 1

--- a/src/arch/aarch64/kernel/start.s
+++ b/src/arch/aarch64/kernel/start.s
@@ -1,11 +1,9 @@
 .section .text
-.extern pre_init
 .extern do_bad_mode
 .extern do_irq
 .extern do_fiq
 .extern do_sync
 .extern do_error
-
 
 .macro trap_entry, el
      stp x29, x30, [sp, #-16]!

--- a/src/arch/aarch64/kernel/stubs.rs
+++ b/src/arch/aarch64/kernel/stubs.rs
@@ -11,21 +11,6 @@ pub fn wakeup_core(core_to_wakeup: CoreId) {
 }
 
 #[no_mangle]
-pub extern "C" fn do_bad_mode() {}
-
-#[no_mangle]
-pub extern "C" fn do_error() {}
-
-#[no_mangle]
-pub extern "C" fn do_fiq() {}
-
-#[no_mangle]
-pub extern "C" fn do_irq() {}
-
-#[no_mangle]
-pub extern "C" fn do_sync() {}
-
-#[no_mangle]
 pub extern "C" fn eoi() {}
 
 #[no_mangle]

--- a/src/arch/aarch64/mm/paging.rs
+++ b/src/arch/aarch64/mm/paging.rs
@@ -216,7 +216,14 @@ impl<S: PageSize> Page<S> {
 		// We use "vale1is" instead of "vae1is" to always flush the last table level only (performance optimization).
 		// The "is" attribute broadcasts the TLB flush to all cores, so we don't need an IPI (unlike x86_64).
 		unsafe {
-			llvm_asm!("dsb ishst; tlbi vale1is, $0; dsb ish; isb" :: "r"(self.virtual_address) : "memory" : "volatile");
+			asm!(
+				"dsb ishst",
+				"tlbi vale1is, {}",
+				"dsb ish",
+				"isb",
+				in(reg) self.virtual_address.as_u64(),
+				options(nostack),
+			);
 		}
 	}
 
@@ -604,3 +611,5 @@ pub fn unmap<S: PageSize>(virtual_address: VirtAddr, count: usize) {}
 pub fn get_application_page_size() -> usize {
 	LargePageSize::SIZE
 }
+
+pub fn init() {}

--- a/src/console.rs
+++ b/src/console.rs
@@ -8,6 +8,7 @@ pub struct Console(());
 /// a message to HermitCore's console.
 impl fmt::Write for Console {
 	/// Print a string of characters.
+	#[inline]
 	fn write_str(&mut self, s: &str) -> fmt::Result {
 		if !s.is_empty() {
 			let buf = s.as_bytes();
@@ -16,14 +17,10 @@ impl fmt::Write for Console {
 
 		Ok(())
 	}
-
-	/// Print a single character.
-	fn write_char(&mut self, c: char) -> fmt::Result {
-		self.write_str(c.encode_utf8(&mut [0; 4]))
-	}
 }
 
 impl Console {
+	#[inline]
 	pub fn write_all(&mut self, buf: &[u8]) {
 		arch::output_message_buf(buf)
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,10 +347,16 @@ fn boot_processor_main() -> ! {
 	#[cfg(target_arch = "aarch64")]
 	{
 		info!("The current hermit-kernel is only implemented up to this point on aarch64.");
-		info!("Attempting to exit via QEMU.");
-		info!("This requires that you passed the `-semihosting` option to QEMU.");
-		let exit_handler = qemu_exit::AArch64::new();
-		exit_handler.exit_success();
+		if environment::is_uhyve() {
+			syscalls::init();
+			syscalls::__sys_shutdown(0);
+		} else {
+			info!("Attempting to exit via QEMU.");
+			info!("This requires that you passed the `-semihosting` option to QEMU.");
+			let exit_handler = qemu_exit::AArch64::new();
+			exit_handler.exit_success();
+		}
+
 		loop {} /* Compiles up to here - loop prevents linker errors */
 	}
 	arch::boot_processor_init();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ mod syscalls;
 mod util;
 
 #[doc(hidden)]
-pub fn _print(args: ::core::fmt::Arguments<'_>) {
+fn _print(args: ::core::fmt::Arguments<'_>) {
 	use core::fmt::Write;
 	crate::console::CONSOLE.lock().write_fmt(args).unwrap();
 }
@@ -331,7 +331,9 @@ fn synch_all_cores() {
 fn boot_processor_main() -> ! {
 	// Initialize the kernel and hardware.
 	arch::message_output_init();
-	logging::init();
+	unsafe {
+		logging::init();
+	}
 
 	info!("Welcome to HermitCore-rs {}", env!("CARGO_PKG_VERSION"));
 	info!("Kernel starts at {:#x}", environment::get_base_address());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,6 @@ mod synch;
 mod syscalls;
 mod util;
 
-#[doc(hidden)]
 fn _print(args: ::core::fmt::Arguments<'_>) {
 	use core::fmt::Write;
 	crate::console::CONSOLE.lock().write_fmt(args).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ mod synch;
 mod syscalls;
 mod util;
 
-fn _print(args: ::core::fmt::Arguments<'_>) {
+pub(crate) fn _print(args: ::core::fmt::Arguments<'_>) {
 	use core::fmt::Write;
 	crate::console::CONSOLE.lock().write_fmt(args).unwrap();
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -56,7 +56,7 @@ macro_rules! infoheader {
 
 #[macro_export]
 macro_rules! infoentry {
-	($str:expr, $rhs:expr) => (crate::infoentry!($str, "{}", $rhs));
+	($str:expr, $rhs:expr) => ($crate::infoentry!($str, "{}", $rhs));
 	($str:expr, $($arg:tt)+) => (::log::info!("{:25}{}", concat!($str, ":"), format_args!($($arg)+)));
 }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,4 +1,4 @@
-use log::{set_logger, set_max_level, LevelFilter, Metadata, Record};
+use log::{set_logger_racy, set_max_level, LevelFilter, Metadata, Record};
 
 /// Data structure to filter kernel messages
 struct KernelLogger;
@@ -24,8 +24,8 @@ impl log::Log for KernelLogger {
 	}
 }
 
-pub fn init() {
-	set_logger(&KernelLogger).expect("Can't initialize logger");
+pub unsafe fn init() {
+	set_logger_racy(&KernelLogger).expect("Can't initialize logger");
 	// Determines LevelFilter at compile time
 	let log_level: Option<&'static str> = option_env!("HERMIT_LOG_LEVEL_FILTER");
 	let max_level: LevelFilter = match log_level {
@@ -56,7 +56,7 @@ macro_rules! infoheader {
 
 #[macro_export]
 macro_rules! infoentry {
-	($str:expr, $rhs:expr) => ($crate::infoentry!($str, "{}", $rhs));
+	($str:expr, $rhs:expr) => (crate::infoentry!($str, "{}", $rhs));
 	($str:expr, $($arg:tt)+) => (::log::info!("{:25}{}", concat!($str, ":"), format_args!($($arg)+)));
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -18,7 +18,7 @@ macro_rules! align_up {
 /// for HermitCore.
 #[macro_export]
 macro_rules! print {
-	($($arg:tt)*) => ($crate::_print(::core::format_args!($($arg)*)));
+	($($arg:tt)+) => ($crate::_print(::core::format_args!($($arg)+)));
 }
 
 /// Print formatted text to our console, followed by a newline.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -18,16 +18,14 @@ macro_rules! align_up {
 /// for HermitCore.
 #[macro_export]
 macro_rules! print {
-	($($arg:tt)+) => ({
-		$crate::_print(format_args!($($arg)*));
-	});
+	($($arg:tt)*) => ($crate::_print(::core::format_args!($($arg)*)));
 }
 
 /// Print formatted text to our console, followed by a newline.
 #[macro_export]
 macro_rules! println {
 	() => ($crate::print!("\n"));
-	($($arg:tt)+) => ($crate::print!("{}\n", format_args!($($arg)+)));
+	($($arg:tt)*) => ($crate::print!("{}\n", ::core::format_args!($($arg)*)));
 }
 
 /// Runs `f` on the kernel stack.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -25,7 +25,7 @@ macro_rules! print {
 #[macro_export]
 macro_rules! println {
 	() => ($crate::print!("\n"));
-	($($arg:tt)*) => ($crate::print!("{}\n", ::core::format_args!($($arg)*)));
+	($($arg:tt)+) => ($crate::print!("{}\n", ::core::format_args!($($arg)+)));
 }
 
 /// Runs `f` on the kernel stack.

--- a/src/runtime_glue.rs
+++ b/src/runtime_glue.rs
@@ -43,10 +43,3 @@ fn rust_oom(layout: Layout) -> ! {
 		arch::processor::halt();
 	}
 }
-
-#[cfg(any(target_os = "none", target_os = "hermit"))]
-#[no_mangle]
-pub unsafe extern "C" fn __rg_oom(size: usize, align: usize) -> ! {
-	let layout = Layout::from_size_align_unchecked(size, align);
-	rust_oom(layout)
-}

--- a/src/runtime_glue.rs
+++ b/src/runtime_glue.rs
@@ -43,3 +43,10 @@ fn rust_oom(layout: Layout) -> ! {
 		arch::processor::halt();
 	}
 }
+
+#[cfg(any(target_os = "none", target_os = "hermit"))]
+#[no_mangle]
+pub unsafe extern "C" fn __rg_oom(size: usize, align: usize) -> ! {
+	let layout = Layout::from_size_align_unchecked(size, align);
+	rust_oom(layout)
+}

--- a/src/runtime_glue.rs
+++ b/src/runtime_glue.rs
@@ -44,7 +44,7 @@ fn rust_oom(layout: Layout) -> ! {
 	}
 }
 
-#[cfg(target_os = "hermit")]
+#[cfg(any(target_os = "none", target_os = "hermit"))]
 #[no_mangle]
 pub unsafe extern "C" fn __rg_oom(size: usize, align: usize) -> ! {
 	let layout = Layout::from_size_align_unchecked(size, align);

--- a/src/runtime_glue.rs
+++ b/src/runtime_glue.rs
@@ -44,7 +44,7 @@ fn rust_oom(layout: Layout) -> ! {
 	}
 }
 
-#[cfg(any(target_os = "none", target_os = "hermit"))]
+#[cfg(target_os = "hermit")]
 #[no_mangle]
 pub unsafe extern "C" fn __rg_oom(size: usize, align: usize) -> ! {
 	let layout = Layout::from_size_align_unchecked(size, align);


### PR DESCRIPTION
- inline wrapper functions
- don't use a thread-safe version to initialize the kernel logger
  because at this stage the kernel doesn't provide threads
- simplifies the boot process