### PR TITLE
Enable lwIP support

### DIFF
--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -64,13 +64,6 @@ pub fn raw_boot_info() -> &'static RawBootInfo {
 static mut COM1: SerialPort = SerialPort::new(0x3f8);
 
 #[cfg(feature = "newlib")]
-pub fn has_ipdevice() -> bool {
-	let ip = boot_info().net_info.ip;
-
-	!(ip[0] == 255 && ip[1] == 255 && ip[2] == 255 && ip[3] == 255)
-}
-
-#[cfg(feature = "newlib")]
 extern "C" fn __sys_uhyve_get_ip(ip: *mut u8) {
 	let data = boot_info().net_info.ip;
 	unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,12 +246,6 @@ extern "C" {
 	static mut __bss_start: usize;
 }
 
-/// Helper function to check if uhyve provide an IP device
-#[cfg(feature = "newlib")]
-fn has_ipdevice() -> bool {
-	arch::x86_64::kernel::has_ipdevice()
-}
-
 /// Entry point of a kernel thread, which initialize the libos
 #[cfg(target_os = "none")]
 extern "C" fn initd(_arg: usize) {
@@ -265,9 +259,7 @@ extern "C" fn initd(_arg: usize) {
 	// initialize LwIP library for newlib-based applications
 	#[cfg(feature = "newlib")]
 	unsafe {
-		if has_ipdevice() {
-			init_lwip();
-		}
+		init_lwip();
 	}
 
 	if env::is_uhyve() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,12 +254,15 @@ extern "C" fn initd(_arg: usize) {
 		fn runtime_entry(argc: i32, argv: *const *const u8, env: *const *const u8) -> !;
 		#[cfg(feature = "newlib")]
 		fn init_lwip();
+		#[cfg(feature = "newlib")]
+		fn init_rtl8139_netif(freq: u32) -> i32;
 	}
 
 	// initialize LwIP library for newlib-based applications
 	#[cfg(feature = "newlib")]
 	unsafe {
 		init_lwip();
+		init_rtl8139_netif(processor::get_frequency() as u32);
 	}
 
 	if env::is_uhyve() {
@@ -273,6 +276,7 @@ extern "C" fn initd(_arg: usize) {
 	}
 
 	// Initialize Drivers
+	#[cfg(not(feature = "newlib"))]
 	arch::init_drivers();
 
 	syscalls::init();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,9 @@
 )]
 #![cfg_attr(target_os = "none", cfg_attr(test, no_main))]
 
+#[cfg(all(feature = "newlib", feature = "pci"))]
+compile_error!("feature \"newlib\" and feature \"pci\" cannot be enabled at the same time");
+
 // EXTERNAL CRATES
 #[macro_use]
 extern crate alloc;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -82,6 +82,7 @@ macro_rules! try_sys {
 /// let ret = f(arg);
 /// ```
 #[allow(unused_macro_rules)]
+#[cfg(all(target_arch = "x86_64", not(feature = "newlib")))]
 macro_rules! kernel_function {
 	($f:ident()) => {
 		$crate::arch::switch::kernel_function0($f)
@@ -112,7 +113,12 @@ macro_rules! kernel_function {
 	};
 }
 
-#[cfg(target_arch = "aarch64")]
+// TODO: Properly switch kernel stack with newlib
+// https://github.com/hermitcore/libhermit-rs/issues/471
+#[cfg(any(
+	target_arch = "aarch64",
+	all(target_arch = "x86_64", feature = "newlib")
+))]
 macro_rules! kernel_function {
 	($f:ident($($x:tt)*)) => {{
 		$f($($x)*)

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -124,6 +124,11 @@ impl flags::Build {
 			"init_lwip",
 			"lwip_read",
 			"lwip_write",
+			// lwIP rtl8139 driver
+			"init_rtl8139_netif",
+			"irq_install_handler",
+			"virt_to_phys",
+			"eoi",
 		]
 		.into_iter();
 
@@ -193,8 +198,15 @@ impl flags::Clippy {
 				.arg("--no-default-features")
 				.run()?;
 			cmd!(sh, "cargo clippy {target_args...}")
-				.arg("--all-features")
+				.arg("--no-default-features")
+				.arg("--features=acpi,fsgsbase,pci,smp,vga")
 				.run()?;
+			// TODO: Enable clippy for newlib
+			// https://github.com/hermitcore/libhermit-rs/issues/470
+			// cmd!(sh, "cargo clippy {target_args...}")
+			// 	.arg("--no-default-features")
+			// 	.arg("--features=acpi,fsgsbase,newlib,smp,vga")
+			// 	.run()?;
 		}
 
 		cmd!(sh, "cargo clippy --package xtask").run()?;


### PR DESCRIPTION
This PR enables lwIP support by using lwIP's rtl8139 driver instead of the kernel implementation.

To workaround https://github.com/hermitcore/libhermit-rs/issues/471, this disables kernel stack switching with newlib. A proper fix would require much more work and insight into our lwIP implementation.