### PR TITLE
Fix integration tests

### DIFF
--- a/.github/workflows/x86.yml
+++ b/.github/workflows/x86.yml
@@ -81,8 +81,7 @@ jobs:
       - name: Integration tests (ubuntu)
         working-directory: libhermit-rs
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: cargo test --tests --no-fail-fast -- --bootloader_path=rusty-loader-x86_64
-        continue-on-error: true
+        run: cargo test --tests --no-fail-fast --target x86_64-unknown-none -- --bootloader_path=../rusty-loader-x86_64
       - name: Build release profile
         run: cargo build -Zbuild-std=core,alloc,std,panic_abort -Zbuild-std-features=compiler-builtins-mem --target x86_64-unknown-hermit --release
       - name: Test release profile

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -30,7 +30,7 @@ pub mod pit;
 pub mod processor;
 pub mod scheduler;
 pub mod serial;
-#[cfg(not(test))]
+#[cfg(target_os = "none")]
 mod start;
 pub mod switch;
 pub mod systemtime;


### PR DESCRIPTION
Closes https://github.com/hermitcore/libhermit-rs/issues/515.

Depends on https://github.com/hermitcore/rusty-loader/pull/148 until https://github.com/hermitcore/libhermit-rs/issues/516 is fixed.