### PR TITLE
add option to assign a task to the nic

### DIFF
--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -634,6 +634,11 @@ pub fn init_local_apic() {
 	);
 }
 
+pub(crate) fn assign_irq_to_core(irq: u8, core_id: CoreId) {
+	info!("Assign interrupt {} to core {}", irq, core_id);
+	ioapic_inton(irq, core_id.try_into().unwrap()).unwrap();
+}
+
 fn calibrate_timer() {
 	// The APIC Timer is used to provide a one-shot interrupt for the tickless timer
 	// implemented through processor::get_timer_ticks.

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -637,8 +637,8 @@ pub fn init_local_apic() {
 pub(crate) fn assign_irq_to_core(irq: u8, core_id: CoreId) {
 	info!("Assign interrupt {} to core {}", irq, core_id);
 	irqsave(|| {
-        ioapic_inton(irq, core_id.try_into().unwrap()).unwrap();
-    });
+		ioapic_inton(irq, core_id.try_into().unwrap()).unwrap();
+	});
 }
 
 fn calibrate_timer() {

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -636,7 +636,9 @@ pub fn init_local_apic() {
 
 pub(crate) fn assign_irq_to_core(irq: u8, core_id: CoreId) {
 	info!("Assign interrupt {} to core {}", irq, core_id);
-	ioapic_inton(irq, core_id.try_into().unwrap()).unwrap();
+	irqsave(|| {
+        ioapic_inton(irq, core_id.try_into().unwrap()).unwrap();
+    });
 }
 
 fn calibrate_timer() {

--- a/src/drivers/net/mod.rs
+++ b/src/drivers/net/mod.rs
@@ -40,6 +40,8 @@ pub trait NetworkInterface {
 	fn set_polling_mode(&mut self, value: bool);
 	/// Handle interrupt and check if a packet is available
 	fn handle_interrupt(&mut self) -> bool;
+	/// handle interrupt on the same core, where the current task is running
+	fn assign_task_to_nic(&self);
 }
 
 #[cfg(all(not(feature = "newlib"), target_arch = "x86_64"))]

--- a/src/drivers/net/rtl8139.rs
+++ b/src/drivers/net/rtl8139.rs
@@ -8,10 +8,11 @@ use core::mem;
 
 use crate::arch::kernel::irq::*;
 use crate::arch::kernel::pci;
-use crate::arch::kernel::percore::increment_irq_counter;
+use crate::arch::kernel::percore::{core_id, increment_irq_counter};
 use crate::arch::mm::paging::virt_to_phys;
 use crate::arch::mm::VirtAddr;
 use crate::drivers::error::DriverError;
+use crate::drivers::net::apic::assign_irq_to_core;
 use crate::drivers::net::{network_irqhandler, NetworkInterface};
 use crate::x86::io::*;
 
@@ -215,6 +216,10 @@ impl NetworkInterface for RTL8139Driver {
 	/// Returns the MAC address of the network interface
 	fn get_mac_address(&self) -> [u8; 6] {
 		self.mac
+	}
+
+	fn assign_task_to_nic(&self) {
+		assign_irq_to_core(self.irq, core_id());
 	}
 
 	/// Returns the current MTU of the device.

--- a/src/drivers/net/virtio_net.rs
+++ b/src/drivers/net/virtio_net.rs
@@ -4,7 +4,7 @@
 
 #[cfg(not(feature = "newlib"))]
 use super::netwakeup;
-use crate::arch::kernel::percore::increment_irq_counter;
+use crate::arch::kernel::percore::{core_id, increment_irq_counter};
 use crate::config::VIRTIO_MAX_QUEUE_SIZE;
 use crate::drivers::net::NetworkInterface;
 
@@ -16,6 +16,7 @@ use core::mem;
 use core::result::Result;
 use core::{cell::RefCell, cmp::Ordering};
 
+use crate::drivers::net::apic::assign_irq_to_core;
 #[cfg(not(feature = "pci"))]
 use crate::drivers::net::virtio_mmio::NetDevCfgRaw;
 #[cfg(feature = "pci")]
@@ -513,6 +514,10 @@ impl NetworkInterface for VirtioNetDriver {
 		} else {
 			unreachable!("Currently VIRTIO_NET_F_MAC must be negotiated!")
 		}
+	}
+
+	fn assign_task_to_nic(&self) {
+		assign_irq_to_core(self.irq, core_id());
 	}
 
 	/// Returns the current MTU of the device.

--- a/src/syscalls/interfaces/mod.rs
+++ b/src/syscalls/interfaces/mod.rs
@@ -127,6 +127,13 @@ pub trait SyscallInterface: Send + Sync {
 		Err(())
 	}
 
+	fn assign_task_to_nic(&self) {
+		#[cfg(not(target_arch = "aarch64"))]
+		if let Some(driver) = get_network_driver() {
+			driver.lock().assign_task_to_nic();
+		}
+	}
+
 	fn get_mtu(&self) -> Result<u16, ()> {
 		#[cfg(not(target_arch = "aarch64"))]
 		match get_network_driver() {

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -103,6 +103,17 @@ pub fn sys_get_mac_address() -> Result<[u8; 6], ()> {
 	kernel_function!(__sys_get_mac_address())
 }
 
+extern "C" fn __sys_assign_task_to_nic() {
+	unsafe {
+		SYS.assign_task_to_nic();
+	}
+}
+
+#[no_mangle]
+fn sys_assign_task_to_nic() {
+	kernel_function!(__sys_assign_task_to_nic());
+}
+
 #[allow(improper_ctypes_definitions)]
 extern "C" fn __sys_get_mtu() -> Result<u16, ()> {
 	unsafe { SYS.get_mtu() }


### PR DESCRIPTION
the new syscall allows us to handle the network interrupt on the core, where the network thread (see hermit-sys) is running