### PR TITLE
Targets: Use none-elf instead of hermit llvm-target

### DIFF
--- a/targets/aarch64-unknown-none-hermitkernel.json
+++ b/targets/aarch64-unknown-none-hermitkernel.json
@@ -7,7 +7,7 @@
     "features": "+strict-align,-neon,-fp-armv8",
     "linker": "rust-lld",
     "linker-flavor": "ld.lld",
-    "llvm-target": "aarch64-unknown-hermit",
+    "llvm-target": "aarch64-unknown-none-elf",
     "max-atomic-width": 128,
     "panic-strategy": "abort",
     "position-independent-executables": true,

--- a/targets/x86_64-unknown-none-hermitkernel.json
+++ b/targets/x86_64-unknown-none-hermitkernel.json
@@ -8,7 +8,7 @@
     "features": "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-3dnow,-3dnowa,-avx,-avx2,+soft-float",
     "linker": "rust-lld",
     "linker-flavor": "ld.lld",
-    "llvm-target": "x86_64-unknown-hermit",
+    "llvm-target": "x86_64-unknown-none-elf",
     "max-atomic-width": 64,
     "panic-strategy": "abort",
     "position-independent-executables": true,


### PR DESCRIPTION
As discussed in https://github.com/hermitcore/rusty-hermit/issues/197#issuecomment-999379314, this way the kernel's `libhermit.a` has `OS/ABI: UNIX - System V` and the resulting application has `OS/ABI: <unknown: ff>`. This works for the Rust-toolchain as well as the C-toolchain.