### PR TITLE
Reduce crate exports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,8 +73,9 @@ use mm::allocator::LockedHeap;
 #[cfg(target_arch = "aarch64")]
 use qemu_exit::QEMUExit;
 
-pub use crate::arch::*;
-pub use crate::config::*;
+pub(crate) use crate::arch::*;
+pub use crate::config::USER_STACK_SIZE;
+pub(crate) use crate::config::*;
 pub use crate::syscalls::*;
 
 #[macro_use]
@@ -141,7 +142,7 @@ static ALLOCATOR: LockedHeap = LockedHeap::empty();
 /// `size` and `align` do not meet this allocator's size or alignment constraints.
 ///
 #[cfg(any(target_os = "none", target_os = "hermit"))]
-pub extern "C" fn __sys_malloc(size: usize, align: usize) -> *mut u8 {
+pub(crate) extern "C" fn __sys_malloc(size: usize, align: usize) -> *mut u8 {
 	let layout_res = Layout::from_size_align(size, align);
 	if layout_res.is_err() || size == 0 {
 		warn!(
@@ -183,7 +184,7 @@ pub extern "C" fn __sys_malloc(size: usize, align: usize) -> *mut u8 {
 /// Returns null if the new layout does not meet the size and alignment constraints of the
 /// allocator, or if reallocation otherwise fails.
 #[cfg(any(target_os = "none", target_os = "hermit"))]
-pub extern "C" fn __sys_realloc(
+pub(crate) extern "C" fn __sys_realloc(
 	ptr: *mut u8,
 	size: usize,
 	align: usize,
@@ -228,7 +229,7 @@ pub extern "C" fn __sys_realloc(
 /// # Errors
 /// May panic if debug assertions are enabled and invalid parameters `size` or `align` where passed.
 #[cfg(any(target_os = "none", target_os = "hermit"))]
-pub extern "C" fn __sys_free(ptr: *mut u8, size: usize, align: usize) {
+pub(crate) extern "C" fn __sys_free(ptr: *mut u8, size: usize, align: usize) {
 	unsafe {
 		let layout_res = Layout::from_size_align(size, align);
 		if layout_res.is_err() || size == 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 #![allow(clippy::missing_safety_doc)]
 #![allow(incomplete_features)]
+#![allow(dead_code)]
 #![feature(abi_x86_interrupt)]
 #![feature(allocator_api)]
 #![feature(asm_const)]

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -40,7 +40,6 @@ pub unsafe fn init() {
 	set_max_level(max_level);
 }
 
-#[macro_export]
 macro_rules! infoheader {
 	// This should work on paper, but it's currently not supported :(
 	// Refer to https://github.com/rust-lang/rust/issues/46569
@@ -54,13 +53,11 @@ macro_rules! infoheader {
 	}};
 }
 
-#[macro_export]
 macro_rules! infoentry {
-	($str:expr, $rhs:expr) => ($crate::infoentry!($str, "{}", $rhs));
+	($str:expr, $rhs:expr) => (infoentry!($str, "{}", $rhs));
 	($str:expr, $($arg:tt)+) => (::log::info!("{:25}{}", concat!($str, ":"), format_args!($($arg)+)));
 }
 
-#[macro_export]
 macro_rules! infofooter {
 	() => {{
 		::log::info!("{:=^70}", '=');

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,14 +1,12 @@
-#[macro_export]
 macro_rules! align_down {
 	($value:expr, $alignment:expr) => {
 		($value) & !($alignment - 1)
 	};
 }
 
-#[macro_export]
 macro_rules! align_up {
 	($value:expr, $alignment:expr) => {
-		$crate::align_down!($value + ($alignment - 1), $alignment)
+		align_down!($value + ($alignment - 1), $alignment)
 	};
 }
 
@@ -24,8 +22,8 @@ macro_rules! print {
 /// Print formatted text to our console, followed by a newline.
 #[macro_export]
 macro_rules! println {
-	() => ($crate::print!("\n"));
-	($($arg:tt)+) => ($crate::print!("{}\n", ::core::format_args!($($arg)+)));
+	() => (print!("\n"));
+	($($arg:tt)+) => (print!("{}\n", ::core::format_args!($($arg)+)));
 }
 
 /// Runs `f` on the kernel stack.
@@ -43,7 +41,6 @@ macro_rules! println {
 /// // instead of
 /// let ret = f(arg);
 /// ```
-#[macro_export]
 macro_rules! kernel_function {
 	($f:ident()) => {
 		$crate::arch::switch::kernel_function0($f)

--- a/src/syscalls/fs.rs
+++ b/src/syscalls/fs.rs
@@ -191,6 +191,7 @@ impl Filesystem {
 	}
 }
 
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Debug)]
 pub enum FileError {
 	ENOENT,

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -20,7 +20,7 @@ pub use self::tasks::*;
 pub use self::timer::*;
 
 mod condvar;
-pub mod fs;
+pub(crate) mod fs;
 mod interfaces;
 #[cfg(feature = "newlib")]
 mod lwip;
@@ -41,7 +41,7 @@ pub static LWIP_LOCK: SpinlockIrqSave<()> = SpinlockIrqSave::new(());
 
 static mut SYS: &'static dyn SyscallInterface = &interfaces::Generic;
 
-pub fn init() {
+pub(crate) fn init() {
 	unsafe {
 		// We know that HermitCore has successfully initialized a network interface.
 		// Now check if we can load a more specific SyscallInterface to make use of networking.
@@ -78,7 +78,7 @@ pub extern "C" fn sys_free(ptr: *mut u8, size: usize, align: usize) {
 	__sys_free(ptr, size, align)
 }
 
-pub fn get_application_parameters() -> (i32, *const *const u8, *const *const u8) {
+pub(crate) fn get_application_parameters() -> (i32, *const *const u8, *const *const u8) {
 	unsafe { SYS.get_application_parameters() }
 }
 
@@ -166,7 +166,7 @@ pub extern "C" fn sys_set_network_polling_mode(value: bool) {
 	kernel_function!(set_polling_mode(value));
 }
 
-pub extern "C" fn __sys_shutdown(arg: i32) -> ! {
+pub(crate) extern "C" fn __sys_shutdown(arg: i32) -> ! {
 	// print some performance statistics
 	crate::arch::kernel::print_statistics();
 

--- a/src/syscalls/random.rs
+++ b/src/syscalls/random.rs
@@ -62,7 +62,7 @@ pub extern "C" fn sys_srand(seed: u32) {
 	kernel_function!(__sys_srand(seed))
 }
 
-pub fn random_init() {
+pub(crate) fn random_init() {
 	let seed: u32 = arch::processor::get_timestamp() as u32;
 
 	*PARK_MILLER_LEHMER_SEED.lock() = seed;

--- a/src/syscalls/tasks.rs
+++ b/src/syscalls/tasks.rs
@@ -108,7 +108,7 @@ pub extern "C" fn sys_sbrk(incr: isize) -> usize {
 	kernel_function!(__sys_sbrk(incr))
 }
 
-pub extern "C" fn __sys_usleep(usecs: u64) {
+pub(crate) extern "C" fn __sys_usleep(usecs: u64) {
 	if usecs >= 10_000 {
 		// Enough time to set a wakeup timer and block the current task.
 		debug!("sys_usleep blocking the task for {} microseconds", usecs);

--- a/src/syscalls/timer.rs
+++ b/src/syscalls/timer.rs
@@ -23,11 +23,11 @@ pub struct timeval {
 	pub tv_usec: i64,
 }
 
-pub const CLOCK_REALTIME: u64 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u64 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u64 = 3;
-pub const CLOCK_MONOTONIC: u64 = 4;
-pub const TIMER_ABSTIME: i32 = 4;
+pub(crate) const CLOCK_REALTIME: u64 = 1;
+pub(crate) const CLOCK_PROCESS_CPUTIME_ID: u64 = 2;
+pub(crate) const CLOCK_THREAD_CPUTIME_ID: u64 = 3;
+pub(crate) const CLOCK_MONOTONIC: u64 = 4;
+pub(crate) const TIMER_ABSTIME: i32 = 4;
 
 fn microseconds_to_timespec(microseconds: u64, result: &mut timespec) {
 	result.tv_sec = (microseconds / 1_000_000) as i64;


### PR DESCRIPTION
Unfortunately macros can't have a path-based scope without being exported from the crate, so we'll have to resort to textual scope.