### PR TITLE
Allow for specifying static network configuration at launch

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -21,6 +21,7 @@ use core::{slice, str};
 
 static mut COMMAND_LINE_CPU_FREQUENCY: Option<u16> = None;
 static mut IS_PROXY: bool = false;
+static mut COMMAND_LINE_ENVIRONMENT: Vec<String> = Vec::new();
 static mut COMMAND_LINE_APPLICATION: Option<Vec<String>> = None;
 static mut COMMAND_LINE_PATH: Option<String> = None;
 
@@ -45,6 +46,18 @@ unsafe fn parse_command_line() {
 			"-freq" => {
 				let mhz_str = tokeniter.next().expect("Invalid -freq command line");
 				COMMAND_LINE_CPU_FREQUENCY = mhz_str.parse().ok();
+			}
+			"-ip" => {
+				COMMAND_LINE_ENVIRONMENT.push(format!("HERMIT_IP={}", tokeniter.next().expect("Invalid -ip command line")));
+			}
+			"-mask" => {
+				COMMAND_LINE_ENVIRONMENT.push(format!("HERMIT_MASK={}", tokeniter.next().expect("Invalid -mask command line")));
+			}
+			"-gateway" => {
+				COMMAND_LINE_ENVIRONMENT.push(format!("HERMIT_GATEWAY={}", tokeniter.next().expect("Invalid -gateway command line")));
+			}
+			"-mac" => {
+				COMMAND_LINE_ENVIRONMENT.push(format!("HERMIT_MAC={}", tokeniter.next().expect("Invalid -mac command line")));
 			}
 			"-proxy" => {
 				IS_PROXY = true;
@@ -76,6 +89,10 @@ pub fn get_command_line_argv() -> Option<&'static [String]> {
 /// Returns the first cmdline argument, if not otherwise recognized. With qemu this is the host-path to the kernel (rusty-loader)
 pub fn get_command_line_path() -> Option<&'static str> {
 	unsafe { COMMAND_LINE_PATH.as_deref() }
+}
+
+pub fn get_command_line_envv() -> &'static [String] {
+	unsafe { COMMAND_LINE_ENVIRONMENT.as_slice() }
 }
 
 pub fn init() {

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -48,16 +48,28 @@ unsafe fn parse_command_line() {
 				COMMAND_LINE_CPU_FREQUENCY = mhz_str.parse().ok();
 			}
 			"-ip" => {
-				COMMAND_LINE_ENVIRONMENT.push(format!("HERMIT_IP={}", tokeniter.next().expect("Invalid -ip command line")));
+				COMMAND_LINE_ENVIRONMENT.push(format!(
+					"HERMIT_IP={}",
+					tokeniter.next().expect("Invalid -ip command line")
+				));
 			}
 			"-mask" => {
-				COMMAND_LINE_ENVIRONMENT.push(format!("HERMIT_MASK={}", tokeniter.next().expect("Invalid -mask command line")));
+				COMMAND_LINE_ENVIRONMENT.push(format!(
+					"HERMIT_MASK={}",
+					tokeniter.next().expect("Invalid -mask command line")
+				));
 			}
 			"-gateway" => {
-				COMMAND_LINE_ENVIRONMENT.push(format!("HERMIT_GATEWAY={}", tokeniter.next().expect("Invalid -gateway command line")));
+				COMMAND_LINE_ENVIRONMENT.push(format!(
+					"HERMIT_GATEWAY={}",
+					tokeniter.next().expect("Invalid -gateway command line")
+				));
 			}
 			"-mac" => {
-				COMMAND_LINE_ENVIRONMENT.push(format!("HERMIT_MAC={}", tokeniter.next().expect("Invalid -mac command line")));
+				COMMAND_LINE_ENVIRONMENT.push(format!(
+					"HERMIT_MAC={}",
+					tokeniter.next().expect("Invalid -mac command line")
+				));
 			}
 			"-proxy" => {
 				IS_PROXY = true;

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -65,12 +65,6 @@ unsafe fn parse_command_line() {
 					tokeniter.next().expect("Invalid -gateway command line")
 				));
 			}
-			"-mac" => {
-				COMMAND_LINE_ENVIRONMENT.push(format!(
-					"HERMIT_MAC={}",
-					tokeniter.next().expect("Invalid -mac command line")
-				));
-			}
 			"-proxy" => {
 				IS_PROXY = true;
 			}

--- a/src/syscalls/interfaces/mod.rs
+++ b/src/syscalls/interfaces/mod.rs
@@ -1,6 +1,6 @@
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use core::{isize, ptr, slice, str};
+use core::{isize, slice, str};
 
 use crate::arch;
 use crate::console::CONSOLE;
@@ -97,12 +97,21 @@ pub trait SyscallInterface: Send + Sync {
 			}
 		}
 
-		let environ = ptr::null() as *const *const u8;
+		let mut envv = Vec::new();
+
+		let envs = environment::get_command_line_envv();
+		debug!("Setting envv as: {:?}", envs);
+		for a in envs {
+			let ptr = Box::leak(format!("{}\0", a).into_boxed_str()).as_ptr();
+			envv.push(ptr);
+		}
+		envv.push(0usize as *const u8);
 
 		let argc = argv.len() as i32;
 		let argv = Box::leak(argv.into_boxed_slice()).as_ptr();
+		let envv = Box::leak(envv.into_boxed_slice()).as_ptr();
 
-		(argc, argv, environ)
+		(argc, argv, envv)
 	}
 
 	fn shutdown(&self, _arg: i32) -> ! {

--- a/src/syscalls/interfaces/mod.rs
+++ b/src/syscalls/interfaces/mod.rs
@@ -105,7 +105,7 @@ pub trait SyscallInterface: Send + Sync {
 			let ptr = Box::leak(format!("{}\0", a).into_boxed_str()).as_ptr();
 			envv.push(ptr);
 		}
-		envv.push(0usize as *const u8);
+		envv.push(core::ptr::null::<u8>());
 
 		let argc = argv.len() as i32;
 		let argv = Box::leak(argv.into_boxed_slice()).as_ptr();


### PR DESCRIPTION
This PR makes it possible to overwrite the default network parameters for IP address, gateway and mask by appending them to the list of command line arguments. This is useful when the network configuration of the corresponding tap interface is not known at build time, for example when running in a container. When one or more values for the keys `-ip`, `-gateway` and `-mask` are specified, they are provided to the application as environment variables. This way, the hermit-sys network code can read these variables and configure the network device accordingly (see https://github.com/hermitcore/rusty-hermit/pull/204).