### PR TITLE
removed all instances of shutdown

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,5 +381,5 @@ fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
 	let core_id = crate::arch::core_local::core_id();
 	println!("[{core_id}][PANIC] {info}");
 
-	crate::syscalls::shutdown(1)
+	crate::__sys_shutdown(1);
 }

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -51,17 +51,6 @@ pub(crate) static SYS: Lazy<&'static dyn SyscallInterface> = Lazy::new(|| {
 	}
 });
 
-/// Shuts down the machine.
-///
-/// This does not require the syscall interface to be initialized.
-pub(crate) fn shutdown(arg: i32) -> ! {
-	if env::is_uhyve() {
-		crate::syscalls::interfaces::Uhyve.shutdown(arg)
-	} else {
-		crate::syscalls::interfaces::Generic.shutdown(arg)
-	}
-}
-
 pub(crate) fn init() {
 	Lazy::force(&SYS);
 


### PR DESCRIPTION
Fixes issue #670.

I removed the shutdown function in src/syscalls/mod.rs as a previous issue #384 had one of the commits implementing early shutdown which was that shutdown function in that particular file. I also removed instances when that shutdown was called, which was in the panic handler, in src/lib.rs, and replaced the shutdown syscall call with crate::__sys_shutdown(1).