### PR TITLE
Reimplement random data generation, add `read_entropy` syscall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,7 @@ dependencies = [
  "num-traits",
  "pci-ids",
  "qemu-exit",
+ "rand_chacha",
  "scopeguard",
  "shell-words",
  "smoltcp",
@@ -465,6 +466,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +501,16 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
  "rand_core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ pci-ids = { version = "0.2", optional = true }
 scopeguard = { version = "1.1", default-features = false }
 shell-words = { version = "1.1", default-features = false }
 qemu-exit = "3.0"
+rand_chacha = { version = "0.3", default-features = false }
 futures-lite = { version = "1.11", default-features = false, optional = true }
 async-task = { version = "4.3", default-features = false, optional = true }
 

--- a/src/arch/aarch64/kernel/processor.rs
+++ b/src/arch/aarch64/kernel/processor.rs
@@ -23,11 +23,7 @@ impl FPUState {
 	}
 }
 
-pub fn generate_random_number32() -> Option<u32> {
-	None
-}
-
-pub fn generate_random_number64() -> Option<u64> {
+pub fn seed_entropy() -> Option<[u8; 32]> {
 	None
 }
 

--- a/src/entropy.rs
+++ b/src/entropy.rs
@@ -7,14 +7,23 @@ use hermit_sync::InterruptTicketMutex;
 use rand_chacha::rand_core::{RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
-use crate::arch::kernel::processor::seed_entropy;
+use crate::arch::kernel::processor::{get_timer_ticks, seed_entropy};
 use crate::errno::ENOSYS;
+
+// Reseed every second for increased security while maintaining the performance of
+// the PRNG.
+const RESEED_INTERVAL: u64 = 1000000;
 
 bitflags! {
 	pub struct Flags: u32 {}
 }
 
-static POOL: InterruptTicketMutex<Option<ChaCha20Rng>> = InterruptTicketMutex::new(None);
+struct Pool {
+	rng: ChaCha20Rng,
+	last_reseed: u64,
+}
+
+static POOL: InterruptTicketMutex<Option<Pool>> = InterruptTicketMutex::new(None);
 
 /// Fills `buf` with random data, respecting the options in `flags`.
 ///
@@ -22,18 +31,22 @@ static POOL: InterruptTicketMutex<Option<ChaCha20Rng>> = InterruptTicketMutex::n
 /// random data generation.
 pub fn read(buf: &mut [u8], _flags: Flags) -> isize {
 	let pool = &mut *POOL.lock();
+	let now = get_timer_ticks();
 	let pool = match pool {
-		Some(pool) => pool,
-		pool @ None => {
+		Some(pool) if now.saturating_sub(pool.last_reseed) <= RESEED_INTERVAL => pool,
+		pool => {
 			if let Some(seed) = seed_entropy() {
-				pool.insert(ChaCha20Rng::from_seed(seed))
+				pool.insert(Pool {
+					rng: ChaCha20Rng::from_seed(seed),
+					last_reseed: now,
+				})
 			} else {
 				return -ENOSYS as isize;
 			}
 		}
 	};
 
-	pool.fill_bytes(buf);
+	pool.rng.fill_bytes(buf);
 	// Slice lengths are always <= isize::MAX so this return value cannot conflict
 	// with error numbers.
 	buf.len() as isize

--- a/src/entropy.rs
+++ b/src/entropy.rs
@@ -1,0 +1,37 @@
+//! Cryptographically secure random data generation.
+//!
+//! This currently uses a ChaCha-based generator (the same one Linux uses!) seeded
+//! with random data provided by the processor.
+
+use hermit_sync::InterruptTicketMutex;
+use rand_chacha::rand_core::{RngCore, SeedableRng};
+use rand_chacha::ChaCha20Rng;
+
+use crate::arch::kernel::processor::seed_entropy;
+use crate::errno::ENOSYS;
+
+bitflags! {
+	pub struct Flags: u32 {}
+}
+
+static POOL: InterruptTicketMutex<Option<ChaCha20Rng>> = InterruptTicketMutex::new(None);
+
+/// Fills `buf` with random data, respecting the options in `flags`.
+///
+/// Returns `-ENOSYS` if the system does not support random data generation.
+pub fn read(buf: &mut [u8], _flags: Flags) -> i32 {
+	let pool = &mut *POOL.lock();
+	let pool = match pool {
+		Some(pool) => pool,
+		pool @ None => {
+			if let Some(seed) = seed_entropy() {
+				pool.insert(ChaCha20Rng::from_seed(seed))
+			} else {
+				return -ENOSYS;
+			}
+		}
+	};
+
+	pool.fill_bytes(buf);
+	0
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ mod arch;
 mod config;
 mod console;
 mod drivers;
+mod entropy;
 mod env;
 pub mod errno;
 pub(crate) mod fd;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -42,18 +42,6 @@ macro_rules! dbg {
     };
 }
 
-macro_rules! try_sys {
-	($expr:expr $(,)?) => {
-		match $expr {
-			::core::result::Result::Ok(val) => val,
-			::core::result::Result::Err(err) => {
-				error!("{err}");
-				return -1;
-			}
-		}
-	};
-}
-
 /// Runs `f` on the kernel stack.
 ///
 /// All arguments and return values have to fit into registers:

--- a/src/syscalls/entropy.rs
+++ b/src/syscalls/entropy.rs
@@ -17,14 +17,13 @@ fn generate_park_miller_lehmer_random_number() -> u32 {
 	random
 }
 
-unsafe extern "C" fn __sys_read_entropy(buf: *mut u8, len: usize, flags: u32) -> i32 {
-	let Some(flags) = Flags::from_bits(flags) else { return -EINVAL };
-
-	if len > isize::MAX as usize {
-		return -EINVAL;
-	}
+unsafe extern "C" fn __sys_read_entropy(buf: *mut u8, len: usize, flags: u32) -> isize {
+	let Some(flags) = Flags::from_bits(flags) else { return -EINVAL as isize  };
 
 	let buf = unsafe {
+		// Cap the number of bytes to be read at a time to isize::MAX to uphold
+		// the safety guarantees of `from_raw_parts`.
+		let len = usize::min(len, isize::MAX as usize);
 		buf.write_bytes(0, len);
 		slice::from_raw_parts_mut(buf, len)
 	};
@@ -34,31 +33,54 @@ unsafe extern "C" fn __sys_read_entropy(buf: *mut u8, len: usize, flags: u32) ->
 
 /// Fill `len` bytes in `buf` with cryptographically secure random data.
 ///
-/// Returns
+/// Returns either the number of bytes written to buf (a positive value) or
 /// * `-EINVAL` if `flags` contains unknown flags.
-/// * `-EINVAL` if `len` is larger than `isize::MAX`.
 /// * `-ENOSYS` if the system does not support random data generation.
 #[no_mangle]
-pub unsafe extern "C" fn sys_read_entropy(buf: *mut u8, len: usize, flags: u32) -> i32 {
+pub unsafe extern "C" fn sys_read_entropy(buf: *mut u8, len: usize, flags: u32) -> isize {
 	kernel_function!(__sys_read_entropy(buf, len, flags))
 }
 
 /// Create a cryptographicly secure 32bit random number with the support of
 /// the underlying hardware. If the required hardware isn't available,
-/// the function returns `None`.
+/// the function returns `-1`.
 #[cfg(not(feature = "newlib"))]
 #[no_mangle]
 pub unsafe extern "C" fn sys_secure_rand32(value: *mut u32) -> i32 {
-	unsafe { sys_read_entropy(value.cast(), size_of::<u32>(), 0) }
+	let mut buf = value.cast();
+	let mut len = size_of::<u32>();
+	while len != 0 {
+		let res = unsafe { sys_read_entropy(buf, len, 0) };
+		if res < 0 {
+			return -1;
+		}
+
+		buf = unsafe { buf.add(res as usize) };
+		len -= res as usize;
+	}
+
+	0
 }
 
 /// Create a cryptographicly secure 64bit random number with the support of
 /// the underlying hardware. If the required hardware isn't available,
-/// the function returns `None`.
+/// the function returns -1.
 #[cfg(not(feature = "newlib"))]
 #[no_mangle]
 pub unsafe extern "C" fn sys_secure_rand64(value: *mut u64) -> i32 {
-	unsafe { sys_read_entropy(value.cast(), size_of::<u64>(), 0) }
+	let mut buf = value.cast();
+	let mut len = size_of::<u64>();
+	while len != 0 {
+		let res = unsafe { sys_read_entropy(buf, len, 0) };
+		if res < 0 {
+			return -1;
+		}
+
+		buf = unsafe { buf.add(res as usize) };
+		len -= res as usize;
+	}
+
+	0
 }
 
 extern "C" fn __sys_rand() -> u32 {

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -5,9 +5,9 @@ use hermit_sync::InterruptTicketMutex;
 use hermit_sync::Lazy;
 
 pub use self::condvar::*;
+pub use self::entropy::*;
 pub use self::futex::*;
 pub use self::processor::*;
-pub use self::random::*;
 pub use self::recmutex::*;
 pub use self::semaphore::*;
 pub use self::spinlock::*;
@@ -21,6 +21,7 @@ use crate::syscalls::interfaces::SyscallInterface;
 use crate::{__sys_free, __sys_malloc, __sys_realloc};
 
 mod condvar;
+mod entropy;
 pub(crate) mod fs;
 mod futex;
 mod interfaces;
@@ -29,7 +30,6 @@ mod lwip;
 #[cfg(all(feature = "tcp", not(feature = "newlib")))]
 mod net;
 mod processor;
-mod random;
 mod recmutex;
 mod semaphore;
 mod spinlock;
@@ -68,7 +68,7 @@ pub(crate) fn init() {
 	// Perform interface-specific initialization steps.
 	SYS.init();
 
-	random_init();
+	init_entropy();
 	#[cfg(feature = "newlib")]
 	sbrk_init();
 }


### PR DESCRIPTION
Fixes #143 by reimplementing random data generation using a [ChaCha-based RNG](https://docs.rs/rand_chacha/0.3.1/rand_chacha/struct.ChaCha20Rng.html) continuously reseeded using the `RDSEED` instruction. This should provide better security, as `RDRAND` is known to have hardware bugs. 

Also adds a new buffer-based syscall, `read_entropy`, which better fits the usecase of crates like [`getrandom`](https://github.com/rust-random/getrandom).

The old `secure_rand*` and `rand` syscalls should probably be removed at some point, but I do not know the Hermit stability policy and therefore have not done this in this PR.