### PR TITLE
RTL8139: Improvement of the ring buffer management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "rusty-hermit"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aarch64",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-hermit"
-version = "0.4.1"
+version = "0.4.2"
 authors = [
 	"Stefan Lankes <slankes@eonerc.rwth-aachen.de>",
 	"Colin Finck <colin.finck@rwth-aachen.de>",

--- a/src/drivers/net/rtl8139.rs
+++ b/src/drivers/net/rtl8139.rs
@@ -337,7 +337,7 @@ impl NetworkInterface for RTL8139Driver {
 		match self.box_map.remove_entry(&self.rxpos) {
 			Some((_, raw)) => {
 				// release temporay created boxed slice
-				let buffer: Box<[u8]> =
+				let _buffer: Box<[u8]> =
 					unsafe { Box::from_raw(slice::from_raw_parts_mut(raw.ptr, raw.len)) };
 			}
 			None => {}

--- a/src/drivers/net/rtl8139.rs
+++ b/src/drivers/net/rtl8139.rs
@@ -283,11 +283,9 @@ impl NetworkInterface for RTL8139Driver {
 				// do we reach the end of the receive buffers?
 				// in this case, we have to copy the data in boxed slice
 				let buf = if pos + length as usize > RX_BUF_LEN {
-					let mut msg: Box<[u8]> = vec![0; length as usize].into_boxed_slice();
-					let limit = RX_BUF_LEN - pos;
-
-					msg[0..limit].copy_from_slice(&self.rxbuffer[pos..RX_BUF_LEN]);
-					msg[limit..].copy_from_slice(&self.rxbuffer[0..length as usize - limit]);
+					let first = &self.rxbuffer[pos..RX_BUF_LEN];
+					let second = &self.rxbuffer[..length as usize - first.len()];
+					let msg = [first, second].concat().into_boxed_slice();
 
 					// buffer address to release box in `rx_buffer_consumed`
 					match self.box_map.entry(self.rxpos) {


### PR DESCRIPTION
The device driver RTL8139 tries to avoid unneeded copies of buffers. But in case, the ring buffer wrap around, two pieces have to copy into one continuous memory region.

=> temporary creation of a boxed buffers