### PR TITLE
Fix deadlock on spurious wakeup in `futex_wait`

### DIFF
--- a/src/scheduler/task.rs
+++ b/src/scheduler/task.rs
@@ -164,6 +164,13 @@ impl TaskHandlePriorityQueue {
 		self.prio_bitmap == 0
 	}
 
+	/// Checks if the given task is in the queue. Returns `true` if the task
+	/// was found.
+	pub fn contains(&self, task: TaskHandle) -> bool {
+		self.queues[task.priority.into() as usize]
+			.is_some_and(|queue| queue.iter().any(|queued| queued.id == task.id))
+	}
+
 	/// Add a task handle by its priority to the queue
 	pub fn push(&mut self, task: TaskHandle) {
 		let i = task.priority.into() as usize;


### PR DESCRIPTION
If a spurious wakeup occurs, the task was removed unconditionally from the queue, meaning it would never be woken. This is fixed if the task is only removed if a timeout occurred.