### PR TITLE
CI downloads loader for aarch64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,37 +206,24 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: libhermit-rs
-      - name: Checkout loader
-        uses: actions/checkout@v3
+      - name: Download loader
+        uses: dsaltares/fetch-gh-release-asset@1.1.0
         with:
-          repository: hermitcore/rusty-loader
-          path: loader
-      - name: Checkout loader release
-        run: |
-          # Get new tags from remote
-          git fetch --tags
-
-          # Get latest tag name
-          latestTag=$(git describe --tags `git rev-list --tags --max-count=1`)
-
-          # Checkout latest tag
-          git checkout $latestTag
-        working-directory: loader
+          repo: hermitcore/rusty-loader
+          file: rusty-loader-aarch64
       - name: Apply rust-toolchain.toml
         run: rustup show
       - uses: Swatinem/rust-cache@v2
       - name: Build dev profile
         run: cargo build -Zbuild-std=std,panic_abort --target aarch64-unknown-hermit --package hello_world
-      - run: rustup toolchain install nightly-2023-04-05 --target aarch64-unknown-none-softfloat --component llvm-tools-preview
-      - name: Build loader
-        run: cargo +nightly-2023-04-05 xtask build --target aarch64
-        working-directory: loader
-        env:
-          HERMIT_APP: ../../../../target/aarch64-unknown-hermit/debug/hello_world
       - name: Install QEMU
         run: |
           sudo apt-get update
           sudo apt-get install qemu-system-aarch64
-          #- name: Test kernel
-          #run: qemu-system-aarch64 -semihosting -display none -serial stdio -kernel target/aarch64/debug/rusty-loader -machine virt,gic-version=max -m 512M -cpu max -smp 1
-          #working-directory: loader
+      - name: Test kernel
+        run: |
+          qemu-system-aarch64 -semihosting \
+            -display none -serial stdio -kernel rusty-loader-aarch64 -machine virt,gic-version=max \
+            -m 512M -cpu max -smp 1 -display none -serial stdio \
+            -kernel target/aarch64/release/rusty-loader \
+            -device guest-loader,addr=0x48000000,initrd=target/aarch64-unknown-hermit/debug/hello_world

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,6 @@ jobs:
       - name: Test kernel
         run: |
           qemu-system-aarch64 -semihosting \
-            -display none -serial stdio -kernel rusty-loader-aarch64 -machine virt,gic-version=max \
-            -m 512M -cpu max -smp 1 -display none -serial stdio \
-            -kernel target/aarch64/release/rusty-loader \
+            -kernel rusty-loader-aarch64 -machine virt,gic-version=max \
+            -m 512M -cpu max -smp 1 -display none -serial stdio -kernel rusty-loader-aarch64 \
             -device guest-loader,addr=0x48000000,initrd=target/aarch64-unknown-hermit/debug/hello_world


### PR DESCRIPTION
CI use the latest published loader for aarch64. An initrd is used to test the application.