### PR TITLE
add BSD socket layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,7 @@ dependencies = [
  "hermit-sync",
  "include-transformed",
  "linked_list_allocator",
+ "lock_api",
  "log",
  "multiboot",
  "num",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "aarch64-cpu"
-version = "9.0.0"
+version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aceb88e55ba626a5479279268d009a92d9d00eacce0de1b8c236c7ad31b7225"
+checksum = "eb711c57d60565ba8f6523eb371e6243639617d817b4df1ae09af250af1af411"
 dependencies = [
  "tock-registers 0.8.1",
 ]
@@ -98,6 +98,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
+
+[[package]]
 name = "exclusive_cell"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "generic_once_cell"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e75ad6783e1fcc13a2ea5af60711f631506b155fdecaaeb6d59ce087a36d850"
+checksum = "c27ddeab45f9c2238a860db235b3e80ce23651fa8293b6f7f53fb72cbb5ce539"
 dependencies = [
  "lock_api",
 ]
@@ -210,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libhermit-rs"
@@ -224,6 +230,7 @@ dependencies = [
  "async-task",
  "bitflags",
  "crossbeam-utils",
+ "dyn-clone",
  "float-cmp",
  "futures-lite",
  "hashbrown",
@@ -307,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.1"
+version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -391,15 +398,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "paste"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "pci-ids"
@@ -466,9 +473,9 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
@@ -481,9 +488,9 @@ checksum = "9ff023245bfcc73fb890e1f8d5383825b3131cc920020a5c487d6f113dfc428a"
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -532,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "scopeguard"
@@ -587,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.104"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae548ec36cf198c0ef7710d3c230987c2d6d7bd98ad6edc0274462724c585ce"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -650,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ ahash = { version = "0.8", default-features = false }
 align-address = "0.1"
 bitflags = "1.3"
 crossbeam-utils = { version = "0.8", default-features = false }
+dyn-clone = "1.0"
 hashbrown = { version = "0.13", default-features = false }
 hermit-entry = { version = "0.9", features = ["kernel"] }
 hermit-sync = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ pci = ["num-derive"]
 acpi = []
 smp = ["include-transformed"]
 fsgsbase = []
+trace = []
 tcp = [
     "async-task",
     "futures-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ shell-words = { version = "1.1", default-features = false }
 qemu-exit = "3.0"
 futures-lite = { version = "1.11", default-features = false, optional = true }
 async-task = { version = "4.3", default-features = false, optional = true }
+lock_api = "0.4"
 
 [dependencies.smoltcp]
 version = "0.8"

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -1,5 +1,5 @@
 use alloc::vec::Vec;
-#[cfg(any(feature = "pci", feature = "smp"))]
+#[cfg(feature = "smp")]
 use core::arch::x86_64::_mm_mfence;
 use core::hint::spin_loop;
 #[cfg(feature = "smp")]

--- a/src/arch/x86_64/kernel/scheduler.rs
+++ b/src/arch/x86_64/kernel/scheduler.rs
@@ -378,8 +378,6 @@ impl TaskFrame for Task {
 
 extern "x86-interrupt" fn timer_handler(_stack_frame: interrupts::ExceptionStackFrame) {
 	increment_irq_counter(apic::TIMER_INTERRUPT_NUMBER.into());
-	#[cfg(feature = "tcp")]
-	crate::net::executor::wakeup_async_tasks();
 	core_scheduler().handle_waiting_tasks();
 	apic::eoi();
 	core_scheduler().scheduler();

--- a/src/arch/x86_64/kernel/scheduler.rs
+++ b/src/arch/x86_64/kernel/scheduler.rs
@@ -378,6 +378,8 @@ impl TaskFrame for Task {
 
 extern "x86-interrupt" fn timer_handler(_stack_frame: interrupts::ExceptionStackFrame) {
 	increment_irq_counter(apic::TIMER_INTERRUPT_NUMBER.into());
+	#[cfg(feature = "tcp")]
+	crate::net::executor::wakeup_async_tasks();
 	core_scheduler().handle_waiting_tasks();
 	apic::eoi();
 	core_scheduler().scheduler();

--- a/src/drivers/net/mod.rs
+++ b/src/drivers/net/mod.rs
@@ -63,6 +63,9 @@ pub extern "x86-interrupt" fn network_irqhandler(_stack_frame: ExceptionStackFra
 	};
 
 	if has_packet {
+		#[cfg(feature = "tcp")]
+		crate::net::executor::wakeup_async_tasks();
+
 		// handle incoming packets
 		#[cfg(feature = "tcp")]
 		crate::net::network_poll();

--- a/src/drivers/net/mod.rs
+++ b/src/drivers/net/mod.rs
@@ -64,10 +64,7 @@ pub extern "x86-interrupt" fn network_irqhandler(_stack_frame: ExceptionStackFra
 
 	if has_packet {
 		let core_scheduler = core_scheduler();
-
-		#[cfg(feature = "tcp")]
 		core_scheduler.wakeup_async_tasks();
-
 		core_scheduler.scheduler();
 	}
 }

--- a/src/drivers/net/mod.rs
+++ b/src/drivers/net/mod.rs
@@ -6,6 +6,8 @@ pub mod virtio_net;
 #[cfg(feature = "pci")]
 pub mod virtio_pci;
 
+use alloc::vec::Vec;
+
 use crate::arch::kernel::apic;
 use crate::arch::kernel::core_local::*;
 use crate::arch::kernel::interrupts::ExceptionStackFrame;
@@ -31,9 +33,7 @@ pub trait NetworkInterface {
 	/// Check if a packet is available
 	fn has_packet(&self) -> bool;
 	/// Get RX buffer with an received packet
-	fn receive_rx_buffer(&mut self) -> Result<(&'static mut [u8], usize), ()>;
-	/// Tells driver, that buffer is consumed and can be deallocated
-	fn rx_buffer_consumed(&mut self, trf_handle: usize);
+	fn receive_rx_buffer(&mut self) -> Result<Vec<u8>, ()>;
 	/// Enable / disable the polling mode of the network interface
 	fn set_polling_mode(&mut self, value: bool);
 	/// Handle interrupt and check if a packet is available
@@ -63,13 +63,11 @@ pub extern "x86-interrupt" fn network_irqhandler(_stack_frame: ExceptionStackFra
 	};
 
 	if has_packet {
-		#[cfg(feature = "tcp")]
-		crate::net::executor::wakeup_async_tasks();
+		let core_scheduler = core_scheduler();
 
-		// handle incoming packets
 		#[cfg(feature = "tcp")]
-		crate::net::network_poll();
+		core_scheduler.wakeup_async_tasks();
 
-		core_scheduler().scheduler();
+		core_scheduler.scheduler();
 	}
 }

--- a/src/drivers/net/mod.rs
+++ b/src/drivers/net/mod.rs
@@ -64,6 +64,7 @@ pub extern "x86-interrupt" fn network_irqhandler(_stack_frame: ExceptionStackFra
 
 	if has_packet {
 		let core_scheduler = core_scheduler();
+		#[cfg(feature = "tcp")]
 		core_scheduler.wakeup_async_tasks();
 		core_scheduler.scheduler();
 	}

--- a/src/drivers/net/rtl8139.rs
+++ b/src/drivers/net/rtl8139.rs
@@ -3,7 +3,7 @@
 #![allow(dead_code)]
 
 use alloc::boxed::Box;
-use alloc::collections::{btree_map, BTreeMap};
+use alloc::vec::Vec;
 use core::mem;
 
 use x86::io::*;
@@ -209,7 +209,6 @@ pub struct RTL8139Driver {
 	rxbuffer: Box<[u8]>,
 	rxpos: usize,
 	txbuffer: Box<[u8]>,
-	box_map: BTreeMap<usize, Box<[u8]>>,
 }
 
 impl NetworkInterface for RTL8139Driver {
@@ -270,7 +269,7 @@ impl NetworkInterface for RTL8139Driver {
 		false
 	}
 
-	fn receive_rx_buffer(&mut self) -> Result<(&'static mut [u8], usize), ()> {
+	fn receive_rx_buffer(&mut self) -> Result<Vec<u8>, ()> {
 		let cmd = unsafe { inb(self.iobase + CR) };
 
 		if (cmd & CR_BUFE) != CR_BUFE {
@@ -282,25 +281,18 @@ impl NetworkInterface for RTL8139Driver {
 				let pos = (self.rxpos + mem::size_of::<u16>()) % RX_BUF_LEN;
 
 				// do we reach the end of the receive buffers?
-				// in this case, we have to copy the data in boxed slice
+				// in this case, we conact the two slices to one vec
 				let buf = if pos + length as usize > RX_BUF_LEN {
 					let first = &self.rxbuffer[pos..RX_BUF_LEN];
 					let second = &self.rxbuffer[..length as usize - first.len()];
-					let msg = [first, second].concat().into_boxed_slice();
-
-					// buffer address to release box in `rx_buffer_consumed`
-					match self.box_map.entry(self.rxpos) {
-						btree_map::Entry::Vacant(entry) => entry.insert(msg),
-						btree_map::Entry::Occupied(_) => unreachable!(),
-					}
+					[first, second].concat()
 				} else {
-					&mut self.rxbuffer[pos..][..length.into()]
+					(&self.rxbuffer[pos..][..length.into()]).to_vec()
 				};
-				// SAFETY: This is a blatant lie and very unsound.
-				// The API must be fixed or the buffer may never touched again.
-				let buf = unsafe { mem::transmute(buf) };
 
-				Ok((buf, self.rxpos))
+				self.consume_current_buffer();
+
+				Ok(buf)
 			} else {
 				error!(
 					"RTL8192: invalid header {:#x}, rx_pos {}\n",
@@ -311,33 +303,6 @@ impl NetworkInterface for RTL8139Driver {
 			}
 		} else {
 			Err(())
-		}
-	}
-
-	// Tells driver, that buffer is consumed and can be deallocated
-	fn rx_buffer_consumed(&mut self, handle: usize) {
-		if self.rxpos != handle {
-			warn!("Invalid handle {} != {}", self.rxpos, handle)
-		}
-
-		drop(self.box_map.remove(&self.rxpos));
-
-		let length = self.rx_peek_u16();
-		self.advance_rxpos(usize::from(length) + mem::size_of::<u16>());
-
-		// packets are dword aligned
-		self.rxpos = ((self.rxpos + 3) & !0x3) % RX_BUF_LEN;
-		if self.rxpos >= 0x10 {
-			unsafe {
-				outw(self.iobase + CAPR, (self.rxpos - 0x10).try_into().unwrap());
-			}
-		} else {
-			unsafe {
-				outw(
-					self.iobase + CAPR,
-					(RX_BUF_LEN - (0x10 - self.rxpos)).try_into().unwrap(),
-				);
-			}
 		}
 	}
 
@@ -390,6 +355,27 @@ impl NetworkInterface for RTL8139Driver {
 }
 
 impl RTL8139Driver {
+	// Tells driver, that buffer is consumed and can be deallocated
+	fn consume_current_buffer(&mut self) {
+		let length = self.rx_peek_u16();
+		self.advance_rxpos(usize::from(length) + mem::size_of::<u16>());
+
+		// packets are dword aligned
+		self.rxpos = ((self.rxpos + 3) & !0x3) % RX_BUF_LEN;
+		if self.rxpos >= 0x10 {
+			unsafe {
+				outw(self.iobase + CAPR, (self.rxpos - 0x10).try_into().unwrap());
+			}
+		} else {
+			unsafe {
+				outw(
+					self.iobase + CAPR,
+					(RX_BUF_LEN - (0x10 - self.rxpos)).try_into().unwrap(),
+				);
+			}
+		}
+	}
+
 	fn rx_peek_u16(&self) -> u16 {
 		u16::from_ne_bytes(
 			self.rxbuffer[self.rxpos..][..mem::size_of::<u16>()]
@@ -611,6 +597,5 @@ pub fn init_device(adapter: &pci::PciAdapter) -> Result<RTL8139Driver, DriverErr
 		rxbuffer,
 		rxpos: 0,
 		txbuffer,
-		box_map: BTreeMap::new(),
 	})
 }

--- a/src/drivers/net/rtl8139.rs
+++ b/src/drivers/net/rtl8139.rs
@@ -287,7 +287,7 @@ impl NetworkInterface for RTL8139Driver {
 					let second = &self.rxbuffer[..length as usize - first.len()];
 					[first, second].concat()
 				} else {
-					(&self.rxbuffer[pos..][..length.into()]).to_vec()
+					(self.rxbuffer[pos..][..length.into()]).to_vec()
 				};
 
 				self.consume_current_buffer();

--- a/src/drivers/net/virtio_mmio.rs
+++ b/src/drivers/net/virtio_mmio.rs
@@ -141,6 +141,7 @@ impl VirtioNetDriver {
 			),
 			num_vqs: 0,
 			irq,
+			polling_mode_counter: 0,
 		})
 	}
 

--- a/src/drivers/net/virtio_net.rs
+++ b/src/drivers/net/virtio_net.rs
@@ -499,6 +499,7 @@ pub struct VirtioNetDriver {
 
 	pub(super) num_vqs: u16,
 	pub(super) irq: u8,
+	pub(super) polling_mode_counter: u32,
 }
 
 impl NetworkInterface for VirtioNetDriver {
@@ -641,9 +642,15 @@ impl NetworkInterface for VirtioNetDriver {
 
 	fn set_polling_mode(&mut self, value: bool) {
 		if value {
-			self.disable_interrupts()
+			if self.polling_mode_counter == 0 {
+				self.disable_interrupts();
+			}
+			self.polling_mode_counter += 1;
 		} else {
-			self.enable_interrupts()
+			self.polling_mode_counter -= 1;
+			if self.polling_mode_counter == 0 {
+				self.enable_interrupts();
+			}
 		}
 	}
 

--- a/src/drivers/net/virtio_net.rs
+++ b/src/drivers/net/virtio_net.rs
@@ -573,7 +573,7 @@ impl NetworkInterface for VirtioNetDriver {
 		!self.recv_vqs.poll_queue.borrow().is_empty()
 	}
 
-	fn receive_rx_buffer(&mut self) -> Result<(&'static mut [u8], usize), ()> {
+	fn receive_rx_buffer(&mut self) -> Result<Vec<u8>, ()> {
 		match self.recv_vqs.get_next() {
 			Some(transfer) => {
 				let transfer = match RxQueues::post_processing(transfer) {
@@ -595,9 +595,14 @@ impl NetworkInterface for VirtioNetDriver {
 					// so this is fine.
 					let recv_ref = (recv_payload as *const [u8]) as *mut [u8];
 					let ref_data: &'static mut [u8] = unsafe { &mut *(recv_ref) };
-					let raw_transfer = Box::into_raw(Box::new(transfer));
+					let vec_data = ref_data.to_vec();
+					transfer
+						.reuse()
+						.unwrap()
+						.provide()
+						.dispatch_await(Rc::clone(&self.recv_vqs.poll_queue), false);
 
-					Ok((ref_data, raw_transfer as usize))
+					Ok(vec_data)
 				} else if recv_data.len() == 1 {
 					let packet = recv_data.pop().unwrap();
 					let payload_ptr =
@@ -609,9 +614,14 @@ impl NetworkInterface for VirtioNetDriver {
 							packet.len() - mem::size_of::<VirtioNetHdr>(),
 						)
 					};
-					let raw_transfer = Box::into_raw(Box::new(transfer));
+					let vec_data = ref_data.to_vec();
+					transfer
+						.reuse()
+						.unwrap()
+						.provide()
+						.dispatch_await(Rc::clone(&self.recv_vqs.poll_queue), false);
 
-					Ok((ref_data, raw_transfer as usize))
+					Ok(vec_data)
 				} else {
 					error!("Empty transfer, or with wrong buffer layout. Reusing and returning error to user-space network driver...");
 					transfer
@@ -626,20 +636,6 @@ impl NetworkInterface for VirtioNetDriver {
 				}
 			}
 			None => Err(()),
-		}
-	}
-
-	// Tells driver, that buffer is consumed and can be deallocated
-	fn rx_buffer_consumed(&mut self, trf_handle: usize) {
-		unsafe {
-			let transfer = *Box::from_raw(trf_handle as *mut Transfer);
-
-			// Reuse transfer directly
-			transfer
-				.reuse()
-				.unwrap()
-				.provide()
-				.dispatch_await(Rc::clone(&self.recv_vqs.poll_queue), false);
 		}
 	}
 

--- a/src/drivers/net/virtio_pci.rs
+++ b/src/drivers/net/virtio_pci.rs
@@ -148,6 +148,7 @@ impl VirtioNetDriver {
 			),
 			num_vqs: 0,
 			irq: adapter.irq,
+			polling_mode_counter: 0,
 		})
 	}
 

--- a/src/fd/file.rs
+++ b/src/fd/file.rs
@@ -34,10 +34,6 @@ impl UhyveFile {
 }
 
 impl ObjectInterface for UhyveFile {
-	fn clone_box(&self) -> Box<dyn ObjectInterface> {
-		Box::new(self.clone())
-	}
-
 	fn write(&self, buf: *const u8, len: usize) -> isize {
 		let mut syswrite = SysWrite::new(self.0, buf, len);
 		uhyve_send(UHYVE_PORT_WRITE, &mut syswrite);
@@ -77,10 +73,6 @@ impl GenericFile {
 }
 
 impl ObjectInterface for GenericFile {
-	fn clone_box(&self) -> Box<dyn ObjectInterface> {
-		Box::new(self.clone())
-	}
-
 	fn write(&self, buf: *const u8, len: usize) -> isize {
 		assert!(len <= isize::MAX as usize);
 		let buf = unsafe { slice::from_raw_parts(buf, len) };

--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -345,6 +345,7 @@ pub(crate) fn get_object(fd: FileDescriptor) -> Result<Arc<Box<dyn ObjectInterfa
 	Ok((*(OBJECT_MAP.lock().get(&fd).ok_or(-EINVAL)?)).clone())
 }
 
+#[cfg(all(feature = "tcp", not(feature = "newlib")))]
 pub(crate) fn insert_object(
 	fd: FileDescriptor,
 	obj: Arc<Box<dyn ObjectInterface>>,

--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -14,9 +14,11 @@ use crate::errno::*;
 use crate::fd::file::{GenericFile, UhyveFile};
 use crate::fd::stdio::*;
 use crate::syscalls::fs::{self, FilePerms};
+#[cfg(all(feature = "tcp", not(feature = "newlib")))]
 use crate::syscalls::net::*;
 
 mod file;
+#[cfg(all(feature = "tcp", not(feature = "newlib")))]
 pub mod socket;
 mod stdio;
 
@@ -212,25 +214,31 @@ pub trait ObjectInterface: Sync + Send + core::fmt::Debug {
 	}
 
 	/// `accept` a connection on a socket
+	#[cfg(all(feature = "tcp", not(feature = "newlib")))]
 	fn accept(&self, _addr: *mut sockaddr, _addrlen: *mut socklen_t) -> i32 {
 		-EINVAL
 	}
 
+	/// initiate a connection on a socket
+	#[cfg(all(feature = "tcp", not(feature = "newlib")))]
 	fn connect(&self, _name: *const sockaddr, _namelen: socklen_t) -> i32 {
 		-EINVAL
 	}
 
 	/// `bind` a name to a socket
+	#[cfg(all(feature = "tcp", not(feature = "newlib")))]
 	fn bind(&self, _name: *const sockaddr, _namelen: socklen_t) -> i32 {
 		-EINVAL
 	}
 
 	/// `listen` for connections on a socket
+	#[cfg(all(feature = "tcp", not(feature = "newlib")))]
 	fn listen(&self, _backlog: i32) -> i32 {
 		-EINVAL
 	}
 
 	/// `setsockopt` sets options on sockets
+	#[cfg(all(feature = "tcp", not(feature = "newlib")))]
 	fn setsockopt(
 		&self,
 		_level: i32,
@@ -241,6 +249,8 @@ pub trait ObjectInterface: Sync + Send + core::fmt::Debug {
 		-EINVAL
 	}
 
+	/// `getsockopt` gets options on sockets
+	#[cfg(all(feature = "tcp", not(feature = "newlib")))]
 	fn getsockopt(
 		&self,
 		_level: i32,
@@ -252,16 +262,19 @@ pub trait ObjectInterface: Sync + Send + core::fmt::Debug {
 	}
 
 	/// `getsockname` gets socket name
+	#[cfg(all(feature = "tcp", not(feature = "newlib")))]
 	fn getsockname(&self, _name: *mut sockaddr, _namelen: *mut socklen_t) -> i32 {
 		-EINVAL
 	}
 
 	/// `getpeername` get address of connected peer
+	#[cfg(all(feature = "tcp", not(feature = "newlib")))]
 	fn getpeername(&self, _name: *mut sockaddr, _namelen: *mut socklen_t) -> i32 {
 		-EINVAL
 	}
 
 	/// shut down part of a full-duplex connection
+	#[cfg(all(feature = "tcp", not(feature = "newlib")))]
 	fn shutdown(&self, _how: i32) -> i32 {
 		-EINVAL
 	}

--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -1,9 +1,9 @@
-use alloc::boxed::Box;
 use alloc::sync::Arc;
 use core::ffi::{c_void, CStr};
 use core::sync::atomic::{AtomicI32, Ordering};
 
 use ahash::RandomState;
+use dyn_clone::DynClone;
 use hashbrown::HashMap;
 use hermit_sync::InterruptTicketMutex;
 #[cfg(target_arch = "x86_64")]
@@ -194,9 +194,7 @@ fn open_flags_to_perm(flags: i32, mode: u32) -> FilePerms {
 	perms
 }
 
-pub trait ObjectInterface: Sync + Send + core::fmt::Debug {
-	fn clone_box(&self) -> Box<dyn ObjectInterface>;
-
+pub trait ObjectInterface: Sync + Send + core::fmt::Debug + DynClone {
 	/// `read` attempts to read `len` bytes from the object references
 	/// by the descriptor
 	fn read(&self, _buf: *mut u8, _len: usize) -> isize {

--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -357,9 +357,9 @@ pub(crate) fn dup_object(fd: FileDescriptor) -> Result<FileDescriptor, i32> {
 	let obj = (*(guard.get(&fd).ok_or(-EINVAL)?)).clone();
 
 	let new_fd = || -> i32 {
-		for (i, key) in guard.keys().enumerate() {
-			if i < (*key).try_into().unwrap() {
-				return i.try_into().unwrap();
+		for i in 3..FD_COUNTER.load(Ordering::SeqCst) {
+			if !guard.contains_key(&i) {
+				return i;
 			}
 		}
 		FD_COUNTER.fetch_add(1, Ordering::SeqCst)

--- a/src/fd/socket/mod.rs
+++ b/src/fd/socket/mod.rs
@@ -181,3 +181,8 @@ pub extern "C" fn __sys_shutdown_socket(fd: i32, how: i32) -> i32 {
 	let obj = get_object(fd);
 	obj.map_or_else(|e| e, |v| (*v).shutdown(how))
 }
+
+pub extern "C" fn __sys_recv(fd: i32, buf: *mut u8, len: usize) -> isize {
+	let obj = get_object(fd);
+	obj.map_or_else(|e| e as isize, |v| (*v).read(buf, len))
+}

--- a/src/fd/socket/mod.rs
+++ b/src/fd/socket/mod.rs
@@ -1,0 +1,184 @@
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use core::ffi::c_void;
+use core::ops::DerefMut;
+use core::sync::atomic::Ordering;
+
+use crate::errno::*;
+use crate::fd::{get_object, insert_object, FD_COUNTER, OBJECT_MAP};
+use crate::net::{NetworkState, NIC};
+use crate::syscalls::net::*;
+
+mod tcp;
+mod udp;
+
+pub(crate) extern "C" fn __sys_socket(domain: i32, type_: i32, protocol: i32) -> i32 {
+	debug!(
+		"sys_socket: domain {}, type {}, protocol {}",
+		domain, type_, protocol
+	);
+
+	if domain != AF_INET && domain != AF_INET6 {
+		-EINVAL
+	} else if type_ != SOCK_STREAM {
+		-EINVAL
+	} else if protocol != 0 && protocol != IPPROTO_UDP && protocol != IPPROTO_TCP {
+		-EINVAL
+	} else {
+		let mut guard = NIC.lock();
+
+		if let NetworkState::Initialized(nic) = guard.deref_mut() {
+			let fd = FD_COUNTER.fetch_add(1, Ordering::SeqCst);
+
+			if protocol == IPPROTO_UDP {
+				let handle = nic.create_udp_handle().unwrap();
+				let socket = self::udp::Socket::new(handle);
+				if OBJECT_MAP
+					.lock()
+					.try_insert(fd, Arc::new(Box::new(socket)))
+					.is_err()
+				{
+					-EINVAL
+				} else {
+					fd
+				}
+			} else {
+				let handle = nic.create_tcp_handle().unwrap();
+				if domain == AF_INET {
+					let socket = self::tcp::Socket::<self::tcp::IPv4>::new(handle);
+					if OBJECT_MAP
+						.lock()
+						.try_insert(fd, Arc::new(Box::new(socket)))
+						.is_err()
+					{
+						-EINVAL
+					} else {
+						fd
+					}
+				} else {
+					let socket = self::tcp::Socket::<self::tcp::IPv6>::new(handle);
+					if OBJECT_MAP
+						.lock()
+						.try_insert(fd, Arc::new(Box::new(socket)))
+						.is_err()
+					{
+						-EINVAL
+					} else {
+						fd
+					}
+				}
+			}
+		} else {
+			-EINVAL
+		}
+	}
+}
+
+pub(crate) extern "C" fn __sys_accept(
+	fd: i32,
+	addr: *mut sockaddr,
+	addrlen: *mut socklen_t,
+) -> i32 {
+	let obj = get_object(fd);
+	obj.map_or_else(
+		|e| e,
+		|v| {
+			let result = (*v).accept(addr, addrlen);
+			if result >= 0 {
+				let new_obj = (*v).clone_box();
+				insert_object(fd, Arc::new(new_obj));
+				let new_fd = FD_COUNTER.fetch_add(1, Ordering::SeqCst);
+				(*v).listen(1);
+				insert_object(new_fd, v.clone());
+				new_fd
+			} else {
+				result
+			}
+		},
+	)
+}
+
+pub(crate) extern "C" fn __sys_listen(fd: i32, backlog: i32) -> i32 {
+	if backlog > 1 {
+		-EINVAL
+	} else {
+		let obj = get_object(fd);
+		obj.map_or_else(|e| e, |v| (*v).listen(backlog))
+	}
+}
+
+pub(crate) extern "C" fn __sys_bind(fd: i32, name: *const sockaddr, namelen: socklen_t) -> i32 {
+	let obj = get_object(fd);
+	obj.map_or_else(|e| e, |v| (*v).bind(name, namelen))
+}
+
+pub(crate) extern "C" fn __sys_connect(fd: i32, name: *const sockaddr, namelen: socklen_t) -> i32 {
+	let obj = get_object(fd);
+	obj.map_or_else(|e| e, |v| (*v).connect(name, namelen))
+}
+
+pub(crate) extern "C" fn __sys_getsockname(
+	fd: i32,
+	name: *mut sockaddr,
+	namelen: *mut socklen_t,
+) -> i32 {
+	let obj = get_object(fd);
+	obj.map_or_else(|e| e, |v| (*v).getsockname(name, namelen))
+}
+
+pub(crate) extern "C" fn __sys_setsockopt(
+	fd: i32,
+	level: i32,
+	optname: i32,
+	optval: *const c_void,
+	optlen: socklen_t,
+) -> i32 {
+	debug!(
+		"sys_setsockopt: {}, level {}, optname {}",
+		fd, level, optname
+	);
+
+	let obj = get_object(fd);
+	obj.map_or_else(|e| e, |v| (*v).setsockopt(level, optname, optval, optlen))
+}
+
+pub(crate) extern "C" fn __sys_getsockopt(
+	fd: i32,
+	level: i32,
+	optname: i32,
+	optval: *mut c_void,
+	optlen: *mut socklen_t,
+) -> i32 {
+	debug!(
+		"sys_getsockopt: {}, level {}, optname {}",
+		fd, level, optname
+	);
+
+	let obj = get_object(fd);
+	obj.map_or_else(|e| e, |v| (*v).getsockopt(level, optname, optval, optlen))
+}
+
+pub(crate) extern "C" fn __sys_getpeername(
+	fd: i32,
+	name: *mut sockaddr,
+	namelen: *mut socklen_t,
+) -> i32 {
+	let obj = get_object(fd);
+	obj.map_or_else(|e| e, |v| (*v).getpeername(name, namelen))
+}
+
+pub extern "C" fn __sys_freeaddrinfo(_ai: *mut addrinfo) {}
+
+pub extern "C" fn __sys_getaddrinfo(
+	_nodename: *const u8,
+	_servname: *const u8,
+	_hints: *const addrinfo,
+	_res: *mut *mut addrinfo,
+) -> i32 {
+	-EINVAL
+}
+
+pub extern "C" fn __sys_shutdown_socket(fd: i32, how: i32) -> i32 {
+	let obj = get_object(fd);
+	obj.map_or_else(|e| e, |v| (*v).shutdown(how))
+}

--- a/src/fd/socket/mod.rs
+++ b/src/fd/socket/mod.rs
@@ -71,7 +71,7 @@ pub(crate) extern "C" fn __sys_accept(
 		|v| {
 			let result = (*v).accept(addr, addrlen);
 			if result >= 0 {
-				let new_obj = (*v).clone_box();
+				let new_obj = dyn_clone::clone_box(&*v);
 				insert_object(fd, Arc::from(new_obj));
 				let new_fd = FD_COUNTER.fetch_add(1, Ordering::SeqCst);
 				(*v).listen(1);

--- a/src/fd/socket/mod.rs
+++ b/src/fd/socket/mod.rs
@@ -18,11 +18,10 @@ pub(crate) extern "C" fn __sys_socket(domain: i32, type_: i32, protocol: i32) ->
 		domain, type_, protocol
 	);
 
-	if domain != AF_INET && domain != AF_INET6 {
-		-EINVAL
-	} else if type_ != SOCK_STREAM {
-		-EINVAL
-	} else if protocol != 0 && protocol != IPPROTO_UDP && protocol != IPPROTO_TCP {
+	if (domain != AF_INET && domain != AF_INET6)
+		|| type_ != SOCK_STREAM
+		|| (protocol != 0 && protocol != IPPROTO_UDP && protocol != IPPROTO_TCP)
+	{
 		-EINVAL
 	} else {
 		let mut guard = NIC.lock();

--- a/src/fd/socket/mod.rs
+++ b/src/fd/socket/mod.rs
@@ -1,4 +1,3 @@
-use alloc::boxed::Box;
 use alloc::sync::Arc;
 use core::ffi::c_void;
 use core::ops::DerefMut;
@@ -32,11 +31,7 @@ pub(crate) extern "C" fn __sys_socket(domain: i32, type_: i32, protocol: i32) ->
 			if protocol == IPPROTO_UDP {
 				let handle = nic.create_udp_handle().unwrap();
 				let socket = self::udp::Socket::new(handle);
-				if OBJECT_MAP
-					.lock()
-					.try_insert(fd, Arc::new(Box::new(socket)))
-					.is_err()
-				{
+				if OBJECT_MAP.lock().try_insert(fd, Arc::new(socket)).is_err() {
 					-EINVAL
 				} else {
 					fd
@@ -45,22 +40,14 @@ pub(crate) extern "C" fn __sys_socket(domain: i32, type_: i32, protocol: i32) ->
 				let handle = nic.create_tcp_handle().unwrap();
 				if domain == AF_INET {
 					let socket = self::tcp::Socket::<self::tcp::IPv4>::new(handle);
-					if OBJECT_MAP
-						.lock()
-						.try_insert(fd, Arc::new(Box::new(socket)))
-						.is_err()
-					{
+					if OBJECT_MAP.lock().try_insert(fd, Arc::new(socket)).is_err() {
 						-EINVAL
 					} else {
 						fd
 					}
 				} else {
 					let socket = self::tcp::Socket::<self::tcp::IPv6>::new(handle);
-					if OBJECT_MAP
-						.lock()
-						.try_insert(fd, Arc::new(Box::new(socket)))
-						.is_err()
-					{
+					if OBJECT_MAP.lock().try_insert(fd, Arc::new(socket)).is_err() {
 						-EINVAL
 					} else {
 						fd
@@ -85,7 +72,7 @@ pub(crate) extern "C" fn __sys_accept(
 			let result = (*v).accept(addr, addrlen);
 			if result >= 0 {
 				let new_obj = (*v).clone_box();
-				insert_object(fd, Arc::new(new_obj));
+				insert_object(fd, Arc::from(new_obj));
 				let new_fd = FD_COUNTER.fetch_add(1, Ordering::SeqCst);
 				(*v).listen(1);
 				insert_object(new_fd, v.clone());

--- a/src/fd/socket/mod.rs
+++ b/src/fd/socket/mod.rs
@@ -31,7 +31,7 @@ pub(crate) extern "C" fn __sys_socket(domain: i32, type_: i32, protocol: i32) ->
 			if protocol == IPPROTO_UDP {
 				let handle = nic.create_udp_handle().unwrap();
 				let socket = self::udp::Socket::new(handle);
-				if OBJECT_MAP.lock().try_insert(fd, Arc::new(socket)).is_err() {
+				if OBJECT_MAP.write().try_insert(fd, Arc::new(socket)).is_err() {
 					-EINVAL
 				} else {
 					fd
@@ -40,14 +40,14 @@ pub(crate) extern "C" fn __sys_socket(domain: i32, type_: i32, protocol: i32) ->
 				let handle = nic.create_tcp_handle().unwrap();
 				if domain == AF_INET {
 					let socket = self::tcp::Socket::<self::tcp::IPv4>::new(handle);
-					if OBJECT_MAP.lock().try_insert(fd, Arc::new(socket)).is_err() {
+					if OBJECT_MAP.write().try_insert(fd, Arc::new(socket)).is_err() {
 						-EINVAL
 					} else {
 						fd
 					}
 				} else {
 					let socket = self::tcp::Socket::<self::tcp::IPv6>::new(handle);
-					if OBJECT_MAP.lock().try_insert(fd, Arc::new(socket)).is_err() {
+					if OBJECT_MAP.write().try_insert(fd, Arc::new(socket)).is_err() {
 						-EINVAL
 					} else {
 						fd

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -294,7 +294,7 @@ impl<T: core::marker::Sync + core::marker::Send + core::fmt::Debug + 'static> Ob
 			&& optlen == size_of::<i32>().try_into().unwrap()
 		{
 			let value = unsafe { *(optval as *const i32) };
-			self.with(|socket| socket.set_nagle_enabled(!(value != 0)));
+			self.with(|socket| socket.set_nagle_enabled(value != 0));
 			0
 		} else if level == SOL_SOCKET && optname == SO_REUSEADDR {
 			// smoltcp is always able to reuse the addr
@@ -407,11 +407,8 @@ impl ObjectInterface for Socket<IPv4> {
 				let remote = socket.remote_endpoint();
 				addr.sin_port = remote.port.to_be();
 
-				match remote.addr {
-					IpAddress::Ipv4(ip) => {
-						addr.sin_addr.s_addr.copy_from_slice(ip.as_bytes());
-					}
-					_ => {}
+				if let IpAddress::Ipv4(ip) = remote.addr {
+					addr.sin_addr.s_addr.copy_from_slice(ip.as_bytes());
 				}
 			});
 
@@ -438,11 +435,8 @@ impl ObjectInterface for Socket<IPv4> {
 				addr.sin_port = local.port.to_be();
 				addr.sin_family = AF_INET.try_into().unwrap();
 
-				match local.addr {
-					IpAddress::Ipv4(ip) => {
-						addr.sin_addr.s_addr.copy_from_slice(ip.as_bytes());
-					}
-					_ => {}
+				if let IpAddress::Ipv4(ip) = local.addr {
+					addr.sin_addr.s_addr.copy_from_slice(ip.as_bytes());
 				}
 			});
 
@@ -479,11 +473,8 @@ impl ObjectInterface for Socket<IPv6> {
 				let remote = socket.remote_endpoint();
 				addr.sin6_port = remote.port.to_be();
 
-				match remote.addr {
-					IpAddress::Ipv6(ip) => {
-						addr.sin6_addr.s6_addr.copy_from_slice(ip.as_bytes());
-					}
-					_ => {}
+				if let IpAddress::Ipv6(ip) = remote.addr {
+					addr.sin6_addr.s6_addr.copy_from_slice(ip.as_bytes());
 				}
 			});
 
@@ -510,11 +501,8 @@ impl ObjectInterface for Socket<IPv6> {
 				addr.sin6_port = local.port.to_be();
 				addr.sin6_family = AF_INET6.try_into().unwrap();
 
-				match local.addr {
-					IpAddress::Ipv6(ip) => {
-						addr.sin6_addr.s6_addr.copy_from_slice(ip.as_bytes());
-					}
-					_ => {}
+				if let IpAddress::Ipv6(ip) = local.addr {
+					addr.sin6_addr.s6_addr.copy_from_slice(ip.as_bytes());
 				}
 			});
 

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -1,4 +1,3 @@
-use alloc::boxed::Box;
 use core::ffi::c_void;
 use core::marker::PhantomData;
 use core::mem::size_of;
@@ -408,10 +407,6 @@ impl<T: core::marker::Sync + core::marker::Send + core::fmt::Debug + 'static> Ob
 		} else {
 			-EINVAL
 		}
-	}
-
-	fn clone_box(&self) -> Box<dyn ObjectInterface> {
-		Box::new(self.clone())
 	}
 }
 

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -411,6 +411,12 @@ impl<T: core::marker::Sync + core::marker::Send + core::fmt::Debug + 'static> Ob
 	}
 
 	fn clone_box(&self) -> Box<dyn ObjectInterface> {
+		Box::new(self.clone())
+	}
+}
+
+impl<T> Clone for Socket<T> {
+	fn clone(&self) -> Self {
 		let mut guard = NIC.lock();
 
 		let handle = if let NetworkState::Initialized(nic) = guard.deref_mut() {
@@ -419,12 +425,12 @@ impl<T: core::marker::Sync + core::marker::Send + core::fmt::Debug + 'static> Ob
 			panic!("Unable to create handle");
 		};
 
-		Box::new(Self {
+		Self {
 			handle,
 			port: AtomicU16::new(self.port.load(Ordering::Acquire)),
 			nonblocking: AtomicBool::new(self.nonblocking.load(Ordering::Acquire)),
 			phantom: PhantomData,
-		})
+		}
 	}
 }
 

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -1,0 +1,528 @@
+use alloc::boxed::Box;
+use core::ffi::c_void;
+use core::marker::PhantomData;
+use core::mem::size_of;
+use core::ops::DerefMut;
+use core::sync::atomic::{AtomicBool, AtomicU16, Ordering};
+use core::task::Poll;
+
+use futures_lite::future;
+use smoltcp::socket::{TcpSocket, TcpState};
+use smoltcp::time::Duration;
+use smoltcp::wire::IpAddress;
+
+use crate::errno::*;
+use crate::fd::ObjectInterface;
+use crate::net::executor::block_on;
+use crate::net::{now, Handle, NetworkState, NIC};
+use crate::syscalls::net::*;
+use crate::DEFAULT_KEEP_ALIVE_INTERVAL;
+
+#[derive(Debug)]
+pub struct IPv4;
+
+#[derive(Debug)]
+pub struct IPv6;
+
+#[derive(Debug)]
+pub struct Socket<T> {
+	handle: Handle,
+	port: AtomicU16,
+	nonblocking: AtomicBool,
+	phantom: PhantomData<T>,
+}
+
+impl<T> Socket<T> {
+	pub fn new(handle: Handle) -> Self {
+		Self {
+			handle,
+			port: AtomicU16::new(0),
+			nonblocking: AtomicBool::new(false),
+			phantom: PhantomData,
+		}
+	}
+
+	fn with<R>(&self, f: impl FnOnce(&mut TcpSocket<'_>) -> R) -> R {
+		let mut guard = NIC.lock();
+		let nic = guard.as_nic_mut().unwrap();
+		let res = {
+			let s = nic.iface.get_socket::<TcpSocket<'_>>(self.handle);
+			f(s)
+		};
+		let t = now();
+		if nic.poll_delay(t).map(|d| d.total_millis()).unwrap_or(0) == 0 {
+			nic.poll_common(t);
+		}
+		res
+	}
+
+	async fn async_read(&self, buffer: &mut [u8]) -> Result<isize, i32> {
+		future::poll_fn(|cx| {
+			self.with(|socket| {
+				if socket.can_recv() {
+					let n = socket.recv_slice(buffer).map_err(|_| -crate::errno::EIO)?;
+					if n > 0 || buffer.is_empty() {
+						return Poll::Ready(Ok(n.try_into().unwrap()));
+					}
+				}
+
+				match socket.state() {
+					TcpState::FinWait1
+					| TcpState::FinWait2
+					| TcpState::Closed
+					| TcpState::Closing
+					| TcpState::CloseWait
+					| TcpState::TimeWait => Poll::Ready(Err(-crate::errno::EIO)),
+					_ => {
+						socket.register_recv_waker(cx.waker());
+						Poll::Pending
+					}
+				}
+			})
+		})
+		.await
+	}
+
+	async fn async_write(&self, buffer: &[u8]) -> Result<isize, i32> {
+		let len = buffer.len();
+		let mut pos: usize = 0;
+
+		while pos < len {
+			let n = future::poll_fn(|cx| {
+				self.with(|socket| match socket.state() {
+					TcpState::FinWait1
+					| TcpState::FinWait2
+					| TcpState::Closed
+					| TcpState::Closing
+					| TcpState::CloseWait
+					| TcpState::TimeWait => Poll::Ready(Err(-crate::errno::EIO)),
+					_ => {
+						if !socket.may_send() {
+							return Poll::Ready(Err(-crate::errno::EIO));
+						} else if socket.can_send() {
+							return Poll::Ready(
+								socket
+									.send_slice(&buffer[pos..])
+									.map_err(|_| -crate::errno::EIO),
+							);
+						}
+
+						if pos > 0 {
+							// we already send some data => return 0 as signal to stop the
+							// async write
+							return Poll::Ready(Ok(0));
+						}
+
+						socket.register_send_waker(cx.waker());
+						Poll::Pending
+					}
+				})
+			})
+			.await?;
+
+			if n == 0 {
+				return Ok(pos.try_into().unwrap());
+			}
+
+			pos += n;
+		}
+
+		Ok(pos.try_into().unwrap())
+	}
+
+	async fn async_close(&self) -> Result<(), i32> {
+		future::poll_fn(|cx| {
+			self.with(|socket| match socket.state() {
+				TcpState::FinWait1
+				| TcpState::FinWait2
+				| TcpState::Closed
+				| TcpState::Closing
+				| TcpState::TimeWait => Poll::Ready(Err(-crate::errno::EIO)),
+				_ => {
+					if socket.send_queue() > 0 {
+						socket.register_send_waker(cx.waker());
+						Poll::Pending
+					} else {
+						socket.close();
+						Poll::Ready(Ok(()))
+					}
+				}
+			})
+		})
+		.await?;
+
+		future::poll_fn(|cx| {
+			self.with(|socket| match socket.state() {
+				TcpState::FinWait1
+				| TcpState::FinWait2
+				| TcpState::Closed
+				| TcpState::Closing
+				| TcpState::TimeWait => Poll::Ready(Ok(())),
+				_ => {
+					socket.register_send_waker(cx.waker());
+					Poll::Pending
+				}
+			})
+		})
+		.await
+	}
+
+	async fn async_accept(
+		&self,
+		_addr: *mut sockaddr,
+		_addrlen: *mut socklen_t,
+	) -> Result<(), i32> {
+		future::poll_fn(|cx| {
+			self.with(|socket| match socket.state() {
+				TcpState::Closed => {
+					let _ = socket.listen(self.port.load(Ordering::Acquire));
+					Poll::Ready(())
+				}
+				TcpState::Listen => Poll::Ready(()),
+				_ => {
+					socket.register_recv_waker(cx.waker());
+					Poll::Pending
+				}
+			})
+		})
+		.await;
+
+		future::poll_fn(|cx| {
+			self.with(|socket| {
+				if socket.is_active() {
+					Poll::Ready(Ok(()))
+				} else {
+					match socket.state() {
+						TcpState::Closed
+						| TcpState::Closing
+						| TcpState::FinWait1
+						| TcpState::FinWait2 => Poll::Ready(Err(-crate::errno::EIO)),
+						_ => {
+							socket.register_recv_waker(cx.waker());
+							Poll::Pending
+						}
+					}
+				}
+			})
+		})
+		.await?;
+
+		let mut guard = NIC.lock();
+		let nic = guard.as_nic_mut().map_err(|_| -crate::errno::EIO)?;
+		let socket = nic.iface.get_socket::<TcpSocket<'_>>(self.handle);
+		socket.set_keep_alive(Some(Duration::from_millis(DEFAULT_KEEP_ALIVE_INTERVAL)));
+
+		Ok(())
+	}
+}
+
+impl<T: core::marker::Sync + core::marker::Send + core::fmt::Debug + 'static> ObjectInterface
+	for Socket<T>
+{
+	default fn bind(&self, _name: *const sockaddr, _namelen: socklen_t) -> i32 {
+		-EINVAL
+	}
+
+	default fn getsockname(&self, _name: *mut sockaddr, _namelen: *mut socklen_t) -> i32 {
+		-EINVAL
+	}
+
+	default fn getpeername(&self, _name: *mut sockaddr, _namelen: *mut socklen_t) -> i32 {
+		-EINVAL
+	}
+
+	fn accept(&self, addr: *mut sockaddr, addrlen: *mut socklen_t) -> i32 {
+		block_on(self.async_accept(addr, addrlen), None)
+			.map(|_| 0)
+			.unwrap_or_else(|x| x)
+	}
+
+	fn read(&self, buf: *mut u8, len: usize) -> isize {
+		let slice = unsafe { core::slice::from_raw_parts_mut(buf, len) };
+
+		if self.nonblocking.load(Ordering::Acquire) {
+			block_on(self.async_read(slice), Some(Duration::ZERO)).unwrap_or_else(|x| {
+				if x == -ETIME {
+					(-EAGAIN).try_into().unwrap()
+				} else {
+					x.try_into().unwrap()
+				}
+			})
+		} else {
+			block_on(self.async_read(slice), None).unwrap_or_else(|x| x.try_into().unwrap())
+		}
+	}
+
+	fn write(&self, buf: *const u8, len: usize) -> isize {
+		let slice = unsafe { core::slice::from_raw_parts(buf, len) };
+
+		if self.nonblocking.load(Ordering::Acquire) {
+			block_on(self.async_write(slice), Some(Duration::ZERO)).unwrap_or_else(|x| {
+				if x == -ETIME {
+					(-EAGAIN).try_into().unwrap()
+				} else {
+					x.try_into().unwrap()
+				}
+			})
+		} else {
+			block_on(self.async_write(slice), None).unwrap_or_else(|x| x.try_into().unwrap())
+		}
+	}
+
+	fn listen(&self, _backlog: i32) -> i32 {
+		self.with(|socket| {
+			if !socket.is_open() {
+				socket
+					.listen(self.port.load(Ordering::Acquire))
+					.map(|_| 0)
+					.unwrap_or_else(|_| -crate::errno::EIO)
+			} else {
+				-crate::errno::EIO
+			}
+		})
+	}
+
+	fn setsockopt(
+		&self,
+		level: i32,
+		optname: i32,
+		optval: *const c_void,
+		optlen: socklen_t,
+	) -> i32 {
+		if level == IPPROTO_TCP
+			&& optname == TCP_NODELAY
+			&& optlen == size_of::<i32>().try_into().unwrap()
+		{
+			let value = unsafe { *(optval as *const i32) };
+			self.with(|socket| socket.set_nagle_enabled(!(value != 0)));
+			0
+		} else if level == SOL_SOCKET && optname == SO_REUSEADDR {
+			// smoltcp is always able to reuse the addr
+			0
+		} else {
+			-EINVAL
+		}
+	}
+
+	fn getsockopt(
+		&self,
+		level: i32,
+		optname: i32,
+		optval: *mut c_void,
+		optlen: *mut socklen_t,
+	) -> i32 {
+		if level == IPPROTO_TCP && optname == TCP_NODELAY {
+			let optlen = unsafe { &mut *optlen };
+			if *optlen >= size_of::<i32>().try_into().unwrap() {
+				let optval = unsafe { &mut *(optval as *mut i32) };
+				self.with(|socket| {
+					if socket.nagle_enabled() {
+						*optval = 0;
+					} else {
+						*optval = 1;
+					}
+				});
+				*optlen = size_of::<i32>().try_into().unwrap();
+
+				0
+			} else {
+				-EINVAL
+			}
+		} else {
+			-EINVAL
+		}
+	}
+
+	fn shutdown(&self, how: i32) -> i32 {
+		match how {
+			SHUT_RD /* Read  */ |
+			SHUT_WR /* Write */ |
+			SHUT_RDWR /* Both */ => 0,
+			_ => -EINVAL,
+		}
+	}
+
+	fn ioctl(&self, cmd: i32, argp: *mut c_void) -> i32 {
+		if cmd == FIONBIO {
+			let value = unsafe { *(argp as *const i32) };
+			if value != 0 {
+				info!("set device to nonblocking mode");
+				self.nonblocking.store(true, Ordering::Release);
+			} else {
+				self.nonblocking.store(false, Ordering::Release);
+			}
+
+			0
+		} else {
+			-EINVAL
+		}
+	}
+
+	fn clone_box(&self) -> Box<dyn ObjectInterface> {
+		let mut guard = NIC.lock();
+
+		let handle = if let NetworkState::Initialized(nic) = guard.deref_mut() {
+			nic.create_tcp_handle().unwrap()
+		} else {
+			panic!("Unable to create handle");
+		};
+
+		Box::new(Self {
+			handle,
+			port: AtomicU16::new(self.port.load(Ordering::Acquire)),
+			nonblocking: AtomicBool::new(self.nonblocking.load(Ordering::Acquire)),
+			phantom: PhantomData,
+		})
+	}
+}
+
+impl<T> Drop for Socket<T> {
+	fn drop(&mut self) {
+		let _ = block_on(self.async_close(), None);
+	}
+}
+
+impl ObjectInterface for Socket<IPv4> {
+	fn bind(&self, name: *const sockaddr, namelen: socklen_t) -> i32 {
+		if namelen == size_of::<sockaddr_in>().try_into().unwrap() {
+			let addr = unsafe { *(name as *const sockaddr_in) };
+			let port = u16::from_be(addr.sin_port);
+			self.port.store(port, Ordering::Release);
+			0
+		} else {
+			-EINVAL
+		}
+	}
+
+	fn getpeername(&self, name: *mut sockaddr, namelen: *mut socklen_t) -> i32 {
+		if namelen.is_null() {
+			return -ENOBUFS;
+		}
+
+		let namelen = unsafe { &mut *namelen };
+		if *namelen >= size_of::<sockaddr_in>().try_into().unwrap() {
+			let addr = unsafe { &mut *(name as *mut sockaddr_in) };
+
+			self.with(|socket| {
+				let remote = socket.remote_endpoint();
+				addr.sin_port = remote.port.to_be();
+
+				match remote.addr {
+					IpAddress::Ipv4(ip) => {
+						addr.sin_addr.s_addr.copy_from_slice(ip.as_bytes());
+					}
+					_ => {}
+				}
+			});
+
+			*namelen = size_of::<sockaddr_in>().try_into().unwrap();
+
+			0
+		} else {
+			-EINVAL
+		}
+	}
+
+	fn getsockname(&self, name: *mut sockaddr, namelen: *mut socklen_t) -> i32 {
+		if namelen.is_null() {
+			return -ENOBUFS;
+		}
+
+		let namelen = unsafe { &mut *namelen };
+		if *namelen >= size_of::<sockaddr_in>().try_into().unwrap() {
+			let addr = unsafe { &mut *(name as *mut sockaddr_in) };
+
+			self.with(|socket| {
+				let local = socket.local_endpoint();
+
+				addr.sin_port = local.port.to_be();
+				addr.sin_family = AF_INET.try_into().unwrap();
+
+				match local.addr {
+					IpAddress::Ipv4(ip) => {
+						addr.sin_addr.s_addr.copy_from_slice(ip.as_bytes());
+					}
+					_ => {}
+				}
+			});
+
+			*namelen = size_of::<sockaddr_in6>().try_into().unwrap();
+
+			0
+		} else {
+			-EINVAL
+		}
+	}
+}
+
+impl ObjectInterface for Socket<IPv6> {
+	fn bind(&self, name: *const sockaddr, namelen: socklen_t) -> i32 {
+		if namelen == size_of::<sockaddr_in6>().try_into().unwrap() {
+			let addr = unsafe { *(name as *const sockaddr_in6) };
+			self.port.store(addr.sin6_port, Ordering::Release);
+			0
+		} else {
+			-EINVAL
+		}
+	}
+
+	fn getpeername(&self, name: *mut sockaddr, namelen: *mut socklen_t) -> i32 {
+		if namelen.is_null() {
+			return -ENOBUFS;
+		}
+
+		let namelen = unsafe { &mut *namelen };
+		if *namelen >= size_of::<sockaddr_in6>().try_into().unwrap() {
+			let addr = unsafe { &mut *(name as *mut sockaddr_in6) };
+
+			self.with(|socket| {
+				let remote = socket.remote_endpoint();
+				addr.sin6_port = remote.port.to_be();
+
+				match remote.addr {
+					IpAddress::Ipv6(ip) => {
+						addr.sin6_addr.s6_addr.copy_from_slice(ip.as_bytes());
+					}
+					_ => {}
+				}
+			});
+
+			*namelen = size_of::<sockaddr_in>().try_into().unwrap();
+
+			0
+		} else {
+			-EINVAL
+		}
+	}
+
+	fn getsockname(&self, name: *mut sockaddr, namelen: *mut socklen_t) -> i32 {
+		if namelen.is_null() {
+			return -ENOBUFS;
+		}
+
+		let namelen = unsafe { &mut *namelen };
+		if *namelen >= size_of::<sockaddr_in6>().try_into().unwrap() {
+			let addr = unsafe { &mut *(name as *mut sockaddr_in6) };
+
+			self.with(|socket| {
+				let local = socket.local_endpoint();
+
+				addr.sin6_port = local.port.to_be();
+				addr.sin6_family = AF_INET6.try_into().unwrap();
+
+				match local.addr {
+					IpAddress::Ipv6(ip) => {
+						addr.sin6_addr.s6_addr.copy_from_slice(ip.as_bytes());
+					}
+					_ => {}
+				}
+			});
+
+			*namelen = size_of::<sockaddr_in6>().try_into().unwrap();
+
+			0
+		} else {
+			-EINVAL
+		}
+	}
+}

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -3,7 +3,6 @@ use core::ffi::c_void;
 use core::marker::PhantomData;
 use core::mem::size_of;
 use core::ops::DerefMut;
-use core::str::FromStr;
 use core::sync::atomic::{AtomicBool, AtomicU16, Ordering};
 use core::task::Poll;
 

--- a/src/fd/socket/udp.rs
+++ b/src/fd/socket/udp.rs
@@ -1,5 +1,3 @@
-use alloc::boxed::Box;
-
 use crate::fd::ObjectInterface;
 use crate::net::Handle;
 
@@ -12,8 +10,4 @@ impl Socket {
 	}
 }
 
-impl ObjectInterface for Socket {
-	fn clone_box(&self) -> Box<dyn ObjectInterface> {
-		Box::new(self.clone())
-	}
-}
+impl ObjectInterface for Socket {}

--- a/src/fd/socket/udp.rs
+++ b/src/fd/socket/udp.rs
@@ -1,0 +1,19 @@
+use alloc::boxed::Box;
+
+use crate::fd::ObjectInterface;
+use crate::net::Handle;
+
+#[derive(Debug, Clone)]
+pub struct Socket(Handle);
+
+impl Socket {
+	pub fn new(handle: Handle) -> Self {
+		Self(handle)
+	}
+}
+
+impl ObjectInterface for Socket {
+	fn clone_box(&self) -> Box<dyn ObjectInterface> {
+		Box::new(self.clone())
+	}
+}

--- a/src/fd/stdio.rs
+++ b/src/fd/stdio.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use core::{isize, slice};
 
 use crate::console::CONSOLE;
@@ -5,12 +6,12 @@ use crate::fd::{
 	uhyve_send, ObjectInterface, SysWrite, STDERR_FILENO, STDOUT_FILENO, UHYVE_PORT_WRITE,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GenericStdin;
 
 impl ObjectInterface for GenericStdin {
-	fn close(&self) -> i32 {
-		0
+	fn clone_box(&self) -> Box<dyn ObjectInterface> {
+		Box::new(self.clone())
 	}
 }
 
@@ -20,12 +21,12 @@ impl GenericStdin {
 	}
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GenericStdout;
 
 impl ObjectInterface for GenericStdout {
-	fn close(&self) -> i32 {
-		0
+	fn clone_box(&self) -> Box<dyn ObjectInterface> {
+		Box::new(self.clone())
 	}
 
 	fn write(&self, buf: *const u8, len: usize) -> isize {
@@ -45,12 +46,12 @@ impl GenericStdout {
 	}
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GenericStderr;
 
 impl ObjectInterface for GenericStderr {
-	fn close(&self) -> i32 {
-		0
+	fn clone_box(&self) -> Box<dyn ObjectInterface> {
+		Box::new(self.clone())
 	}
 
 	fn write(&self, buf: *const u8, len: usize) -> isize {
@@ -70,12 +71,12 @@ impl GenericStderr {
 	}
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UhyveStdin;
 
 impl ObjectInterface for UhyveStdin {
-	fn close(&self) -> i32 {
-		0
+	fn clone_box(&self) -> Box<dyn ObjectInterface> {
+		Box::new(self.clone())
 	}
 }
 
@@ -85,12 +86,12 @@ impl UhyveStdin {
 	}
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UhyveStdout;
 
 impl ObjectInterface for UhyveStdout {
-	fn close(&self) -> i32 {
-		0
+	fn clone_box(&self) -> Box<dyn ObjectInterface> {
+		Box::new(self.clone())
 	}
 
 	fn write(&self, buf: *const u8, len: usize) -> isize {
@@ -107,12 +108,12 @@ impl UhyveStdout {
 	}
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UhyveStderr;
 
 impl ObjectInterface for UhyveStderr {
-	fn close(&self) -> i32 {
-		0
+	fn clone_box(&self) -> Box<dyn ObjectInterface> {
+		Box::new(self.clone())
 	}
 
 	fn write(&self, buf: *const u8, len: usize) -> isize {

--- a/src/fd/stdio.rs
+++ b/src/fd/stdio.rs
@@ -1,4 +1,3 @@
-use alloc::boxed::Box;
 use core::{isize, slice};
 
 use crate::console::CONSOLE;
@@ -9,11 +8,7 @@ use crate::fd::{
 #[derive(Debug, Clone)]
 pub struct GenericStdin;
 
-impl ObjectInterface for GenericStdin {
-	fn clone_box(&self) -> Box<dyn ObjectInterface> {
-		Box::new(self.clone())
-	}
-}
+impl ObjectInterface for GenericStdin {}
 
 impl GenericStdin {
 	pub const fn new() -> Self {
@@ -25,10 +20,6 @@ impl GenericStdin {
 pub struct GenericStdout;
 
 impl ObjectInterface for GenericStdout {
-	fn clone_box(&self) -> Box<dyn ObjectInterface> {
-		Box::new(self.clone())
-	}
-
 	fn write(&self, buf: *const u8, len: usize) -> isize {
 		assert!(len <= isize::MAX as usize);
 		let buf = unsafe { slice::from_raw_parts(buf, len) };
@@ -50,10 +41,6 @@ impl GenericStdout {
 pub struct GenericStderr;
 
 impl ObjectInterface for GenericStderr {
-	fn clone_box(&self) -> Box<dyn ObjectInterface> {
-		Box::new(self.clone())
-	}
-
 	fn write(&self, buf: *const u8, len: usize) -> isize {
 		assert!(len <= isize::MAX as usize);
 		let buf = unsafe { slice::from_raw_parts(buf, len) };
@@ -74,11 +61,7 @@ impl GenericStderr {
 #[derive(Debug, Clone)]
 pub struct UhyveStdin;
 
-impl ObjectInterface for UhyveStdin {
-	fn clone_box(&self) -> Box<dyn ObjectInterface> {
-		Box::new(self.clone())
-	}
-}
+impl ObjectInterface for UhyveStdin {}
 
 impl UhyveStdin {
 	pub const fn new() -> Self {
@@ -90,10 +73,6 @@ impl UhyveStdin {
 pub struct UhyveStdout;
 
 impl ObjectInterface for UhyveStdout {
-	fn clone_box(&self) -> Box<dyn ObjectInterface> {
-		Box::new(self.clone())
-	}
-
 	fn write(&self, buf: *const u8, len: usize) -> isize {
 		let mut syswrite = SysWrite::new(STDOUT_FILENO, buf, len);
 		uhyve_send(UHYVE_PORT_WRITE, &mut syswrite);
@@ -112,10 +91,6 @@ impl UhyveStdout {
 pub struct UhyveStderr;
 
 impl ObjectInterface for UhyveStderr {
-	fn clone_box(&self) -> Box<dyn ObjectInterface> {
-		Box::new(self.clone())
-	}
-
 	fn write(&self, buf: *const u8, len: usize) -> isize {
 		let mut syswrite = SysWrite::new(STDERR_FILENO, buf, len);
 		uhyve_send(UHYVE_PORT_WRITE, &mut syswrite);

--- a/src/net/device.rs
+++ b/src/net/device.rs
@@ -113,7 +113,7 @@ impl NetworkInterface<HermitNet> {
 
 	#[cfg(not(feature = "dhcpv4"))]
 	pub(crate) fn create() -> NetworkState {
-		let mtu = match unsafe { SYS.get_mtu() } {
+		let mtu = match SYS.get_mtu() {
 			Ok(mtu) => mtu,
 			Err(_) => {
 				return NetworkState::InitializationFailed;
@@ -125,7 +125,7 @@ impl NetworkInterface<HermitNet> {
 			trace!("{}", printer);
 		});
 
-		let mac: [u8; 6] = match unsafe { SYS.get_mac_address() } {
+		let mac: [u8; 6] = match SYS.get_mac_address() {
 			Ok(mac) => mac,
 			Err(_) => {
 				return NetworkState::InitializationFailed;

--- a/src/net/executor.rs
+++ b/src/net/executor.rs
@@ -150,9 +150,7 @@ where
 				let core_scheduler = core_scheduler();
 				let task = core_scheduler.get_current_task_handle();
 				let wakeup_time = delay.map(|us| crate::arch::processor::get_timer_ticks() + us);
-				BLOCKED_ASYNC_TASKS
-					.lock()
-					.insert(task.get_id(), task.clone());
+				BLOCKED_ASYNC_TASKS.lock().insert(task.get_id(), task);
 				core_scheduler.block_current_task(wakeup_time);
 				// allow interrupts => NIC thread is able to run
 				set_polling_mode(false);

--- a/src/net/executor.rs
+++ b/src/net/executor.rs
@@ -142,7 +142,7 @@ where
 		counter += 1;
 		let now = crate::net::now();
 		let delay = network_delay(now).map(|d| d.total_micros());
-		if counter > 100 && delay.unwrap_or(10_000_000) > 100_000 {
+		if counter > 200 && delay.unwrap_or(10_000_000) > 100_000 {
 			let unparked = task_notify.unparked.swap(false, Ordering::AcqRel);
 			if !unparked {
 				let core_scheduler = core_scheduler();

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -85,19 +85,6 @@ async fn network_run() {
 	.await
 }
 
-#[inline]
-pub(crate) fn network_poll() {
-	if let Some(mut guard) = NIC.try_lock() {
-		if let NetworkState::Initialized(nic) = guard.deref_mut() {
-			let time = now();
-			if let Some(delay) = nic.poll_delay(time).map(|d| d.total_micros()) {
-				let wakeup_time = crate::arch::processor::get_timer_ticks() + delay;
-				crate::core_scheduler().add_network_timer(wakeup_time);
-			}
-		}
-	}
-}
-
 pub(crate) fn init() {
 	info!("Try to nitialize network!");
 
@@ -145,7 +132,7 @@ where
 		Ok(tcp_handle)
 	}
 
-	pub(crate) fn poll_common(&mut self, timestamp: Instant){
+	pub(crate) fn poll_common(&mut self, timestamp: Instant) {
 		let _ = self.iface.poll(timestamp);
 
 		#[cfg(feature = "dhcpv4")]

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -145,10 +145,9 @@ where
 		Ok(tcp_handle)
 	}
 
-	pub(crate) fn poll_common(&mut self, timestamp: Instant) {
-		while self.iface.poll(timestamp).unwrap_or(true) {
-			// just to make progress
-		}
+	pub(crate) fn poll_common(&mut self, timestamp: Instant){
+		let _ = self.iface.poll(timestamp);
+
 		#[cfg(feature = "dhcpv4")]
 		match self
 			.iface

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -98,10 +98,10 @@ pub(crate) fn init() {
 	if let NetworkState::Initialized(nic) = guard.deref_mut() {
 		let time = now();
 		nic.poll_common(time);
-		if let Some(delay) = nic.poll_delay(time).map(|d| d.total_micros()) {
-			let wakeup_time = crate::arch::processor::get_timer_ticks() + delay;
-			crate::core_scheduler().add_network_timer(wakeup_time);
-		}
+		let wakeup_time = nic
+			.poll_delay(time)
+			.map(|d| crate::arch::processor::get_timer_ticks() + d.total_micros());
+		crate::core_scheduler().add_network_timer(wakeup_time);
 
 		spawn(network_run()).detach();
 	}

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -72,6 +72,7 @@ pub struct PerCoreScheduler {
 	/// Queue of blocked tasks, sorted by wakeup time.
 	blocked_tasks: BlockedTaskQueue,
 	/// Queue of blocked tasks, sorted by wakeup time.
+	#[cfg(feature = "tcp")]
 	blocked_async_tasks: VecDeque<TaskHandle>,
 	/// Queues to handle incoming requests from the other cores
 	#[cfg(feature = "smp")]
@@ -282,6 +283,7 @@ impl PerCoreScheduler {
 	#[inline]
 	pub fn handle_waiting_tasks(&mut self) {
 		without_interrupts(|| {
+			#[cfg(feature = "tcp")]
 			self.wakeup_async_tasks();
 			self.blocked_tasks.handle_waiting_tasks()
 		});
@@ -320,6 +322,7 @@ impl PerCoreScheduler {
 		without_interrupts(|| self.blocked_tasks.add_network_timer(wakeup_time))
 	}
 
+	#[cfg(feature = "tcp")]
 	#[inline]
 	pub fn block_current_async_task(&mut self) {
 		without_interrupts(|| {
@@ -328,6 +331,7 @@ impl PerCoreScheduler {
 		});
 	}
 
+	#[cfg(feature = "tcp")]
 	#[inline]
 	pub fn wakeup_async_tasks(&mut self) {
 		without_interrupts(|| {
@@ -664,6 +668,7 @@ pub fn add_current_core() {
 		ready_queue: PriorityTaskQueue::new(),
 		finished_tasks: VecDeque::new(),
 		blocked_tasks: BlockedTaskQueue::new(),
+		#[cfg(feature = "tcp")]
 		blocked_async_tasks: VecDeque::new(),
 		#[cfg(feature = "smp")]
 		input: InterruptTicketMutex::new(SchedulerInput::new()),

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -320,7 +320,7 @@ impl PerCoreScheduler {
 
 	#[cfg(feature = "tcp")]
 	#[inline]
-	pub fn add_network_timer(&mut self, wakeup_time: u64) {
+	pub fn add_network_timer(&mut self, wakeup_time: Option<u64>) {
 		without_interrupts(|| self.blocked_tasks.add_network_timer(wakeup_time))
 	}
 
@@ -345,15 +345,15 @@ impl PerCoreScheduler {
 				self.custom_wakeup(task)
 			}
 
-			if !has_tasks {
-				if let Some(mut guard) = crate::net::NIC.try_lock() {
-					if let crate::net::NetworkState::Initialized(nic) = guard.deref_mut() {
-						let time = crate::net::now();
-						nic.poll_common(time);
-						if let Some(delay) = nic.poll_delay(time).map(|d| d.total_micros()) {
-							let wakeup_time = crate::arch::processor::get_timer_ticks() + delay;
-							self.add_network_timer(wakeup_time);
-						}
+			if let Some(mut guard) = crate::net::NIC.try_lock() {
+				if let crate::net::NetworkState::Initialized(nic) = guard.deref_mut() {
+					let time = crate::net::now();
+					nic.poll_common(time);
+					if !has_tasks {
+						let wakeup_time = nic
+							.poll_delay(time)
+							.map(|d| crate::arch::processor::get_timer_ticks() + d.total_micros());
+						self.add_network_timer(wakeup_time);
 					}
 				}
 			}

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -345,11 +345,11 @@ impl PerCoreScheduler {
 				self.custom_wakeup(task)
 			}
 
-			if let Some(mut guard) = crate::net::NIC.try_lock() {
-				if let crate::net::NetworkState::Initialized(nic) = guard.deref_mut() {
-					let time = crate::net::now();
-					nic.poll_common(time);
-					if !has_tasks {
+			if !has_tasks {
+				if let Some(mut guard) = crate::net::NIC.try_lock() {
+					if let crate::net::NetworkState::Initialized(nic) = guard.deref_mut() {
+						let time = crate::net::now();
+						nic.poll_common(time);
 						let wakeup_time = nic
 							.poll_delay(time)
 							.map(|d| crate::arch::processor::get_timer_ticks() + d.total_micros());

--- a/src/scheduler/task.rs
+++ b/src/scheduler/task.rs
@@ -711,6 +711,13 @@ impl BlockedTaskQueue {
 		let mut cursor = self.list.cursor_front_mut();
 
 		#[cfg(feature = "tcp")]
+		if let Some(wakeup_time) = self.network_wakeup_time {
+			if wakeup_time <= arch::processor::get_timer_ticks() {
+				self.network_wakeup_time = None;
+			}
+		}
+
+		#[cfg(feature = "tcp")]
 		if let Some(mut guard) = crate::net::NIC.try_lock() {
 			if let crate::net::NetworkState::Initialized(nic) = guard.deref_mut() {
 				let time = crate::net::now();

--- a/src/scheduler/task.rs
+++ b/src/scheduler/task.rs
@@ -749,7 +749,7 @@ impl BlockedTaskQueue {
 			cursor.remove_current();
 		}
 
-		#[cfg(not(feature = "tcp"))]
+		#[cfg(feature = "tcp")]
 		arch::set_oneshot_timer(cursor.current().map_or_else(
 			|| self.network_wakeup_time,
 			|node| match node.wakeup_time {

--- a/src/synch/mod.rs
+++ b/src/synch/mod.rs
@@ -2,4 +2,5 @@
 
 pub mod futex;
 pub mod recmutex;
+pub mod rwlock;
 pub mod semaphore;

--- a/src/synch/rwlock.rs
+++ b/src/synch/rwlock.rs
@@ -32,7 +32,7 @@ const PHID: usize = 0x1; // phase ID bit
 const ZERO_MASK: usize = !255usize;
 
 unsafe impl RawRwLock for RWSpinLock {
-    #[allow(clippy::declare_interior_mutable_const)]
+	#[allow(clippy::declare_interior_mutable_const)]
 	const INIT: RWSpinLock = RWSpinLock {
 		rin: AtomicUsize::new(0),
 		rout: AtomicUsize::new(0),

--- a/src/synch/rwlock.rs
+++ b/src/synch/rwlock.rs
@@ -1,0 +1,124 @@
+//! This library provides a phase-fair reader-writer lock, as described in the
+//! paper ["Reader-Writer Synchronization for Shared-Memory Multiprocessor
+//! Real-Time Systems"](https://www.cs.unc.edu/~anderson/papers/ecrts09b.pdf)
+//! by Brandenburg et. al.
+//!
+//! > Reader preference, writer preference, and task-fair reader-writer locks are
+//! > shown to cause undue blocking in multiprocessor real-time systems. A new
+//! > phase-fair reader-writer lock is proposed as an alternative that
+//! > significantly reduces worst-case blocking for readers.
+//!
+//! This implementation is derived from https://github.com/cmnord/pflock and
+//! modified for RustyHermit.
+
+#![allow(dead_code)]
+
+use core::hint::spin_loop;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use lock_api::{GuardSend, RawRwLock, RwLock};
+
+pub(crate) struct RWSpinLock {
+	rin: AtomicUsize,
+	rout: AtomicUsize,
+	win: AtomicUsize,
+	wout: AtomicUsize,
+}
+
+const RINC: usize = 0x100; // reader increment
+const WBITS: usize = 0x3; // writer bits in rin
+const PRES: usize = 0x2; // writer present bit
+const PHID: usize = 0x1; // phase ID bit
+const ZERO_MASK: usize = !255usize;
+
+unsafe impl RawRwLock for RWSpinLock {
+	const INIT: RWSpinLock = RWSpinLock {
+		rin: AtomicUsize::new(0),
+		rout: AtomicUsize::new(0),
+		win: AtomicUsize::new(0),
+		wout: AtomicUsize::new(0),
+	};
+
+	type GuardMarker = GuardSend;
+
+	#[inline]
+	fn lock_shared(&self) {
+		// Increment the rin count and read the writer bits
+		let w = self.rin.fetch_add(RINC, Ordering::Relaxed) & WBITS;
+
+		// Spin (wait) if there is a writer present (w != 0), until either PRES
+		// and/or PHID flips
+		while (w != 0) && (w == (self.rin.load(Ordering::Relaxed) & WBITS)) {
+			spin_loop();
+		}
+	}
+
+	#[inline]
+	unsafe fn unlock_shared(&self) {
+		// Increment rout to mark the read-lock returned
+		self.rout.fetch_add(RINC, Ordering::Relaxed);
+	}
+
+	#[inline]
+	fn try_lock_shared(&self) -> bool {
+		let w = self.rin.fetch_add(RINC, Ordering::Relaxed) & WBITS;
+
+		if w == 0 || w != (self.rin.load(Ordering::Relaxed) & WBITS) {
+			true
+		} else {
+			self.rout.fetch_add(RINC, Ordering::Relaxed);
+			false
+		}
+	}
+
+	#[inline]
+	fn lock_exclusive(&self) {
+		// Wait until it is my turn to write-lock the resource
+		let wticket = self.win.fetch_add(1, Ordering::Relaxed);
+		while wticket != self.wout.load(Ordering::Relaxed) {
+			spin_loop();
+		}
+
+		// Set the write-bits of rin to indicate this writer is here
+		let w = PRES | (wticket & PHID);
+		let rticket = self.rin.fetch_add(w, Ordering::Relaxed);
+
+		// Wait until all current readers have finished (i.e. rout catches up)
+		while rticket != self.rout.load(Ordering::Relaxed) {
+			spin_loop();
+		}
+	}
+
+	#[inline]
+	unsafe fn unlock_exclusive(&self) {
+		// Clear the least-significant byte of rin
+		self.rin.fetch_and(ZERO_MASK, Ordering::Relaxed);
+
+		// Increment wout to indicate this write has released the lock
+		// Only one writer should ever be here
+		self.wout.fetch_add(1, Ordering::Relaxed);
+	}
+
+	#[inline]
+	fn try_lock_exclusive(&self) -> bool {
+		let wticket = self.win.fetch_add(1, Ordering::Relaxed);
+		if wticket != self.wout.load(Ordering::Relaxed) {
+			self.wout.fetch_add(1, Ordering::Relaxed);
+			return false;
+		}
+		let w = PRES | (wticket & PHID);
+		let rticket = self.rin.fetch_add(w, Ordering::Relaxed);
+
+		if rticket != self.rout.load(Ordering::Relaxed) {
+			self.rin.fetch_and(ZERO_MASK, Ordering::Relaxed);
+			self.wout.fetch_add(1, Ordering::Relaxed);
+			return false;
+		}
+
+		true
+	}
+}
+
+/// A phase-fair reader-writer lock.
+pub(crate) type RWLock<T> = RwLock<RWSpinLock, T>;
+pub(crate) type RWLockGuard<'a, T> = lock_api::MutexGuard<'a, RWSpinLock, T>;

--- a/src/synch/rwlock.rs
+++ b/src/synch/rwlock.rs
@@ -8,7 +8,7 @@
 //! > phase-fair reader-writer lock is proposed as an alternative that
 //! > significantly reduces worst-case blocking for readers.
 //!
-//! This implementation is derived from https://github.com/cmnord/pflock and
+//! This implementation is derived from <https://github.com/cmnord/pflock> and
 //! modified for RustyHermit.
 
 #![allow(dead_code)]
@@ -32,6 +32,7 @@ const PHID: usize = 0x1; // phase ID bit
 const ZERO_MASK: usize = !255usize;
 
 unsafe impl RawRwLock for RWSpinLock {
+    #[allow(clippy::declare_interior_mutable_const)]
 	const INIT: RWSpinLock = RWSpinLock {
 		rin: AtomicUsize::new(0),
 		rout: AtomicUsize::new(0),

--- a/src/syscalls/interfaces/mod.rs
+++ b/src/syscalls/interfaces/mod.rs
@@ -118,23 +118,10 @@ pub trait SyscallInterface: Send + Sync {
 		Err(())
 	}
 
-	fn receive_rx_buffer(&self) -> Result<(&'static mut [u8], usize), ()> {
+	fn receive_rx_buffer(&self) -> Result<Vec<u8>, ()> {
 		#[cfg(not(target_arch = "aarch64"))]
 		match get_network_driver() {
 			Some(driver) => driver.lock().receive_rx_buffer(),
-			_ => Err(()),
-		}
-		#[cfg(target_arch = "aarch64")]
-		Err(())
-	}
-
-	fn rx_buffer_consumed(&self, handle: usize) -> Result<(), ()> {
-		#[cfg(not(target_arch = "aarch64"))]
-		match get_network_driver() {
-			Some(driver) => {
-				driver.lock().rx_buffer_consumed(handle);
-				Ok(())
-			}
 			_ => Err(()),
 		}
 		#[cfg(target_arch = "aarch64")]

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -15,7 +15,7 @@ pub use self::system::*;
 pub use self::tasks::*;
 pub use self::timer::*;
 use crate::env;
-use crate::fd::{get_object, remove_object, FileDescriptor};
+use crate::fd::{dup_object, get_object, remove_object, FileDescriptor};
 use crate::syscalls::interfaces::SyscallInterface;
 #[cfg(target_os = "none")]
 use crate::{__sys_free, __sys_malloc, __sys_realloc};
@@ -27,7 +27,7 @@ mod interfaces;
 #[cfg(feature = "newlib")]
 mod lwip;
 #[cfg(all(feature = "tcp", not(feature = "newlib")))]
-mod net;
+pub mod net;
 mod processor;
 mod random;
 mod recmutex;
@@ -126,13 +126,8 @@ pub extern "C" fn sys_open(name: *const u8, flags: i32, mode: i32) -> FileDescri
 }
 
 extern "C" fn __sys_close(fd: FileDescriptor) -> i32 {
-	let obj = get_object(fd);
-	let result = obj.map_or_else(|e| e, |v| v.close());
-	if result == 0 {
-		remove_object(fd);
-	}
-
-	result
+	let obj = remove_object(fd);
+	obj.map_or_else(|e| e, |_| 0)
 }
 
 #[no_mangle]
@@ -142,8 +137,9 @@ pub extern "C" fn sys_close(fd: FileDescriptor) -> i32 {
 
 extern "C" fn __sys_read(fd: FileDescriptor, buf: *mut u8, len: usize) -> isize {
 	let obj = get_object(fd);
-	obj.map_or_else(|e| e as isize, |v| v.read(buf, len))
+	obj.map_or_else(|e| e as isize, |v| (*v).read(buf, len))
 }
+
 #[no_mangle]
 pub extern "C" fn sys_read(fd: FileDescriptor, buf: *mut u8, len: usize) -> isize {
 	kernel_function!(__sys_read(fd, buf, len))
@@ -151,7 +147,7 @@ pub extern "C" fn sys_read(fd: FileDescriptor, buf: *mut u8, len: usize) -> isiz
 
 extern "C" fn __sys_write(fd: FileDescriptor, buf: *const u8, len: usize) -> isize {
 	let obj = get_object(fd);
-	obj.map_or_else(|e| e as isize, |v| v.write(buf, len))
+	obj.map_or_else(|e| e as isize, |v| (*v).write(buf, len))
 }
 
 #[no_mangle]
@@ -159,9 +155,19 @@ pub extern "C" fn sys_write(fd: FileDescriptor, buf: *const u8, len: usize) -> i
 	kernel_function!(__sys_write(fd, buf, len))
 }
 
+extern "C" fn __sys_ioctl(fd: FileDescriptor, cmd: i32, argp: *mut core::ffi::c_void) -> i32 {
+	let obj = get_object(fd);
+	obj.map_or_else(|e| e, |v| (*v).ioctl(cmd, argp))
+}
+
+#[no_mangle]
+pub extern "C" fn sys_ioctl(fd: FileDescriptor, cmd: i32, argp: *mut core::ffi::c_void) -> i32 {
+	kernel_function!(__sys_ioctl(fd, cmd, argp))
+}
+
 extern "C" fn __sys_lseek(fd: FileDescriptor, offset: isize, whence: i32) -> isize {
 	let obj = get_object(fd);
-	obj.map_or_else(|e| e as isize, |v| v.lseek(offset, whence))
+	obj.map_or_else(|e| e as isize, |v| (*v).lseek(offset, whence))
 }
 
 #[no_mangle]
@@ -176,4 +182,13 @@ extern "C" fn __sys_stat(file: *const u8, st: usize) -> i32 {
 #[no_mangle]
 pub extern "C" fn sys_stat(file: *const u8, st: usize) -> i32 {
 	kernel_function!(__sys_stat(file, st))
+}
+
+extern "C" fn __sys_dup(fd: i32) -> i32 {
+	dup_object(fd).map_or_else(|e| e, |v| v)
+}
+
+#[no_mangle]
+pub extern "C" fn sys_dup(fd: i32) -> i32 {
+	kernel_function!(__sys_dup(fd))
 }

--- a/src/syscalls/net.rs
+++ b/src/syscalls/net.rs
@@ -1,33 +1,39 @@
+#![allow(dead_code)]
+#![allow(nonstandard_style)]
+use core::ffi::c_void;
+
 use smoltcp::socket::TcpSocket;
 use smoltcp::time::Duration;
 use smoltcp::wire::IpAddress;
 
+use crate::fd::socket::*;
 use crate::net::executor::block_on;
 use crate::net::{AsyncSocket, Handle};
+use crate::syscalls::__sys_write;
 use crate::DEFAULT_KEEP_ALIVE_INTERVAL;
 
 #[no_mangle]
 pub fn sys_tcp_stream_connect(ip: &[u8], port: u16, timeout: Option<u64>) -> Result<Handle, ()> {
 	let socket = AsyncSocket::new();
-	block_on(socket.connect(ip, port), timeout.map(Duration::from_millis))?.map_err(|_| ())
+	block_on(socket.connect(ip, port), timeout.map(Duration::from_millis)).map_err(|_| ())
 }
 
 #[no_mangle]
 pub fn sys_tcp_stream_read(handle: Handle, buffer: &mut [u8]) -> Result<usize, ()> {
 	let socket = AsyncSocket::from(handle);
-	block_on(socket.read(buffer), None)?.map_err(|_| ())
+	block_on(socket.read(buffer), None).map_err(|_| ())
 }
 
 #[no_mangle]
 pub fn sys_tcp_stream_write(handle: Handle, buffer: &[u8]) -> Result<usize, ()> {
 	let socket = AsyncSocket::from(handle);
-	block_on(socket.write(buffer), None)?.map_err(|_| ())
+	block_on(socket.write(buffer), None).map_err(|_| ())
 }
 
 #[no_mangle]
 pub fn sys_tcp_stream_close(handle: Handle) -> Result<(), ()> {
 	let socket = AsyncSocket::from(handle);
-	block_on(socket.close(), None)?.map_err(|_| ())
+	block_on(socket.close(), None).map_err(|_| ())
 }
 
 //ToDo: an enum, or at least constants would be better
@@ -132,7 +138,204 @@ pub fn sys_tcp_stream_peer_addr(handle: Handle) -> Result<(IpAddress, u16), ()> 
 #[no_mangle]
 pub fn sys_tcp_listener_accept(port: u16) -> Result<(Handle, IpAddress, u16), ()> {
 	let socket = AsyncSocket::new();
-	let (addr, port) = block_on(socket.accept(port), None)?.map_err(|_| ())?;
+	let (addr, port) = block_on(socket.accept(port), None).map_err(|_| ())?;
 
 	Ok((socket.inner(), addr, port))
+}
+
+pub const AF_INET: i32 = 0;
+pub const AF_INET6: i32 = 1;
+pub const IPPROTO_IP: i32 = 0;
+pub const IPPROTO_IPV6: i32 = 41;
+pub const IPPROTO_TCP: i32 = 6;
+pub const IPPROTO_UDP: i32 = 17;
+pub const IPV6_ADD_MEMBERSHIP: i32 = 12;
+pub const IPV6_DROP_MEMBERSHIP: i32 = 13;
+pub const IPV6_MULTICAST_LOOP: i32 = 19;
+pub const IPV6_V6ONLY: i32 = 27;
+pub const IP_TTL: i32 = 2;
+pub const IP_MULTICAST_TTL: i32 = 5;
+pub const IP_MULTICAST_LOOP: i32 = 7;
+pub const IP_ADD_MEMBERSHIP: i32 = 3;
+pub const IP_DROP_MEMBERSHIP: i32 = 4;
+pub const SHUT_RD: i32 = 0;
+pub const SHUT_WR: i32 = 1;
+pub const SHUT_RDWR: i32 = 2;
+pub const SOCK_DGRAM: i32 = 2;
+pub const SOCK_STREAM: i32 = 1;
+pub const SOL_SOCKET: i32 = 4095;
+pub const SO_BROADCAST: i32 = 32;
+pub const SO_ERROR: i32 = 4103;
+pub const SO_RCVTIMEO: i32 = 4102;
+pub const SO_REUSEADDR: i32 = 4;
+pub const SO_SNDTIMEO: i32 = 4101;
+pub const SO_LINGER: i32 = 128;
+pub const TCP_NODELAY: i32 = 1;
+pub const MSG_PEEK: i32 = 1;
+pub const FIONBIO: i32 = 0x8008667eu32 as i32;
+pub const EAI_NONAME: i32 = -2200;
+pub const EAI_SERVICE: i32 = -2201;
+pub const EAI_FAIL: i32 = -2202;
+pub const EAI_MEMORY: i32 = -2203;
+pub const EAI_FAMILY: i32 = -2204;
+pub type sa_family_t = u8;
+pub type socklen_t = u32;
+pub type in_addr_t = u32;
+pub type in_port_t = u16;
+pub type time_t = i64;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct in_addr {
+	pub s_addr: [u8; 4],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct in6_addr {
+	pub s6_addr: [u8; 16],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sockaddr {
+	pub sa_len: u8,
+	pub sa_family: sa_family_t,
+	pub sa_data: [u8; 14],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sockaddr_in {
+	pub sin_len: u8,
+	pub sin_family: sa_family_t,
+	pub sin_port: in_port_t,
+	pub sin_addr: in_addr,
+	pub sin_zero: [u8; 8],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sockaddr_in6 {
+	pub sin6_family: sa_family_t,
+	pub sin6_port: in_port_t,
+	pub sin6_addr: in6_addr,
+	pub sin6_flowinfo: u32,
+	pub sin6_scope_id: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ip_mreq {
+	pub imr_multiaddr: in_addr,
+	pub imr_interface: in_addr,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ipv6_mreq {
+	pub ipv6mr_multiaddr: in6_addr,
+	pub ipv6mr_interface: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct addrinfo {
+	pub ai_flags: i32,
+	pub ai_family: i32,
+	pub ai_socktype: i32,
+	pub ai_protocol: i32,
+	pub ai_addrlen: socklen_t,
+	pub ai_addr: *mut sockaddr,
+	pub ai_canonname: *mut u8,
+	pub ai_next: *mut addrinfo,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct linger {
+	pub l_onoff: i32,
+	pub l_linger: i32,
+}
+
+#[no_mangle]
+pub extern "C" fn sys_socket(domain: i32, type_: i32, protocol: i32) -> i32 {
+	kernel_function!(__sys_socket(domain, type_, protocol))
+}
+
+#[no_mangle]
+pub extern "C" fn sys_accept(s: i32, addr: *mut sockaddr, addrlen: *mut socklen_t) -> i32 {
+	kernel_function!(__sys_accept(s, addr, addrlen))
+}
+
+#[no_mangle]
+pub extern "C" fn sys_listen(s: i32, backlog: i32) -> i32 {
+	kernel_function!(__sys_listen(s, backlog))
+}
+
+#[no_mangle]
+pub extern "C" fn sys_bind(s: i32, name: *const sockaddr, namelen: socklen_t) -> i32 {
+	kernel_function!(__sys_bind(s, name, namelen))
+}
+
+#[no_mangle]
+pub extern "C" fn sys_connect(s: i32, name: *const sockaddr, namelen: socklen_t) -> i32 {
+	kernel_function!(__sys_connect(s, name, namelen))
+}
+
+#[no_mangle]
+pub extern "C" fn sys_getsockname(s: i32, name: *mut sockaddr, namelen: *mut socklen_t) -> i32 {
+	kernel_function!(__sys_getsockname(s, name, namelen))
+}
+
+#[no_mangle]
+pub extern "C" fn sys_setsockopt(
+	s: i32,
+	level: i32,
+	optname: i32,
+	optval: *const c_void,
+	optlen: socklen_t,
+) -> i32 {
+	kernel_function!(__sys_setsockopt(s, level, optname, optval, optlen))
+}
+
+#[no_mangle]
+pub extern "C" fn getsockopt(
+	s: i32,
+	level: i32,
+	optname: i32,
+	optval: *mut c_void,
+	optlen: *mut socklen_t,
+) -> i32 {
+	kernel_function!(__sys_getsockopt(s, level, optname, optval, optlen))
+}
+
+#[no_mangle]
+pub extern "C" fn sys_getpeername(s: i32, name: *mut sockaddr, namelen: *mut socklen_t) -> i32 {
+	kernel_function!(__sys_getpeername(s, name, namelen))
+}
+
+#[no_mangle]
+pub extern "C" fn sys_freeaddrinfo(ai: *mut addrinfo) {
+	kernel_function!(__sys_freeaddrinfo(ai))
+}
+
+#[no_mangle]
+pub extern "C" fn sys_getaddrinfo(
+	nodename: *const u8,
+	servname: *const u8,
+	hints: *const addrinfo,
+	res: *mut *mut addrinfo,
+) -> i32 {
+	kernel_function!(__sys_getaddrinfo(nodename, servname, hints, res))
+}
+
+#[no_mangle]
+pub extern "C" fn sys_send(s: i32, mem: *const c_void, len: usize, _flags: i32) -> isize {
+	kernel_function!(__sys_write(s, mem as *const u8, len))
+}
+
+#[no_mangle]
+pub extern "C" fn sys_shutdown_socket(s: i32, how: i32) -> i32 {
+	kernel_function!(__sys_shutdown_socket(s, how))
 }

--- a/src/syscalls/net.rs
+++ b/src/syscalls/net.rs
@@ -9,7 +9,7 @@ use smoltcp::wire::IpAddress;
 use crate::fd::socket::*;
 use crate::net::executor::block_on;
 use crate::net::{AsyncSocket, Handle};
-use crate::syscalls::{__sys_write, get_object};
+use crate::syscalls::__sys_write;
 use crate::DEFAULT_KEEP_ALIVE_INTERVAL;
 
 #[no_mangle]
@@ -338,11 +338,6 @@ pub extern "C" fn sys_send(s: i32, mem: *const c_void, len: usize, _flags: i32) 
 #[no_mangle]
 pub extern "C" fn sys_shutdown_socket(s: i32, how: i32) -> i32 {
 	kernel_function!(__sys_shutdown_socket(s, how))
-}
-
-extern "C" fn __sys_recv(fd: i32, buf: *mut u8, len: usize) -> isize {
-	let obj = get_object(fd);
-	obj.map_or_else(|e| e as isize, |v| (*v).read(buf, len))
 }
 
 #[no_mangle]


### PR DESCRIPTION
This PR realize a classical BSD socket layer. To realize a BSD socket layer, the executor has to return directly UNIX-like error number because the layer depends on a C interface and doesn't support Rust's error handling.