### PR TITLE
assign separate stack to handle interrupts

### DIFF
--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -477,14 +477,24 @@ pub fn init() {
 
 	// Set gates to ISRs for the APIC interrupts we are going to enable.
 	let idt = unsafe { &mut *(&mut IDT as *mut _ as *mut InterruptDescriptorTable) };
-	idt[ERROR_INTERRUPT_NUMBER as usize].set_handler_fn(error_interrupt_handler);
-	idt[SPURIOUS_INTERRUPT_NUMBER as usize].set_handler_fn(spurious_interrupt_handler);
-	#[cfg(feature = "smp")]
-	{
-		idt[TLB_FLUSH_INTERRUPT_NUMBER as usize].set_handler_fn(tlb_flush_handler);
-		interrupts::add_irq_name((TLB_FLUSH_INTERRUPT_NUMBER - 32).into(), "TLB flush");
-		idt[WAKEUP_INTERRUPT_NUMBER as usize].set_handler_fn(wakeup_handler);
-		interrupts::add_irq_name((WAKEUP_INTERRUPT_NUMBER - 32).into(), "Wakeup");
+	unsafe {
+		idt[ERROR_INTERRUPT_NUMBER as usize]
+			.set_handler_fn(error_interrupt_handler)
+			.set_stack_index(0);
+		idt[SPURIOUS_INTERRUPT_NUMBER as usize]
+			.set_handler_fn(spurious_interrupt_handler)
+			.set_stack_index(0);
+		#[cfg(feature = "smp")]
+		{
+			idt[TLB_FLUSH_INTERRUPT_NUMBER as usize]
+				.set_handler_fn(tlb_flush_handler)
+				.set_stack_index(0);
+			interrupts::add_irq_name((TLB_FLUSH_INTERRUPT_NUMBER - 32).into(), "TLB flush");
+			idt[WAKEUP_INTERRUPT_NUMBER as usize]
+				.set_handler_fn(wakeup_handler)
+				.set_stack_index(0);
+			interrupts::add_irq_name((WAKEUP_INTERRUPT_NUMBER - 32).into(), "Wakeup");
+		}
 	}
 
 	// Initialize interrupt handling over APIC.

--- a/src/arch/x86_64/kernel/gdt.rs
+++ b/src/arch/x86_64/kernel/gdt.rs
@@ -29,7 +29,7 @@ pub fn add_current_core() {
 	CoreLocal::get().kernel_stack.set(rsp);
 
 	// Allocate all ISTs for this core.
-	// Every task later gets its own IST1, so the IST1 allocated here is only used by the Idle task.
+	// Every task later gets its own IST0, so the IST0 allocated here is only used by the Idle task.
 	for i in 0..IST_ENTRIES {
 		let ist = crate::mm::allocate(IST_SIZE, true);
 		let ist_start = ist.as_u64() + IST_SIZE as u64 - TaskStacks::MARKER_SIZE as u64;

--- a/src/arch/x86_64/kernel/interrupts.rs
+++ b/src/arch/x86_64/kernel/interrupts.rs
@@ -35,7 +35,7 @@ pub fn install() {
 	set_general_handler!(idt, unknown, 64..);
 
 	unsafe {
-		for i in idt.slice_mut(0..) {
+		for i in idt.slice_mut(32..) {
 			let addr = i.handler_addr();
 			i.set_handler_addr(addr).set_stack_index(0);
 		}

--- a/src/arch/x86_64/kernel/interrupts.rs
+++ b/src/arch/x86_64/kernel/interrupts.rs
@@ -110,7 +110,9 @@ pub extern "C" fn irq_install_handler(irq_number: u32, handler: usize) {
 
 	let idt = unsafe { &mut *(&mut IDT as *mut _ as *mut InterruptDescriptorTable) };
 	unsafe {
-		idt[(32 + irq_number) as usize].set_handler_addr(x86_64::VirtAddr::new(handler as u64));
+		idt[(32 + irq_number) as usize]
+			.set_handler_addr(x86_64::VirtAddr::new(handler as u64))
+			.set_stack_index(0);
 	}
 }
 

--- a/src/arch/x86_64/kernel/interrupts.rs
+++ b/src/arch/x86_64/kernel/interrupts.rs
@@ -28,9 +28,16 @@ pub fn load_idt() {
 }
 
 pub fn install() {
+	// Set gates to the Interrupt Service Routines (ISRs) for all 32 CPU exceptions.
+	// All of them use a dedicated stack per task (IST0) to prevent clobbering the current task stack.
+	// Some critical exceptions also get their own stacks to always execute on a known good stack:
+	//   - Non-Maskable Interrupt Exception (IST1)
+	//   - Double Fault Exception (IST2)
+	//   - Machine Check Exception (IST3)
+	//
+	// Refer to Intel Vol. 3A, 6.14.5 Interrupt Stack Table.
 	let idt = unsafe { &mut *(&mut IDT as *mut _ as *mut InterruptDescriptorTable) };
 
-	set_general_handler!(idt, abort, 0..32);
 	set_general_handler!(idt, unhandle, 32..64);
 	set_general_handler!(idt, unknown, 64..);
 
@@ -39,20 +46,60 @@ pub fn install() {
 			let addr = i.handler_addr();
 			i.set_handler_addr(addr).set_stack_index(0);
 		}
-		idt.double_fault
-			.set_handler_fn(double_fault_exception)
-			.set_stack_index(1);
+		idt.divide_error
+			.set_handler_fn(divide_error_exception)
+			.set_stack_index(0);
+		idt.debug.set_handler_fn(debug_exception).set_stack_index(0);
 		idt.non_maskable_interrupt
 			.set_handler_fn(nmi_exception)
-			.set_stack_index(2);
-		idt.machine_check
-			.set_handler_fn(machine_check_exception)
-			.set_stack_index(3);
+			.set_stack_index(1);
+		idt.breakpoint
+			.set_handler_fn(breakpoint_exception)
+			.set_stack_index(0);
+		idt.overflow
+			.set_handler_fn(overflow_exception)
+			.set_stack_index(0);
+		idt.bound_range_exceeded
+			.set_handler_fn(bound_range_exceeded_exception)
+			.set_stack_index(0);
+		idt.invalid_opcode
+			.set_handler_fn(invalid_opcode_exception)
+			.set_stack_index(0);
 		idt.device_not_available
 			.set_handler_fn(device_not_available_exception)
 			.set_stack_index(0);
+		idt.double_fault
+			.set_handler_fn(double_fault_exception)
+			.set_stack_index(2);
+		idt.invalid_tss
+			.set_handler_fn(invalid_tss_exception)
+			.set_stack_index(0);
+		idt.segment_not_present
+			.set_handler_fn(segment_not_present_exception)
+			.set_stack_index(0);
+		idt.stack_segment_fault
+			.set_handler_fn(stack_segment_fault_exception)
+			.set_stack_index(0);
+		idt.general_protection_fault
+			.set_handler_fn(general_protection_exception)
+			.set_stack_index(0);
 		idt.page_fault
 			.set_handler_fn(page_fault_handler)
+			.set_stack_index(0);
+		idt.x87_floating_point
+			.set_handler_fn(floating_point_exception)
+			.set_stack_index(0);
+		idt.alignment_check
+			.set_handler_fn(alignment_check_exception)
+			.set_stack_index(0);
+		idt.machine_check
+			.set_handler_fn(machine_check_exception)
+			.set_stack_index(3);
+		idt.simd_floating_point
+			.set_handler_fn(simd_floating_point_exception)
+			.set_stack_index(0);
+		idt.virtualization
+			.set_handler_fn(virtualization_exception)
 			.set_stack_index(0);
 	}
 }
@@ -67,13 +114,6 @@ pub extern "C" fn irq_install_handler(irq_number: u32, handler: usize) {
 	}
 }
 
-fn abort(stack_frame: ExceptionStackFrame, index: u8, error_code: Option<u64>) {
-	error!("Exception {index}");
-	error!("Error code: {error_code:?}");
-	error!("Stack frame: {stack_frame:#?}");
-	scheduler::abort();
-}
-
 fn unhandle(_stack_frame: ExceptionStackFrame, index: u8, _error_code: Option<u64>) {
 	warn!("received unhandled irq {index}");
 	apic::eoi();
@@ -85,8 +125,34 @@ fn unknown(_stack_frame: ExceptionStackFrame, index: u8, _error_code: Option<u64
 	apic::eoi();
 }
 
+extern "x86-interrupt" fn divide_error_exception(stack_frame: ExceptionStackFrame) {
+	error!("Divide Error (#DE) Exception: {:#?}", stack_frame);
+	scheduler::abort();
+}
+extern "x86-interrupt" fn debug_exception(stack_frame: ExceptionStackFrame) {
+	error!("Debug (#DB) Exception: {:#?}", stack_frame);
+	scheduler::abort();
+}
+
 extern "x86-interrupt" fn nmi_exception(stack_frame: ExceptionStackFrame) {
 	error!("Non-Maskable Interrupt (NMI) Exception: {:#?}", stack_frame);
+	scheduler::abort();
+}
+
+extern "x86-interrupt" fn breakpoint_exception(stack_frame: ExceptionStackFrame) {
+	error!("Breakpoint (#BP) Exception: {:#?}", stack_frame);
+	scheduler::abort();
+}
+extern "x86-interrupt" fn overflow_exception(stack_frame: ExceptionStackFrame) {
+	error!("Overflow (#OF) Exception: {:#?}", stack_frame);
+	scheduler::abort();
+}
+extern "x86-interrupt" fn bound_range_exceeded_exception(stack_frame: ExceptionStackFrame) {
+	error!("BOUND Range Exceeded (#BR) Exception: {:#?}", stack_frame);
+	scheduler::abort();
+}
+extern "x86-interrupt" fn invalid_opcode_exception(stack_frame: ExceptionStackFrame) {
+	error!("Invalid Opcode (#UD) Exception: {:#?}", stack_frame);
 	scheduler::abort();
 }
 
@@ -116,6 +182,43 @@ extern "x86-interrupt" fn double_fault_exception(
 	scheduler::abort()
 }
 
+extern "x86-interrupt" fn invalid_tss_exception(stack_frame: ExceptionStackFrame, _code: u64) {
+	error!("Invalid TSS (#TS) Exception: {:#?}", stack_frame);
+	scheduler::abort();
+}
+extern "x86-interrupt" fn segment_not_present_exception(
+	stack_frame: ExceptionStackFrame,
+	_code: u64,
+) {
+	error!("Segment Not Present (#NP) Exception: {:#?}", stack_frame);
+	scheduler::abort();
+}
+extern "x86-interrupt" fn stack_segment_fault_exception(
+	stack_frame: ExceptionStackFrame,
+	error_code: u64,
+) {
+	error!(
+		"Stack Segment Fault (#SS) Exception: {:#?}, error {:#X}",
+		stack_frame, error_code
+	);
+	scheduler::abort();
+}
+extern "x86-interrupt" fn general_protection_exception(
+	stack_frame: ExceptionStackFrame,
+	error_code: u64,
+) {
+	error!(
+		"General Protection (#GP) Exception: {:#?}, error {:#X}",
+		stack_frame, error_code
+	);
+	error!(
+		"fs = {:#X}, gs = {:#X}",
+		processor::readfs(),
+		processor::readgs()
+	);
+	scheduler::abort();
+}
+
 pub extern "x86-interrupt" fn page_fault_handler(
 	stack_frame: ExceptionStackFrame,
 	error_code: PageFaultErrorCode,
@@ -129,9 +232,27 @@ pub extern "x86-interrupt" fn page_fault_handler(
 	scheduler::abort();
 }
 
+extern "x86-interrupt" fn floating_point_exception(stack_frame: ExceptionStackFrame) {
+	error!("Floating-Point Error (#MF) Exception: {:#?}", stack_frame);
+	scheduler::abort();
+}
+extern "x86-interrupt" fn alignment_check_exception(stack_frame: ExceptionStackFrame, _code: u64) {
+	error!("Alignment Check (#AC) Exception: {:#?}", stack_frame);
+	scheduler::abort();
+}
+
 extern "x86-interrupt" fn machine_check_exception(stack_frame: ExceptionStackFrame) -> ! {
 	error!("Machine Check (#MC) Exception: {:#?}", stack_frame);
 	scheduler::abort()
+}
+
+extern "x86-interrupt" fn simd_floating_point_exception(stack_frame: ExceptionStackFrame) {
+	error!("SIMD Floating-Point (#XM) Exception: {:#?}", stack_frame);
+	scheduler::abort();
+}
+extern "x86-interrupt" fn virtualization_exception(stack_frame: ExceptionStackFrame) {
+	error!("Virtualization (#VE) Exception: {:#?}", stack_frame);
+	scheduler::abort();
 }
 
 static IRQ_NAMES: InterruptTicketMutex<HashMap<u32, &'static str, RandomState>> =

--- a/src/arch/x86_64/kernel/pic.rs
+++ b/src/arch/x86_64/kernel/pic.rs
@@ -32,10 +32,14 @@ pub fn init() {
 	// Even if we mask all interrupts, spurious interrupts may still occur.
 	// This is especially true for real hardware. So provide a handler for them.
 	let idt = unsafe { &mut *(&mut IDT as *mut _ as *mut InterruptDescriptorTable) };
-	idt[(PIC1_INTERRUPT_OFFSET + SPURIOUS_IRQ_NUMBER) as usize]
-		.set_handler_fn(spurious_interrupt_on_master);
-	idt[(PIC2_INTERRUPT_OFFSET + SPURIOUS_IRQ_NUMBER) as usize]
-		.set_handler_fn(spurious_interrupt_on_slave);
+	unsafe {
+		idt[(PIC1_INTERRUPT_OFFSET + SPURIOUS_IRQ_NUMBER) as usize]
+			.set_handler_fn(spurious_interrupt_on_master)
+			.set_stack_index(0);
+		idt[(PIC2_INTERRUPT_OFFSET + SPURIOUS_IRQ_NUMBER) as usize]
+			.set_handler_fn(spurious_interrupt_on_slave)
+			.set_stack_index(0);
+	}
 
 	unsafe {
 		// Remapping IRQs with a couple of IO output operations

--- a/src/arch/x86_64/kernel/processor.rs
+++ b/src/arch/x86_64/kernel/processor.rs
@@ -411,8 +411,11 @@ impl CpuFrequency {
 		// Use the Programmable Interval Timer (PIT) for this measurement, which is the only
 		// system timer with a known constant frequency.
 		let idt = unsafe { &mut *(&mut IDT as *mut _ as *mut InterruptDescriptorTable) };
-		idt[pit::PIT_INTERRUPT_NUMBER as usize]
-			.set_handler_fn(Self::measure_frequency_timer_handler);
+		unsafe {
+			idt[pit::PIT_INTERRUPT_NUMBER as usize]
+				.set_handler_fn(Self::measure_frequency_timer_handler)
+				.set_stack_index(0);
+		}
 		pit::init(measurement_frequency);
 
 		// we need a timer interrupt to meature the frequency

--- a/src/arch/x86_64/kernel/scheduler.rs
+++ b/src/arch/x86_64/kernel/scheduler.rs
@@ -382,6 +382,10 @@ extern "x86-interrupt" fn timer_handler(_stack_frame: interrupts::ExceptionStack
 
 pub fn install_timer_handler() {
 	let idt = unsafe { &mut *(&mut IDT as *mut _ as *mut InterruptDescriptorTable) };
-	idt[apic::TIMER_INTERRUPT_NUMBER as usize].set_handler_fn(timer_handler);
+	unsafe {
+		idt[apic::TIMER_INTERRUPT_NUMBER as usize]
+			.set_handler_fn(timer_handler)
+			.set_stack_index(0);
+	}
 	interrupts::add_irq_name((apic::TIMER_INTERRUPT_NUMBER - 32).into(), "Timer");
 }

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -411,7 +411,7 @@ impl PerCoreScheduler {
 			+ current_task_borrowed.stacks.get_kernel_stack_size()
 			- TaskStacks::MARKER_SIZE)
 			.as_u64();
-		tss.interrupt_stack_table[0] = VirtAddr::new(rsp);
+		tss.privilege_stack_table[0] = VirtAddr::new(rsp);
 		CoreLocal::get().kernel_stack.set(rsp);
 		let ist_start = (current_task_borrowed.stacks.get_interrupt_stack()
 			+ current_task_borrowed.stacks.get_interrupt_stack_size()


### PR DESCRIPTION
This is required to allow red zones, where a task is able to use the stack below the rsp. Consequetly, the kernel should avoid that interrupts override the stack of a user thread.