### PR TITLE
Make CoreLocal repr(C)

### DIFF
--- a/src/arch/x86_64/kernel/core_local.rs
+++ b/src/arch/x86_64/kernel/core_local.rs
@@ -12,6 +12,7 @@ use super::interrupts::{IrqStatistics, IRQ_COUNTERS};
 use super::CPU_ONLINE;
 use crate::scheduler::{CoreId, PerCoreScheduler};
 
+#[repr(C)]
 pub struct CoreLocal {
 	this: *const Self,
 	/// Sequential ID of this CPU Core.


### PR DESCRIPTION
Addresses #686

Add the `repr(C)` layout specifier to the CoreLocal struct.