### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -15,6 +15,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: aarch64 tests

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -12,6 +12,9 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
 
+permissions:
+  contents: read
+
 jobs:
   clippy:
     name: Clippy

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -11,6 +11,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   doc:
     name: Doc

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,6 +11,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   format:
     name: Format

--- a/.github/workflows/x86.yml
+++ b/.github/workflows/x86.yml
@@ -15,6 +15,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: x86 tests


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
