### PR TITLE
add option that COMMAND_LINE_CPU_FREQUENCY is invalid

### DIFF
--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -377,12 +377,12 @@ pub fn boot_processor_init() {
 	idt::install();
 	pic::init();
 
-	irq::install();
 	processor::detect_frequency();
 	processor::print_information();
 	unsafe {
 		trace!("Cr0: {:#x}, Cr4: {:#x}", cr0(), cr4());
 	}
+	irq::install();
 	systemtime::init();
 
 	if environment::is_single_kernel() {

--- a/src/arch/x86_64/kernel/processor.rs
+++ b/src/arch/x86_64/kernel/processor.rs
@@ -204,7 +204,7 @@ enum CpuFrequencySources {
 	CpuId,
 	CpuIdTscInfo,
 	HypervisorTscInfo,
-	Guess,
+	Visionary,
 }
 
 impl fmt::Display for CpuFrequencySources {
@@ -217,7 +217,7 @@ impl fmt::Display for CpuFrequencySources {
 			CpuFrequencySources::CpuId => write!(f, "CpuId"),
 			CpuFrequencySources::CpuIdTscInfo => write!(f, "CpuId Tsc Info"),
 			CpuFrequencySources::HypervisorTscInfo => write!(f, "Tsc Info from Hypervisor"),
-			CpuFrequencySources::Guess => write!(f, "Guess"),
+			CpuFrequencySources::Visionary => write!(f, "Visionary"),
 			_ => panic!("Attempted to print an invalid CPU Frequency Source"),
 		}
 	}
@@ -432,7 +432,7 @@ impl CpuFrequency {
 			.or_else(|_e| self.measure_frequency())
 			.or_else(|_e| {
 				warn!("Could not determine the processor frequency! Guess a frequncy of 2Ghz!");
-				self.set_detected_cpu_frequency(2000, CpuFrequencySources::Guess)
+				self.set_detected_cpu_frequency(2000, CpuFrequencySources::Visionary)
 			})
 			.unwrap();
 	}

--- a/src/arch/x86_64/kernel/processor.rs
+++ b/src/arch/x86_64/kernel/processor.rs
@@ -388,7 +388,7 @@ impl CpuFrequency {
 
 			spin_loop();
 		}
-		.ok_or({
+		.ok_or_else(|| {
 			irq::disable();
 			pit::deinit();
 		})?;

--- a/src/arch/x86_64/kernel/processor.rs
+++ b/src/arch/x86_64/kernel/processor.rs
@@ -204,6 +204,7 @@ enum CpuFrequencySources {
 	CpuId,
 	CpuIdTscInfo,
 	HypervisorTscInfo,
+	Guess,
 }
 
 impl fmt::Display for CpuFrequencySources {
@@ -216,6 +217,7 @@ impl fmt::Display for CpuFrequencySources {
 			CpuFrequencySources::CpuId => write!(f, "CpuId"),
 			CpuFrequencySources::CpuIdTscInfo => write!(f, "CpuId Tsc Info"),
 			CpuFrequencySources::HypervisorTscInfo => write!(f, "Tsc Info from Hypervisor"),
+			CpuFrequencySources::Guess => write!(f, "Guess"),
 			_ => panic!("Attempted to print an invalid CPU Frequency Source"),
 		}
 	}
@@ -370,17 +372,26 @@ impl CpuFrequency {
 		// Determine the current timer tick.
 		// We are probably loading this value in the middle of a time slice.
 		let first_tick = unsafe { core::ptr::read_volatile(&MEASUREMENT_TIMER_TICKS) };
+		let start = get_timestamp();
 
 		// Wait until the tick count changes.
 		// As soon as it has done, we are at the start of a new time slice.
 		let start_tick = loop {
 			let tick = unsafe { core::ptr::read_volatile(&MEASUREMENT_TIMER_TICKS) };
 			if tick != first_tick {
-				break tick;
+				break Some(tick);
+			}
+
+			if get_timestamp() - start > 120000000 {
+				break None;
 			}
 
 			spin_loop();
-		};
+		}.ok_or({
+			irq::disable();
+			pit::deinit();
+			()
+		})?;
 
 		// Count the number of CPU cycles during 3 timer ticks.
 		let start = get_timestamp();
@@ -419,7 +430,11 @@ impl CpuFrequency {
 			.or_else(|_e| self.detect_from_cmdline())
 			.or_else(|_e| self.detect_from_cpuid_brand_string(&cpuid))
 			.or_else(|_e| self.measure_frequency())
-			.expect("Could not determine the processor frequency");
+			.or_else(|_e| {
+				warn!("Could not determine the processor frequency! Guess a frequncy of 2Ghz!");
+				self.set_detected_cpu_frequency(2000, CpuFrequencySources::Guess)
+			})
+			.unwrap();
 	}
 
 	fn get(&self) -> u16 {

--- a/src/arch/x86_64/kernel/processor.rs
+++ b/src/arch/x86_64/kernel/processor.rs
@@ -387,7 +387,8 @@ impl CpuFrequency {
 			}
 
 			spin_loop();
-		}.ok_or({
+		}
+		.ok_or({
 			irq::disable();
 			pit::deinit();
 			()

--- a/src/arch/x86_64/kernel/processor.rs
+++ b/src/arch/x86_64/kernel/processor.rs
@@ -391,7 +391,6 @@ impl CpuFrequency {
 		.ok_or({
 			irq::disable();
 			pit::deinit();
-			()
 		})?;
 
 		// Count the number of CPU cycles during 3 timer ticks.

--- a/src/arch/x86_64/kernel/processor.rs
+++ b/src/arch/x86_64/kernel/processor.rs
@@ -250,7 +250,7 @@ impl CpuFrequency {
 	}
 
 	unsafe fn detect_from_cmdline(&mut self) -> Result<(), ()> {
-		let mhz = environment::get_command_line_cpu_frequency();
+		let mhz = environment::get_command_line_cpu_frequency().ok_or(())?;
 		self.set_detected_cpu_frequency(mhz, CpuFrequencySources::CommandLine)
 	}
 

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -19,7 +19,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use core::{slice, str};
 
-static mut COMMAND_LINE_CPU_FREQUENCY: u16 = 0;
+static mut COMMAND_LINE_CPU_FREQUENCY: Option<u16> = None;
 static mut IS_PROXY: bool = false;
 static mut COMMAND_LINE_APPLICATION: Option<Vec<String>> = None;
 static mut COMMAND_LINE_PATH: Option<String> = None;
@@ -44,9 +44,7 @@ unsafe fn parse_command_line() {
 		match token.as_str() {
 			"-freq" => {
 				let mhz_str = tokeniter.next().expect("Invalid -freq command line");
-				COMMAND_LINE_CPU_FREQUENCY = mhz_str
-					.parse()
-					.expect("Could not parse -freq command line as number");
+				COMMAND_LINE_CPU_FREQUENCY = mhz_str.parse().ok();
 			}
 			"-proxy" => {
 				IS_PROXY = true;
@@ -96,13 +94,7 @@ pub fn init() {
 
 /// CPU Frequency in MHz if given through the -freq command-line parameter, otherwise zero.
 pub fn get_command_line_cpu_frequency() -> Option<u16> {
-	unsafe {
-		if COMMAND_LINE_CPU_FREQUENCY > 0 {
-			Some(COMMAND_LINE_CPU_FREQUENCY)
-		} else {
-			None
-		}
-	}
+	unsafe { COMMAND_LINE_CPU_FREQUENCY }
 }
 
 /// Whether HermitCore shall communicate with the "proxy" application over a network interface.

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -95,8 +95,14 @@ pub fn init() {
 }
 
 /// CPU Frequency in MHz if given through the -freq command-line parameter, otherwise zero.
-pub fn get_command_line_cpu_frequency() -> u16 {
-	unsafe { COMMAND_LINE_CPU_FREQUENCY }
+pub fn get_command_line_cpu_frequency() -> Option<u16> {
+	unsafe {
+		if COMMAND_LINE_CPU_FREQUENCY > 0 {
+			Some(COMMAND_LINE_CPU_FREQUENCY)
+		} else {
+			None
+		}
+	}
 }
 
 /// Whether HermitCore shall communicate with the "proxy" application over a network interface.


### PR DESCRIPTION
If `parse_command_line` isn't able to identify the processor frequency, the function `get_command_line_cpu_frequency` will return `None` instead of a invalid frequency.

In addition, the frequency measurement with PIT is able to fail. In this case, we just guess a frequency of 2Ghz. For tests is guessing a good workaround.