### PR TITLE
[WIP] SCHEDULERS: Fix race condition

### DIFF
--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -478,7 +478,7 @@ unsafe fn pre_init(boot_info: &'static mut BootInfo) -> ! {
 
 	BOOT_INFO = boot_info as *mut BootInfo;
 
-	atomic::fence(Ordering::SeqCst);
+	atomic::fence(Ordering::Acquire);
 	if boot_info.cpu_online == 0 {
 		crate::boot_processor_main()
 	} else {

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -443,7 +443,6 @@ fn finish_processor_init() {
 	// to initialize the next processor.
 	unsafe {
 		let _ = intrinsics::atomic_xadd(&mut (*BOOT_INFO).cpu_online as *mut u32, 1);
-		atomic::fence(Ordering::SeqCst);
 	}
 }
 

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -1,7 +1,6 @@
 use alloc::collections::BTreeMap;
 #[cfg(feature = "newlib")]
 use core::slice;
-use core::sync::atomic::{self, Ordering};
 use core::{intrinsics, ptr};
 
 use x86::controlregs::{cr0, cr0_write, cr4, Cr0};
@@ -478,8 +477,8 @@ unsafe fn pre_init(boot_info: &'static mut BootInfo) -> ! {
 
 	BOOT_INFO = boot_info as *mut BootInfo;
 
-	atomic::fence(Ordering::Acquire);
-	if boot_info.cpu_online == 0 {
+	let cpu_online = intrinsics::atomic_load_acq(&mut (*BOOT_INFO).cpu_online as *mut u32);
+	if cpu_online == 0 {
 		crate::boot_processor_main()
 	} else {
 		#[cfg(not(feature = "smp"))]

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -1,6 +1,7 @@
 use alloc::collections::BTreeMap;
 #[cfg(feature = "newlib")]
 use core::slice;
+use core::sync::atomic::{self, Ordering};
 use core::{intrinsics, ptr};
 
 use x86::controlregs::{cr0, cr0_write, cr4, Cr0};
@@ -442,6 +443,7 @@ fn finish_processor_init() {
 	// to initialize the next processor.
 	unsafe {
 		let _ = intrinsics::atomic_xadd(&mut (*BOOT_INFO).cpu_online as *mut u32, 1);
+		atomic::fence(Ordering::SeqCst);
 	}
 }
 
@@ -477,6 +479,7 @@ unsafe fn pre_init(boot_info: &'static mut BootInfo) -> ! {
 
 	BOOT_INFO = boot_info as *mut BootInfo;
 
+	atomic::fence(Ordering::SeqCst);
 	if boot_info.cpu_online == 0 {
 		crate::boot_processor_main()
 	} else {


### PR DESCRIPTION
Fixes https://github.com/hermitcore/libhermit-rs/issues/301.

Vec::insert does not work when initializing core schedulers in the wrong order. The mutex synchronizes accesses to the map.