### PR TITLE
Migrate to x86_64-unknown-none

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:$PATH \
     # Manually sync this with rust-toolchain.toml!
     RUST_VERSION=nightly-2022-04-24 \
-    RUST_COMPONENTS="clippy llvm-tools-preview rustfmt rust-src"
+    RUST_COMPONENTS="clippy llvm-tools-preview rustfmt rust-src" \
+    RUST_TARGETS="x86_64-unknown-none"
 
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \
@@ -26,6 +27,7 @@ RUN set -eux; \
         --default-toolchain $RUST_VERSION \
         --default-host ${rustArch} \
         --component $RUST_COMPONENTS \
+        --target $RUST_TARGETS \
     ; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -7,3 +7,4 @@ components = [
     "rustfmt",
     "rust-src",
 ]
+targets = [ "x86_64-unknown-none" ]


### PR DESCRIPTION
Closes https://github.com/hermitcore/libhermit-rs/issues/412.

This reduces initial build times of the kernel, since `core` and `alloc` are now downloaded instead of compiled ourselves. `x86_64-unknown-none` is tier 2 and ships artifacts, so we can omit `build-std`.