### PR TITLE
Export errno module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ mod config;
 mod console;
 mod drivers;
 mod environment;
-mod errno;
+pub mod errno;
 mod kernel_message_buffer;
 mod mm;
 #[cfg(any(target_os = "none", target_os = "hermit"))]


### PR DESCRIPTION
https://github.com/hermitcore/libhermit-rs/pull/387 has been merged incorrectly in https://github.com/hermitcore/libhermit-rs/pull/387/commits/6c2d63e6a55e6323a6eec4ff40dabe6c4a6495a6.