### PR TITLE
Make _print public again

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,7 +53,6 @@ build:demo:
 test:integration:
   stage: test
   image: ${DOCKER_IMAGE}:${DOCKER_TAG}
-  allow_failure: true
   script:
     - lscpu
     - kvm-ok

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,8 @@ mod synch;
 mod syscalls;
 mod util;
 
-pub(crate) fn _print(args: ::core::fmt::Arguments<'_>) {
+#[doc(hidden)]
+pub fn _print(args: ::core::fmt::Arguments<'_>) {
 	use core::fmt::Write;
 	crate::console::CONSOLE.lock().write_fmt(args).unwrap();
 }


### PR DESCRIPTION
This is required for integration tests.