### PR TITLE
Use custom targets for kernel

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,7 +4,7 @@ build-std = ["core", "alloc"]
 build-std-features = ["compiler-builtins-mem"]
 
 [build]
-target = "x86_64-unknown-none-hermitkernel"
+target = "targets/x86_64-unknown-none-hermitkernel.json"
 rustflags = [
   "-Zmutable-noalias=no"
 ]

--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -41,7 +41,7 @@ jobs:
         run: rustup show
       - name: Build minimal kernel
         working-directory: libhermit-rs
-        run: cargo build --no-default-features --target aarch64-unknown-none-hermitkernel -Z build-std=core,alloc
+        run: cargo build --no-default-features --target targets/aarch64-unknown-none-hermitkernel.json -Z build-std=core,alloc
       - name: Build dev profile
         run: cargo build --target aarch64-unknown-hermit -p hello_world
       - name: Build loader

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -27,5 +27,5 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
         run: |
-          cargo doc --no-deps --document-private-items --target x86_64-unknown-none-hermitkernel
-          cargo doc --no-deps --document-private-items --target aarch64-unknown-none-hermitkernel
+          cargo doc --no-deps --document-private-items --target targets/x86_64-unknown-none-hermitkernel.json
+          cargo doc --no-deps --document-private-items --target targets/aarch64-unknown-none-hermitkernel.json

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,10 +59,10 @@ test:integration:
     - python3 --version
     - HERMIT_LOG_LEVEL_FILTER=Debug cargo test --test '*' --no-fail-fast -Z build-std=core,alloc 
         -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi 
-        --target x86_64-unknown-none-hermitkernel -- --veryverbose
+        --target targets/x86_64-unknown-none-hermitkernel.json -- --veryverbose
     - HERMIT_LOG_LEVEL_FILTER=Debug cargo test --test '*' --no-fail-fast -Z build-std=core,alloc 
         -Z build-std-features=compiler-builtins-mem --no-default-features --features=pci,acpi 
-        --target x86_64-unknown-none-hermitkernel -- --num_cores 2
+        --target targets/x86_64-unknown-none-hermitkernel.json -- --num_cores 2
         --veryverbose
   tags:
     - privileged

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,6 @@ exclude = [
 	".gitignore",
 ]
 
-[package.metadata.docs.rs]
-targets = [
-	"x86_64-unknown-none-hermitkernel",
-	"aarch64-unknown-none-hermitkernel",
-]
-
 [lib]
 crate-type = ["staticlib", "lib"]  # "lib" required for integration tests
 name = "hermit"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ rustup component add rust-src llvm-tools-preview
 You can then build `libhermit-rs` with the following command
 
 ```sh
-cargo build -Z build-std=core,alloc,panic_abort --target x86_64-unknown-none-hermitkernel
+cargo build -Z build-std=core,alloc,panic_abort --target targets/x86_64-unknown-none-hermitkernel.json
 ```
 
 The resulting library then can be found in `target/x86_64-unknown-none-hermitkernel/debug/libhermit.a`
@@ -44,7 +44,7 @@ You can change it by setting it at compile time to a string matching the name of
 If the variable is not set, or the name doesn't match, then `LevelFilter::Info` is used by default.
 
 ```sh
-$ HERMIT_LOG_LEVEL_FILTER=Debug cargo build -Z build-std=core,alloc,panic_abort --target x86_64-unknown-none-hermitkernel
+$ HERMIT_LOG_LEVEL_FILTER=Debug cargo build -Z build-std=core,alloc,panic_abort --target targets/x86_64-unknown-none-hermitkernel.json
 ```
 
 ## Credits

--- a/targets/aarch64-unknown-none-hermitkernel.json
+++ b/targets/aarch64-unknown-none-hermitkernel.json
@@ -1,0 +1,23 @@
+{
+    "abi": "softfloat",
+    "arch": "aarch64",
+    "data-layout": "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
+    "disable-redzone": true,
+    "executables": true,
+    "features": "+strict-align,-neon,-fp-armv8",
+    "linker": "rust-lld",
+    "linker-flavor": "ld.lld",
+    "llvm-target": "aarch64-unknown-hermit",
+    "max-atomic-width": 128,
+    "panic-strategy": "abort",
+    "position-independent-executables": true,
+    "pre-link-args": {
+        "ld.lld": [
+            "--build-id",
+            "--hash-style=gnu",
+            "--Bstatic"
+        ]
+    },
+    "static-position-independent-executables": true,
+    "target-pointer-width": "64"
+}

--- a/targets/x86_64-unknown-none-hermitkernel.json
+++ b/targets/x86_64-unknown-none-hermitkernel.json
@@ -1,0 +1,26 @@
+{
+    "arch": "x86_64",
+    "cpu": "x86-64",
+    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+    "disable-redzone": true,
+    "executables": true,
+    "features": "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-3dnow,-3dnowa,-avx,-avx2,+soft-float",
+    "linker": "rust-lld",
+    "linker-flavor": "ld.lld",
+    "llvm-target": "x86_64-unknown-hermit",
+    "max-atomic-width": 64,
+    "panic-strategy": "abort",
+    "position-independent-executables": true,
+    "pre-link-args": {
+        "ld.lld": [
+            "--build-id",
+            "--hash-style=gnu",
+            "--Bstatic"
+        ]
+    },
+    "stack-probes": {
+        "kind": "call"
+    },
+    "static-position-independent-executables": true,
+    "target-pointer-width": "64"
+}


### PR DESCRIPTION
Closes https://github.com/hermitcore/rusty-hermit/issues/197#issuecomment-1076416891.

This puts our kernel targets into json files. This is now possible since we do not distribute the kernel via crates.io anymore.