### PR TITLE
virtio-net: Replace AsSliceU8 trait with zerocopy::AsBytes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,6 +374,7 @@ dependencies = [
  "uart_16550",
  "x86",
  "x86_64",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1112,4 +1113,25 @@ dependencies = [
  "llvm-tools",
  "xflags",
  "xshell",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ lock_api = "0.4"
 num = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-derive = "0.3"
+zerocopy = "0.6"
 
 [dependencies.smoltcp]
 version = "0.9"

--- a/src/drivers/net/virtio_net.rs
+++ b/src/drivers/net/virtio_net.rs
@@ -11,6 +11,8 @@ use core::cmp::Ordering;
 use core::mem;
 use core::result::Result;
 
+use zerocopy::AsBytes;
+
 use self::constants::{FeatureSet, Features, NetHdrGSO, Status, MAX_NUM_VQ};
 use self::error::VirtioNetError;
 use crate::arch::kernel::core_local::increment_irq_counter;
@@ -25,7 +27,7 @@ use crate::drivers::virtio::transport::mmio::{ComCfg, IsrStatus, NotifCfg};
 #[cfg(feature = "pci")]
 use crate::drivers::virtio::transport::pci::{ComCfg, IsrStatus, NotifCfg};
 use crate::drivers::virtio::virtqueue::{
-	AsSliceU8, BuffSpec, BufferToken, Bytes, Transfer, Virtq, VqIndex, VqSize, VqType,
+	BuffSpec, BufferToken, Bytes, Transfer, Virtq, VqIndex, VqSize, VqType,
 };
 
 pub const ETH_HDR: usize = 14usize;
@@ -41,7 +43,7 @@ pub struct NetDevCfg {
 	pub features: FeatureSet,
 }
 
-#[derive(Debug)]
+#[derive(AsBytes, Debug)]
 #[repr(C)]
 pub struct VirtioNetHdr {
 	flags: u8,
@@ -57,9 +59,6 @@ pub struct VirtioNetHdr {
 	/// Number of buffers this Packet consists of
 	num_buffers: u16,
 }
-
-// Using the default implementation of the trait for VirtioNetHdr
-impl AsSliceU8 for VirtioNetHdr {}
 
 impl VirtioNetHdr {
 	pub fn get_tx_hdr() -> VirtioNetHdr {

--- a/src/drivers/virtio/virtqueue/mod.rs
+++ b/src/drivers/virtio/virtqueue/mod.rs
@@ -21,6 +21,7 @@ use core::cell::RefCell;
 use core::ops::{BitAnd, Deref, DerefMut};
 
 use align_address::Align;
+use zerocopy::AsBytes;
 
 use self::error::{BufferError, VirtqError};
 use self::packed::PackedVq;
@@ -1683,7 +1684,7 @@ impl BufferToken {
 	///   * Will result in 4 bytes written to the second buffer descriptor of the recv buffer. Nothing is written into the second buffer descriptor.
 	/// * Third Write: `write_seq(Some(10 bytes, Some(4 bytes))`:
 	///   * Will result in 10 bytes written to the second buffer descriptor of the send buffer and 4 bytes written to the third buffer descriptor of the recv buffer.
-	pub fn write_seq<K: AsSliceU8, H: AsSliceU8 + ?Sized>(
+	pub fn write_seq<K: AsBytes, H: AsBytes + ?Sized>(
 		mut self,
 		send_seq: Option<&K>,
 		recv_seq: Option<&H>,
@@ -1691,7 +1692,7 @@ impl BufferToken {
 		if let Some(data) = send_seq {
 			match self.send_buff.as_mut() {
 				Some(buff) => {
-					match buff.next_write(data.as_slice_u8()) {
+					match buff.next_write(data.as_bytes()) {
 						Ok(_) => (), // Do nothing, write fitted inside descriptor and not to many writes to buffer happened
 						Err(_) => {
 							// Need no match here, as result is the same, but for the future one could
@@ -1707,7 +1708,7 @@ impl BufferToken {
 		if let Some(data) = recv_seq {
 			match self.recv_buff.as_mut() {
 				Some(buff) => {
-					match buff.next_write(data.as_slice_u8()) {
+					match buff.next_write(data.as_bytes()) {
 						Ok(_) => (), // Do nothing, write fitted inside descriptor and not to many writes to buffer happened
 						Err(_) => {
 							// Need no match here, as result is the same, but for the future one could


### PR DESCRIPTION
Changed VirtioNetHdr to derive from AsBytes instead of AsSliceU8 and changed related functions as necessary.
