### PR TITLE
Implement early shutdown

### DIFF
--- a/.github/workflows/x86.yml
+++ b/.github/workflows/x86.yml
@@ -72,6 +72,7 @@ jobs:
         run: |
           qemu-system-x86_64 -display none -smp 1 -m 128M -serial stdio \
             -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr \
+            -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
             -kernel loader/target/x86_64-unknown-hermit-loader/release/rusty-loader \
             -initrd target/x86_64-unknown-hermit/debug/rusty_demo
       - name: Integration tests (ubuntu)
@@ -85,6 +86,7 @@ jobs:
         run: |
           qemu-system-x86_64 -display none -smp 1 -m 128M -serial stdio \
             -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr \
+            -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
             -kernel loader/target/x86_64-unknown-hermit-loader/release/rusty-loader \
             -initrd target/x86_64-unknown-hermit/release/rusty_demo
       - name: Build minimal profile

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,21 +92,25 @@ test:qemu:
      - kvm-ok
      - qemu-system-x86_64 -smp 1
         -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand
+        -device isa-debug-exit,iobase=0xf4,iosize=0x04
         -display none -m 64M -serial stdio -enable-kvm
         -kernel /usr/local/bin/rusty-loader
         -initrd rusty-hermit/target/x86_64-unknown-hermit/debug/rusty_demo
      - qemu-system-x86_64 -smp 2
         -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand
+        -device isa-debug-exit,iobase=0xf4,iosize=0x04
         -display none -m 64M -serial stdio -enable-kvm
         -kernel /usr/local/bin/rusty-loader
         -initrd rusty-hermit/target/x86_64-unknown-hermit/debug/rusty_demo
      - qemu-system-x86_64 -smp 1
         -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand
+        -device isa-debug-exit,iobase=0xf4,iosize=0x04
         -display none -m 64M -serial stdio -enable-kvm
         -kernel /usr/local/bin/rusty-loader
         -initrd rusty-hermit/target/x86_64-unknown-hermit/release/rusty_demo
      - qemu-system-x86_64 -smp 2
         -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand
+        -device isa-debug-exit,iobase=0xf4,iosize=0x04
         -display none -m 64M -serial stdio -enable-kvm
         -kernel /usr/local/bin/rusty-loader
         -initrd rusty-hermit/target/x86_64-unknown-hermit/release/rusty_demo

--- a/src/arch/x86_64/kernel/acpi.rs
+++ b/src/arch/x86_64/kernel/acpi.rs
@@ -453,7 +453,7 @@ pub fn poweroff() {
 			);
 			outw(pm1a_cnt_blk, bits);
 		} else {
-			debug!("ACPI Power Off is not available");
+			warn!("ACPI Power Off is not available");
 		}
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@
 #![feature(linked_list_cursors)]
 #![feature(naked_functions)]
 #![feature(new_uninit)]
-#![feature(panic_info_message)]
 #![feature(specialization)]
 #![feature(core_intrinsics)]
 #![feature(alloc_error_handler)]

--- a/src/runtime_glue.rs
+++ b/src/runtime_glue.rs
@@ -1,34 +1,19 @@
 //! Minor functions that Rust really expects to be defined by the compiler,
 //! but which we need to provide manually because we're on bare metal.
 
-use crate::arch::kernel::processor::run_on_hypervisor;
-use crate::{__sys_shutdown, arch};
 use alloc::alloc::Layout;
 use core::panic::PanicInfo;
 
-// see https://users.rust-lang.org/t/psa-breaking-change-panic-fmt-language-item-removed-in-favor-of-panic-implementation/17875
+use crate::arch::percore;
+use crate::syscalls;
+
 #[cfg(any(target_os = "none", target_os = "hermit"))]
 #[panic_handler]
 fn panic(info: &PanicInfo<'_>) -> ! {
-	print!("[{}][!!!PANIC!!!] ", arch::percore::core_id());
+	let core_id = percore::core_id();
+	println!("[{core_id}][PANIC] {info}");
 
-	if let Some(location) = info.location() {
-		print!("{}:{}: ", location.file(), location.line());
-	}
-
-	if let Some(message) = info.message() {
-		print!("{}", message);
-	}
-
-	println!();
-
-	if run_on_hypervisor() {
-		__sys_shutdown(1);
-	}
-
-	loop {
-		arch::processor::halt();
-	}
+	syscalls::shutdown(1)
 }
 
 #[alloc_error_handler]

--- a/src/runtime_glue.rs
+++ b/src/runtime_glue.rs
@@ -33,15 +33,8 @@ fn panic(info: &PanicInfo<'_>) -> ! {
 
 #[alloc_error_handler]
 fn rust_oom(layout: Layout) -> ! {
-	println!(
-		"[{}][!!!OOM!!!] Memory allocation of {} bytes failed",
-		arch::percore::core_id(),
-		layout.size()
-	);
-
-	loop {
-		arch::processor::halt();
-	}
+	let size = layout.size();
+	panic!("memory allocation of {size} bytes failed")
 }
 
 #[cfg(target_os = "hermit")]

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -41,6 +41,17 @@ pub static LWIP_LOCK: SpinlockIrqSave<()> = SpinlockIrqSave::new(());
 
 static mut SYS: &'static dyn SyscallInterface = &interfaces::Generic;
 
+/// Shuts down the machine.
+///
+/// This does not require the syscall interface to be initialized.
+pub(crate) fn shutdown(arg: i32) -> ! {
+	if environment::is_uhyve() {
+		interfaces::Uhyve.shutdown(arg)
+	} else {
+		interfaces::Generic.shutdown(arg)
+	}
+}
+
 pub(crate) fn init() {
 	unsafe {
 		// We know that HermitCore has successfully initialized a network interface.


### PR DESCRIPTION
This fixes panicking (exiting in general) before syscalls::init. 

This should fix CI timeouts on early kernel panics.