### PR TITLE
Align aarch64 target to aarch64-unknown-none-softfloat

### DIFF
--- a/targets/aarch64-unknown-none-hermitkernel.json
+++ b/targets/aarch64-unknown-none-hermitkernel.json
@@ -11,13 +11,6 @@
     "max-atomic-width": 128,
     "panic-strategy": "abort",
     "position-independent-executables": true,
-    "pre-link-args": {
-        "ld.lld": [
-            "--build-id",
-            "--hash-style=gnu",
-            "--Bstatic"
-        ]
-    },
     "static-position-independent-executables": true,
     "target-pointer-width": "64"
 }


### PR DESCRIPTION
This removes custom pre-link-args.