### PR TITLE
add check if the idle task has to give up the processor

### DIFF
--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -520,12 +520,7 @@ impl PerCoreScheduler {
 			// do housekeeping
 			let _ = self.cleanup_tasks();
 
-			let still_idle = {
-				let status = self.current_task.borrow().status;
-				status == TaskStatus::Idle && self.ready_queue.is_empty()
-			};
-
-			if still_idle {
+			if self.ready_queue.is_empty() {
 				if backoff.is_completed() {
 					interrupts::enable_and_wait();
 				} else {

--- a/src/scheduler/task.rs
+++ b/src/scheduler/task.rs
@@ -323,6 +323,11 @@ impl PriorityTaskQueue {
 		Some(task)
 	}
 
+	/// Returns true if the queue is empty.
+	pub fn is_empty(&self) -> bool {
+		self.prio_bitmap == 0
+	}
+
 	/// Pop the task with the highest priority from the queue
 	pub fn pop(&mut self) -> Option<Rc<RefCell<Task>>> {
 		if let Some(i) = msb(self.prio_bitmap) {


### PR DESCRIPTION
- simplifies the run function of the scheduler
- avoids unneeded calls of the function `schedule`