### PR TITLE
Align x86_64 target to x86_64-unknown-none

### DIFF
--- a/targets/x86_64-unknown-none-hermitkernel.json
+++ b/targets/x86_64-unknown-none-hermitkernel.json
@@ -1,5 +1,6 @@
 {
     "arch": "x86_64",
+    "code-model": "kernel",
     "cpu": "x86-64",
     "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     "disable-redzone": true,
@@ -11,13 +12,7 @@
     "max-atomic-width": 64,
     "panic-strategy": "abort",
     "position-independent-executables": true,
-    "pre-link-args": {
-        "ld.lld": [
-            "--build-id",
-            "--hash-style=gnu",
-            "--Bstatic"
-        ]
-    },
+    "relro-level": "full",
     "stack-probes": {
         "kind": "call"
     },


### PR DESCRIPTION
The only remaining difference is the llvm-target.