### PR TITLE
revise assertion

### DIFF
--- a/src/arch/aarch64/mm/virtualmem.rs
+++ b/src/arch/aarch64/mm/virtualmem.rs
@@ -85,8 +85,8 @@ pub fn allocate_aligned(size: usize, alignment: usize) -> Result<VirtAddr, Alloc
 
 pub fn deallocate(virtual_address: VirtAddr, size: usize) {
 	assert!(
-		virtual_address >= mm::kernel_end_address(),
-		"Virtual address {:#X} is not >= KERNEL_END_ADDRESS",
+		virtual_address >= mm::kernel_end_address() || virtual_address < mm::kernel_start_address(),
+		"Virtual address {:#X} belongs to the kernel",
 		virtual_address
 	);
 	assert!(


### PR DESCRIPTION
On aarch64, the memory region below the kernel can be used for dynamic allocation.
Consequently, the assertion should allow this region.