### PR TITLE
add support to boot RustyHermit on Firecracker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,9 +279,9 @@ checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hermit-entry"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95c35e11db119492028983535374cc944260a8c0db53a784d80ccfa44a97369"
+checksum = "5161b343513f1cd3bcc38a7e9ef5f7ba996e9533fa7116797b2684cffe11038f"
 dependencies = [
  "align-address",
  "time",
@@ -820,9 +820,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.13"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -859,7 +859,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,5 +51,5 @@ RUN set -eux; \
         qemu-system-x86 \
     ; \
     rm -rf /var/lib/apt/lists/*;
-ADD https://github.com/hermitcore/rusty-loader/releases/download/v0.4.1/rusty-loader-x86_64 /usr/local/bin/
+ADD https://github.com/hermitcore/rusty-loader/releases/download/v0.4.3/rusty-loader-x86_64 /usr/local/bin/
 COPY --from=stable-deps $CARGO_HOME/bin/uhyve $CARGO_HOME/bin/uhyve

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -111,6 +111,7 @@ pub fn get_mbinfo() -> VirtAddr {
 			multiboot_info_addr,
 			..
 		} => VirtAddr(multiboot_info_addr.get()),
+		PlatformInfo::LinuxBootParams { .. } => VirtAddr(0),
 		PlatformInfo::Uhyve { .. } => VirtAddr(0),
 	}
 }
@@ -147,6 +148,7 @@ pub fn is_uhyve() -> bool {
 pub fn is_uhyve_with_pci() -> bool {
 	match boot_info().platform_info {
 		PlatformInfo::Multiboot { .. } => false,
+		PlatformInfo::LinuxBootParams { .. } => false,
 		PlatformInfo::Uhyve { has_pci, .. } => has_pci,
 	}
 }
@@ -156,6 +158,9 @@ pub fn get_cmdsize() -> usize {
 		PlatformInfo::Multiboot { command_line, .. } => command_line
 			.map(|command_line| command_line.len())
 			.unwrap_or_default(),
+		PlatformInfo::LinuxBootParams { command_line, .. } => command_line
+			.map(|command_line| command_line.len())
+			.unwrap_or_default(),
 		PlatformInfo::Uhyve { .. } => 0,
 	}
 }
@@ -163,6 +168,11 @@ pub fn get_cmdsize() -> usize {
 pub fn get_cmdline() -> VirtAddr {
 	match boot_info().platform_info {
 		PlatformInfo::Multiboot { command_line, .. } => VirtAddr(
+			command_line
+				.map(|command_line| command_line.as_ptr() as u64)
+				.unwrap_or_default(),
+		),
+		PlatformInfo::LinuxBootParams { command_line, .. } => VirtAddr(
 			command_line
 				.map(|command_line| command_line.as_ptr() as u64)
 				.unwrap_or_default(),

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -121,6 +121,7 @@ pub fn get_possible_cpus() -> u32 {
 	use core::cmp;
 
 	match boot_info().platform_info {
+        PlatformInfo::LinuxBootParams { .. } => apic::local_apic_id_count(),
 		PlatformInfo::Multiboot { .. } => apic::local_apic_id_count(),
 		// FIXME: Remove get_processor_count after a transition period for uhyve 0.1.3 adoption
 		PlatformInfo::Uhyve { num_cpus, .. } => cmp::max(

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -121,7 +121,7 @@ pub fn get_possible_cpus() -> u32 {
 	use core::cmp;
 
 	match boot_info().platform_info {
-        PlatformInfo::LinuxBootParams { .. } => apic::local_apic_id_count(),
+		PlatformInfo::LinuxBootParams { .. } => apic::local_apic_id_count(),
 		PlatformInfo::Multiboot { .. } => apic::local_apic_id_count(),
 		// FIXME: Remove get_processor_count after a transition period for uhyve 0.1.3 adoption
 		PlatformInfo::Uhyve { num_cpus, .. } => cmp::max(

--- a/src/arch/x86_64/kernel/systemtime.rs
+++ b/src/arch/x86_64/kernel/systemtime.rs
@@ -185,6 +185,13 @@ pub fn init() {
 			let boot_time = current_time - processor::get_timer_ticks();
 			OffsetDateTime::from_unix_timestamp_nanos(boot_time as i128 * 1000).unwrap()
 		}
+		PlatformInfo::LinuxBootParams { .. } => {
+			// Get the current time in microseconds since the epoch (1970-01-01) from the x86 RTC.
+			// Subtract the timer ticks to get the actual time when HermitCore-rs was booted.
+			let current_time = without_interrupts(|| Rtc::new().get_microseconds_since_epoch());
+			let boot_time = current_time - processor::get_timer_ticks();
+			OffsetDateTime::from_unix_timestamp_nanos(boot_time as i128 * 1000).unwrap()
+		}
 		PlatformInfo::Uhyve { boot_time, .. } => boot_time,
 	};
 	info!("HermitCore-rs booted on {boot_time}");


### PR DESCRIPTION
In case of Firecracker, RustyHermit has to emulate the boot process of Linux. Consequently, rusty-loader forwards the Linux boot params to RustyHermit.

This PR requires hermitcore/hermit-entry#12 and hermitcore/rusty-loader#200.