### PR TITLE
Update toolchain to 2022-03-27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
     # Manually sync this with rust-toolchain.toml!
-    RUST_VERSION=nightly-2022-01-30 \
+    RUST_VERSION=nightly-2022-03-27 \
     RUST_COMPONENTS="clippy llvm-tools-preview rustfmt rust-src"
 
 RUN set -eux; \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # Manually sync this with Dockerfile!
-channel = "nightly-2022-02-12"
+channel = "nightly-2022-03-27"
 components = [
     "clippy",
     "llvm-tools-preview",

--- a/src/arch/x86_64/kernel/idt.rs
+++ b/src/arch/x86_64/kernel/idt.rs
@@ -133,6 +133,7 @@ pub fn install() {
 /// * `handler`   - Handler function to call for this interrupt/exception.
 /// * `ist_index` - Index of the Interrupt Stack Table (IST) to switch to.
 ///                 A zero value means that the stack won't be switched, a value of 1 refers to the first IST entry, etc.
+#[allow(clippy::only_used_in_recursion)]
 pub fn set_gate(index: u8, handler: usize, ist_index: u8) {
 	let sel = SegmentSelector::new(gdt::GDT_KERNEL_CODE, Ring::Ring0);
 	let entry = IdtEntry::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@
 #![feature(asm_const)]
 #![feature(asm_sym)]
 #![feature(const_btree_new)]
-#![feature(const_fn_trait_bound)]
 #![feature(const_mut_refs)]
 #![feature(const_ptr_offset_from)]
 #![feature(linked_list_cursors)]


### PR DESCRIPTION
This is the first nightly to not include the hermitkernel targets.