### PR TITLE
add option to program the the PCI bars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
             -device vhost-user-fs-pci,queue-size=1024,chardev=char0,tag=root \
             -object memory-backend-file,id=mem,size=1G,mem-path=/dev/shm,share=on -numa node,memdev=mem \
             -initrd target/x86_64-unknown-hermit/release/rusty_demo
-      - name: Build httpd with DHCP support (debug  )
+      - name: Build httpd with DHCP support (debug)
         run:
           cargo build -Zbuild-std=std,panic_abort --target x86_64-unknown-hermit --package httpd --features ci,dhcpv4
       - name: Test httpd with DHCP support (debug, rtl8139)
@@ -271,7 +271,7 @@ jobs:
         run: |
           qemu-system-aarch64 -semihosting \
             -kernel rusty-loader-aarch64 -machine virt,gic-version=max \
-            -m 512M -cpu max -smp 1 -display none -serial stdio -kernel rusty-loader-aarch64 \
+            -m 512M -cpu max -smp 1 -display none -serial stdio \
             -device guest-loader,addr=0x48000000,initrd=target/aarch64-unknown-hermit/debug/rusty_demo
       - name: Build release profile
         run: cargo build -Zbuild-std=std,panic_abort --target aarch64-unknown-hermit --package rusty_demo --release --features pci-ids
@@ -279,5 +279,33 @@ jobs:
         run: |
           qemu-system-aarch64 -semihosting \
             -kernel rusty-loader-aarch64 -machine virt,gic-version=max \
-            -m 512M -cpu max -smp 1 -display none -serial stdio -kernel rusty-loader-aarch64 \
+            -m 512M -cpu max -smp 1 -display none -serial stdio \
             -device guest-loader,addr=0x48000000,initrd=target/aarch64-unknown-hermit/release/rusty_demo
+      - name: Build httpd with DHCP support (debug)
+        run:
+          cargo build -Zbuild-std=std,panic_abort --target aarch64-unknown-hermit --package httpd --features ci,dhcpv4
+      - name: Test httpd with DHCP support (debug, virtio-net)
+        run: |
+          qemu-system-aarch64 -semihosting \
+            -kernel rusty-loader-aarch64 -machine virt,gic-version=max \
+            -m 512M -cpu max -smp 1 -display none -serial stdio \
+            -device guest-loader,addr=0x48000000,initrd=target/aarch64-unknown-hermit/debug/httpd \
+            -netdev user,id=u1,hostfwd=tcp::9975-:9975,net=192.168.76.0/24,dhcpstart=192.168.76.9 \
+            -device virtio-net-pci,netdev=u1,disable-legacy=on &
+            sleep 5
+            curl http://127.0.0.1:9975/help
+            sleep 1
+      - name: Build httpd with DHCP support (release)
+        run:
+          cargo build -Zbuild-std=std,panic_abort --target aarch64-unknown-hermit --package httpd --release --features ci,dhcpv4
+      - name: Test httpd with DHCP support (release, virtio-net)
+        run: |
+          qemu-system-aarch64 -semihosting \
+            -kernel rusty-loader-aarch64 -machine virt,gic-version=max \
+            -m 512M -cpu max -smp 1 -display none -serial stdio \
+            -device guest-loader,addr=0x48000000,initrd=target/aarch64-unknown-hermit/release/httpd \
+            -netdev user,id=u1,hostfwd=tcp::9975-:9975,net=192.168.76.0/24,dhcpstart=192.168.76.9 \
+            -device virtio-net-pci,netdev=u1,disable-legacy=on &
+            sleep 5
+            curl http://127.0.0.1:9975/help
+            sleep 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,8 +560,9 @@ dependencies = [
 
 [[package]]
 name = "pci_types"
-version = "0.4.0"
-source = "git+https://github.com/hermitcore/pci_types.git?branch=hermit#87f0e23e0e4a6afc11674e5a2f8847188244ae69"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec74736768a26e78cdc5d8d54b32ab60dd5ed82aef39c4e00c47e78145b90fa4"
 dependencies = [
  "bit_field",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -356,6 +356,7 @@ dependencies = [
  "align-address",
  "arm-gic",
  "async-task",
+ "bit_field",
  "bitflags 2.3.1",
  "crossbeam-utils",
  "dyn-clone",
@@ -396,9 +397,9 @@ checksum = "9afa463f5405ee81cdb9cc2baf37e08ec7e4c8209442b5d72c04cfb2cd6e6286"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "llvm-tools"
@@ -535,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
 
 [[package]]
 name = "paste"
@@ -658,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
 ]
@@ -673,9 +674,9 @@ checksum = "9ff023245bfcc73fb890e1f8d5383825b3131cc920020a5c487d6f113dfc428a"
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -838,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -877,7 +878,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -914,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ dhcpv4 = [
 ahash = { version = "0.8", default-features = false }
 align-address = "0.1"
 bitflags = "2.3"
+bit_field = "0.10"
 crossbeam-utils = { version = "0.8", default-features = false }
 dyn-clone = "1.0"
 hashbrown = { version = "0.13", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ num-traits = { version = "0.2", default-features = false }
 num-derive = "0.3"
 zerocopy = "0.6"
 time = { version = "0.3", default-features = false }
-pci_types = { git = "https://github.com/hermitcore/pci_types.git", branch = "hermit" }
+pci_types = { version = "0.5" }
 
 [dependencies.smoltcp]
 version = "0.9"

--- a/src/arch/aarch64/kernel/mod.rs
+++ b/src/arch/aarch64/kernel/mod.rs
@@ -15,14 +15,12 @@ use core::arch::{asm, global_asm};
 use core::ptr;
 use core::sync::atomic::{AtomicU32, Ordering};
 
-use hermit_entry::boot_info::{BootInfo, PlatformInfo, RawBootInfo};
-use hermit_sync::TicketMutex;
+use hermit_entry::boot_info::{BootInfo, RawBootInfo};
 
 use crate::arch::aarch64::kernel::core_local::*;
 use crate::arch::aarch64::kernel::serial::SerialPort;
 pub use crate::arch::aarch64::kernel::systemtime::get_boot_time;
 use crate::arch::aarch64::mm::{PhysAddr, VirtAddr};
-use crate::config::*;
 use crate::env;
 
 const SERIAL_PORT_BAUDRATE: u32 = 115200;

--- a/src/arch/aarch64/kernel/pci.rs
+++ b/src/arch/aarch64/kernel/pci.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 use core::{str, u32, u64, u8};
 
-use arm_gic::gicv3::IntId;
+use arm_gic::gicv3::{IntId, Trigger};
 use hermit_dtb::Dtb;
 use pci_types::{
 	Bar, ConfigRegionAccess, InterruptLine, InterruptPin, PciAddress, PciHeader, MAX_BARS,
@@ -208,6 +208,13 @@ fn detect_interrupt(
 				let irq_id = IntId::spi(irq_number.into());
 				let gic = unsafe { GIC.get_mut().unwrap() };
 				gic.set_interrupt_priority(irq_id, 0x10);
+				if irq_flags == 4 {
+					gic.set_trigger(irq_id, Trigger::Level);
+				} else if irq_flags == 2 {
+					gic.set_trigger(irq_id, Trigger::Edge);
+				} else {
+					panic!("Invalid interrupt level!");
+				}
 				gic.enable_interrupt(irq_id, true);
 
 				return Some((pin, irq_number.try_into().unwrap()));

--- a/src/arch/aarch64/kernel/processor.rs
+++ b/src/arch/aarch64/kernel/processor.rs
@@ -110,30 +110,8 @@ pub fn seed_entropy() -> Option<[u8; 32]> {
 	None
 }
 
-pub fn run_on_hypervisor() -> bool {
+pub(crate) fn run_on_hypervisor() -> bool {
 	true
-}
-
-/// Search the most significant bit
-#[inline(always)]
-pub fn msb(value: u64) -> Option<u64> {
-	if value > 0 {
-		let ret: u64;
-
-		unsafe {
-			asm!(
-				"clz {0}, {1}",
-				"sub {0}, {2}, {0}",
-				out(reg) ret,
-				in(reg) value,
-				const 64 - 1,
-				options(nostack, nomem),
-			);
-		}
-		Some(ret)
-	} else {
-		None
-	}
 }
 
 /// The halt function stops the processor until the next interrupt arrives
@@ -292,5 +270,8 @@ pub fn print_information() {
 	infoheader!(" CPU INFORMATION ");
 	infoentry!("Processor compatiblity", str::from_utf8(reg).unwrap());
 	infoentry!("Counter frequency", *CPU_FREQUENCY);
+	if run_on_hypervisor() {
+		info!("Run on hypervisor");
+	}
 	infofooter!();
 }

--- a/src/arch/aarch64/kernel/processor.rs
+++ b/src/arch/aarch64/kernel/processor.rs
@@ -100,10 +100,6 @@ impl FPUState {
 	pub fn new() -> Self {
 		Self {}
 	}
-
-	pub fn restore(&self) {}
-
-	pub fn save(&self) {}
 }
 
 pub fn seed_entropy() -> Option<[u8; 32]> {

--- a/src/arch/aarch64/kernel/start.rs
+++ b/src/arch/aarch64/kernel/start.rs
@@ -20,18 +20,20 @@ pub unsafe extern "C" fn _start(boot_info: &'static RawBootInfo, cpu_id: u32) ->
 	const _START: Entry = _start;
 	const _PRE_INIT: Entry = pre_init;
 
-	asm!(
-		// Add stack top offset
-		"mov x8, {stack_top_offset}",
-		"add sp, sp, x8",
+	unsafe {
+		asm!(
+			// Add stack top offset
+			"mov x8, {stack_top_offset}",
+			"add sp, sp, x8",
 
-		// Jump to Rust code
-		"b {pre_init}",
+			// Jump to Rust code
+			"b {pre_init}",
 
-		stack_top_offset = const KERNEL_STACK_SIZE - TaskStacks::MARKER_SIZE,
-		pre_init = sym pre_init,
-		options(noreturn),
-	)
+			stack_top_offset = const KERNEL_STACK_SIZE - TaskStacks::MARKER_SIZE,
+			pre_init = sym pre_init,
+			options(noreturn),
+		)
+	}
 }
 
 #[inline(never)]
@@ -43,14 +45,16 @@ unsafe extern "C" fn pre_init(boot_info: &'static RawBootInfo, cpu_id: u32) -> !
 	}
 
 	// set exception table
-	asm!(
-		"adrp x4, {vector_table}",
-		"add  x4, x4, #:lo12:{vector_table}",
-		"msr vbar_el1, x4",
-		vector_table = sym vector_table,
-		out("x4") _,
-		options(nostack),
-	);
+	unsafe {
+		asm!(
+			"adrp x4, {vector_table}",
+			"add  x4, x4, #:lo12:{vector_table}",
+			"msr vbar_el1, x4",
+			vector_table = sym vector_table,
+			out("x4") _,
+			options(nostack),
+		);
+	}
 
 	// Memory barrier
 	asm!("dsb sy", options(nostack),);

--- a/src/arch/aarch64/kernel/switch.rs
+++ b/src/arch/aarch64/kernel/switch.rs
@@ -2,7 +2,9 @@ use core::arch::asm;
 
 #[inline(always)]
 pub unsafe extern "C" fn switch_to_fpu_owner(old_stack: *mut usize, new_stack: usize) {
-	switch_to_task(old_stack, new_stack);
+	unsafe {
+		switch_to_task(old_stack, new_stack);
+	}
 }
 
 #[naked]

--- a/src/arch/aarch64/kernel/systemtime.rs
+++ b/src/arch/aarch64/kernel/systemtime.rs
@@ -1,3 +1,5 @@
+#![allow(unused)]
+
 use alloc::vec::Vec;
 use core::arch::asm;
 use core::str;

--- a/src/arch/aarch64/mm/paging.rs
+++ b/src/arch/aarch64/mm/paging.rs
@@ -1,3 +1,5 @@
+#![allow(unused)]
+
 use core::arch::asm;
 use core::marker::PhantomData;
 use core::{fmt, mem, ptr, usize};

--- a/src/arch/aarch64/mm/physicalmem.rs
+++ b/src/arch/aarch64/mm/physicalmem.rs
@@ -3,10 +3,9 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 
 use hermit_sync::InterruptTicketMutex;
 
-use crate::arch::aarch64::kernel::{get_boot_info_address, get_limit, get_ram_address};
+use crate::arch::aarch64::kernel::{get_limit, get_ram_address};
 use crate::arch::aarch64::mm::paging::{BasePageSize, PageSize};
-use crate::arch::aarch64::mm::{PhysAddr, VirtAddr};
-use crate::env::is_uhyve;
+use crate::arch::aarch64::mm::PhysAddr;
 use crate::mm;
 use crate::mm::freelist::{FreeList, FreeListEntry};
 

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -62,6 +62,28 @@ pub use crate::arch::x86_64::kernel::{
 #[cfg(target_arch = "x86_64")]
 pub use crate::arch::x86_64::*;
 
+/// Force strict CPU ordering, serializes load and store operations.
+#[allow(dead_code)]
+#[cfg(target_arch = "aarch64")]
+#[inline(always)]
+pub(crate) fn memory_barrier() {
+	use core::arch::asm;
+	unsafe {
+		asm!("dmb ish", options(nostack, nomem, preserves_flags),);
+	}
+}
+
+/// Force strict CPU ordering, serializes load and store operations.
+#[allow(dead_code)]
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+pub(crate) fn memory_barrier() {
+	use core::arch::asm;
+	unsafe {
+		asm!("mfence", options(nostack, nomem, preserves_flags),);
+	}
+}
+
 pub fn init_drivers() {
 	// Initialize PCI Drivers for x86_64
 	#[cfg(feature = "pci")]

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -64,7 +64,7 @@ pub use crate::arch::x86_64::*;
 
 pub fn init_drivers() {
 	// Initialize PCI Drivers for x86_64
-	#[cfg(all(target_arch = "x86_64", feature = "pci"))]
+	#[cfg(feature = "pci")]
 	crate::drivers::pci::init_drivers();
 	#[cfg(all(target_arch = "x86_64", not(feature = "pci")))]
 	crate::arch::x86_64::kernel::mmio::init_drivers();

--- a/src/arch/x86_64/kernel/processor.rs
+++ b/src/arch/x86_64/kernel/processor.rs
@@ -665,7 +665,7 @@ impl fmt::Display for CpuFeaturePrinter {
 	}
 }
 
-pub fn run_on_hypervisor() -> bool {
+pub(crate) fn run_on_hypervisor() -> bool {
 	env::is_uhyve() || FEATURES.run_on_hypervisor
 }
 

--- a/src/drivers/fs/virtio_pci.rs
+++ b/src/drivers/fs/virtio_pci.rs
@@ -113,7 +113,7 @@ impl VirtioFsDriver {
 			notif_cfg,
 			vqueues: Vec::new(),
 			ready_queue: Vec::new(),
-			irq: device.irq().unwrap(),
+			irq: device.get_irq().unwrap(),
 		})
 	}
 

--- a/src/drivers/net/rtl8139.rs
+++ b/src/drivers/net/rtl8139.rs
@@ -16,7 +16,7 @@ use crate::arch::mm::VirtAddr;
 use crate::arch::pci::PciConfigRegion;
 use crate::drivers::error::DriverError;
 use crate::drivers::net::{network_irqhandler, NetworkInterface};
-use crate::drivers::pci::PciDevice;
+use crate::drivers::pci::{PciCommand, PciDevice};
 
 /// size of the receive buffer
 const RX_BUF_LEN: usize = 8192;
@@ -438,7 +438,7 @@ pub(crate) fn init_device(
 	let mut iobase: Option<u32> = None;
 
 	for i in 0..MAX_BARS {
-		if let Some(Bar::Io { port }) = device.bar(i.try_into().unwrap()) {
+		if let Some(Bar::Io { port }) = device.get_bar(i.try_into().unwrap()) {
 			iobase = Some(port)
 		}
 	}
@@ -450,7 +450,7 @@ pub(crate) fn init_device(
 
 	debug!("Found RTL8139 at iobase {:#x} (irq {})", iobase, irq);
 
-	device.make_bus_master();
+	device.set_command(PciCommand::PCI_COMMAND_MASTER);
 
 	let mac: [u8; 6] = unsafe {
 		[

--- a/src/drivers/net/rtl8139.rs
+++ b/src/drivers/net/rtl8139.rs
@@ -434,7 +434,7 @@ impl Drop for RTL8139Driver {
 pub(crate) fn init_device(
 	device: &PciDevice<PciConfigRegion>,
 ) -> Result<RTL8139Driver, DriverError> {
-	let irq = device.irq().unwrap();
+	let irq = device.get_irq().unwrap();
 	let mut iobase: Option<u32> = None;
 
 	for i in 0..MAX_BARS {

--- a/src/drivers/net/virtio_net.rs
+++ b/src/drivers/net/virtio_net.rs
@@ -764,7 +764,7 @@ impl VirtioNetDriver {
 		// Reset
 		self.com_cfg.reset_dev();
 
-		// Indiacte device, that OS noticed it
+		// Indicate device, that OS noticed it
 		self.com_cfg.ack_dev();
 
 		// Indicate device, that driver is able to handle it

--- a/src/drivers/net/virtio_net.rs
+++ b/src/drivers/net/virtio_net.rs
@@ -799,7 +799,7 @@ impl VirtioNetDriver {
 		// feats.push(Features::VIRTIO_NET_F_GUEST_TSO6);
 
 		// Negotiate features with device. Automatically reduces selected feats in order to meet device capabilities.
-		// Aborts in case incompatible features are selected by the dricer or the device does not support min_feat_set.
+		// Aborts in case incompatible features are selected by the driver or the device does not support min_feat_set.
 		match self.negotiate_features(&feats) {
 			Ok(_) => info!(
 				"Driver found a subset of features for virtio device {:x}. Features are: {:?}",

--- a/src/drivers/net/virtio_pci.rs
+++ b/src/drivers/net/virtio_pci.rs
@@ -149,7 +149,7 @@ impl VirtioNetDriver {
 				false,
 			),
 			num_vqs: 0,
-			irq: device.irq().unwrap(),
+			irq: device.get_irq().unwrap(),
 			polling_mode_counter: 0,
 		})
 	}

--- a/src/drivers/net/virtio_pci.rs
+++ b/src/drivers/net/virtio_pci.rs
@@ -10,7 +10,7 @@ use core::cell::RefCell;
 use crate::arch::pci::PciConfigRegion;
 use crate::drivers::net::virtio_net::constants::FeatureSet;
 use crate::drivers::net::virtio_net::{CtrlQueue, NetDevCfg, RxQueues, TxQueues, VirtioNetDriver};
-use crate::drivers::pci::PciDevice;
+use crate::drivers::pci::{PciCommand, PciDevice};
 use crate::drivers::virtio::error::{self, VirtioError};
 use crate::drivers::virtio::transport::pci;
 use crate::drivers::virtio::transport::pci::{PciCap, UniCapsColl};
@@ -165,6 +165,9 @@ impl VirtioNetDriver {
 	pub(crate) fn init(
 		device: &PciDevice<PciConfigRegion>,
 	) -> Result<VirtioNetDriver, VirtioError> {
+		// enable bus master mode
+		device.set_command(PciCommand::PCI_COMMAND_MASTER);
+
 		let mut drv = match pci::map_caps(device) {
 			Ok(caps) => match VirtioNetDriver::new(caps, device) {
 				Ok(driver) => driver,

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -3,6 +3,7 @@
 use alloc::vec::Vec;
 use core::fmt;
 
+use bitflags::bitflags;
 use hermit_sync::{without_interrupts, InterruptTicketMutex};
 use pci_types::{
 	Bar, ConfigRegionAccess, DeviceId, EndpointHeader, InterruptLine, PciAddress, PciHeader,
@@ -45,65 +46,92 @@ pub(crate) mod constants {
 	pub(crate) const PCI_CONFIG_DATA_PORT: u16 = 0xCFC;
 	pub(crate) const PCI_CAP_ID_VNDR_VIRTIO: u32 = 0x09;
 	pub(crate) const PCI_MASK_IS_DEV_BUS_MASTER: u32 = 0x0000_0004u32;
-	pub(crate) const PCI_COMMAND_BUSMASTER: u32 = 1 << 2;
+}
 
-	/// PCI registers offset inside header,
-	/// if PCI header is of type 00h.
-	#[allow(dead_code, non_camel_case_types)]
-	#[repr(u16)]
-	pub enum RegisterHeader {
-		PCI_ID_REGISTER = 0x00u16,
-		PCI_COMMAND_REGISTER = 0x04u16,
-		PCI_CLASS_REGISTER = 0x08u16,
-		PCI_HEADER_REGISTER = 0x0Cu16,
-		PCI_BAR0_REGISTER = 0x10u16,
-		PCI_CAPABILITY_LIST_REGISTER = 0x34u16,
-		PCI_INTERRUPT_REGISTER = 0x3Cu16,
+bitflags! {
+	#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+	pub struct PciCommand: u32 {
+		/// Enable response in I/O space
+		const PCI_COMMAND_IO = 0x1;
+		/// Enable response in Memory space
+		const PCI_COMMAND_MEMORY = 0x2;
+		/// Enable bus mastering
+		const PCI_COMMAND_MASTER = 0x4;
+		/// Enable response to special cycles
+		const PCI_COMMAND_SPECIAL = 0x8;
+		// Use memory write and invalidate
+		const PCI_COMMAND_INVALIDATE = 0x10;
+		/// Enable palette snooping
+		const PCI_COMMAND_VGA_PALETTE = 0x20;
+		/// Enable parity checking
+		const PCI_COMMAND_PARITY = 0x40;
+		/// Enable address/data stepping
+		const PCI_COMMAND_WAIT = 0x80;
+		/// Enable SERR
+		const PCI_COMMAND_SERR = 0x100;
+		/// Enable back-to-back writes
+		const PCI_COMMAND_FAST_BACK = 0x200;
+		/// INTx Emulation Disable
+		const PCI_COMMAND_INTX_DISABLE = 0x400;
 	}
+}
 
-	impl From<RegisterHeader> for u16 {
-		fn from(val: RegisterHeader) -> u16 {
-			match val {
-				RegisterHeader::PCI_ID_REGISTER => 0x00u16,
-				RegisterHeader::PCI_COMMAND_REGISTER => 0x04u16,
-				RegisterHeader::PCI_CLASS_REGISTER => 0x08u16,
-				RegisterHeader::PCI_HEADER_REGISTER => 0x0Cu16,
-				RegisterHeader::PCI_BAR0_REGISTER => 0x10u16,
-				RegisterHeader::PCI_CAPABILITY_LIST_REGISTER => 0x34u16,
-				RegisterHeader::PCI_INTERRUPT_REGISTER => 0x3Cu16,
-			}
+/// PCI registers offset inside header,
+/// if PCI header is of type 00h (general device).
+#[allow(dead_code, non_camel_case_types)]
+#[repr(u16)]
+pub enum DeviceHeader {
+	PCI_ID_REGISTER = 0x00u16,
+	PCI_COMMAND_REGISTER = 0x04u16,
+	PCI_CLASS_REGISTER = 0x08u16,
+	PCI_HEADER_REGISTER = 0x0Cu16,
+	PCI_BAR0_REGISTER = 0x10u16,
+	PCI_CAPABILITY_LIST_REGISTER = 0x34u16,
+	PCI_INTERRUPT_REGISTER = 0x3Cu16,
+}
+
+impl From<DeviceHeader> for u16 {
+	fn from(val: DeviceHeader) -> u16 {
+		match val {
+			DeviceHeader::PCI_ID_REGISTER => 0x00u16,
+			DeviceHeader::PCI_COMMAND_REGISTER => 0x04u16,
+			DeviceHeader::PCI_CLASS_REGISTER => 0x08u16,
+			DeviceHeader::PCI_HEADER_REGISTER => 0x0Cu16,
+			DeviceHeader::PCI_BAR0_REGISTER => 0x10u16,
+			DeviceHeader::PCI_CAPABILITY_LIST_REGISTER => 0x34u16,
+			DeviceHeader::PCI_INTERRUPT_REGISTER => 0x3Cu16,
 		}
 	}
+}
 
-	/// PCI masks. For convenience put into an enum and provides
-	/// an `Into<u32>` method for usage.
-	#[allow(dead_code, non_camel_case_types)]
-	#[repr(u32)]
-	pub enum Masks {
-		PCI_MASK_IS_BAR_IO_BAR = 0x0000_0001u32,
-		PCI_MASK_IS_MEM_BASE_ADDRESS_64BIT = 0x0000_0004u32,
-		PCI_MASK_IS_MEM_BAR_PREFETCHABLE = 0x0000_0008u32,
-		PCI_MASK_STATUS_CAPABILITIES_LIST = 0x0000_0010u32,
-		PCI_MASK_CAPLIST_POINTER = 0x0000_00FCu32,
-		PCI_MASK_HEADER_TYPE = 0x007F_0000u32,
-		PCI_MASK_MULTIFUNCTION = 0x0080_0000u32,
-		PCI_MASK_MEM_BASE_ADDRESS = 0xFFFF_FFF0u32,
-		PCI_MASK_IO_BASE_ADDRESS = 0xFFFF_FFFCu32,
-	}
+/// PCI masks. For convenience put into an enum and provides
+/// an `Into<u32>` method for usage.
+#[allow(dead_code, non_camel_case_types)]
+#[repr(u32)]
+pub enum Masks {
+	PCI_MASK_IS_BAR_IO_BAR = 0x0000_0001u32,
+	PCI_MASK_IS_MEM_BASE_ADDRESS_64BIT = 0x0000_0004u32,
+	PCI_MASK_IS_MEM_BAR_PREFETCHABLE = 0x0000_0008u32,
+	PCI_MASK_STATUS_CAPABILITIES_LIST = 0x0000_0010u32,
+	PCI_MASK_CAPLIST_POINTER = 0x0000_00FCu32,
+	PCI_MASK_HEADER_TYPE = 0x007F_0000u32,
+	PCI_MASK_MULTIFUNCTION = 0x0080_0000u32,
+	PCI_MASK_MEM_BASE_ADDRESS = 0xFFFF_FFF0u32,
+	PCI_MASK_IO_BASE_ADDRESS = 0xFFFF_FFFCu32,
+}
 
-	impl From<Masks> for u32 {
-		fn from(val: Masks) -> u32 {
-			match val {
-				Masks::PCI_MASK_STATUS_CAPABILITIES_LIST => 0x0000_0010u32,
-				Masks::PCI_MASK_CAPLIST_POINTER => 0x0000_00FCu32,
-				Masks::PCI_MASK_HEADER_TYPE => 0x007F_0000u32,
-				Masks::PCI_MASK_MULTIFUNCTION => 0x0080_0000u32,
-				Masks::PCI_MASK_MEM_BASE_ADDRESS => 0xFFFF_FFF0u32,
-				Masks::PCI_MASK_IO_BASE_ADDRESS => 0xFFFF_FFFCu32,
-				Masks::PCI_MASK_IS_MEM_BAR_PREFETCHABLE => 0x0000_0008u32,
-				Masks::PCI_MASK_IS_MEM_BASE_ADDRESS_64BIT => 0x0000_0004u32,
-				Masks::PCI_MASK_IS_BAR_IO_BAR => 0x0000_0001u32,
-			}
+impl From<Masks> for u32 {
+	fn from(val: Masks) -> u32 {
+		match val {
+			Masks::PCI_MASK_STATUS_CAPABILITIES_LIST => 0x0000_0010u32,
+			Masks::PCI_MASK_CAPLIST_POINTER => 0x0000_00FCu32,
+			Masks::PCI_MASK_HEADER_TYPE => 0x007F_0000u32,
+			Masks::PCI_MASK_MULTIFUNCTION => 0x0080_0000u32,
+			Masks::PCI_MASK_MEM_BASE_ADDRESS => 0xFFFF_FFF0u32,
+			Masks::PCI_MASK_IO_BASE_ADDRESS => 0xFFFF_FFFCu32,
+			Masks::PCI_MASK_IS_MEM_BAR_PREFETCHABLE => 0x0000_0008u32,
+			Masks::PCI_MASK_IS_MEM_BASE_ADDRESS_64BIT => 0x0000_0004u32,
+			Masks::PCI_MASK_IS_BAR_IO_BAR => 0x0000_0001u32,
 		}
 	}
 }
@@ -130,24 +158,34 @@ impl<T: ConfigRegionAccess> PciDevice<T> {
 		unsafe { self.access.write(self.address, register, value) }
 	}
 
-	pub fn make_bus_master(&self) {
-		use crate::drivers::pci::constants::{RegisterHeader, PCI_COMMAND_BUSMASTER};
-
+	/// Set flag to the command register
+	pub fn set_command(&self, cmd: PciCommand) {
 		unsafe {
 			let mut command = self
 				.access
-				.read(self.address, RegisterHeader::PCI_COMMAND_REGISTER.into());
-			command |= PCI_COMMAND_BUSMASTER;
+				.read(self.address, DeviceHeader::PCI_COMMAND_REGISTER.into());
+			command |= cmd.bits();
 			self.access.write(
 				self.address,
-				RegisterHeader::PCI_COMMAND_REGISTER.into(),
+				DeviceHeader::PCI_COMMAND_REGISTER.into(),
 				command,
 			)
 		}
 	}
 
+	/// Get value of the command register
+	pub fn get_command(&self) -> PciCommand {
+		unsafe {
+			PciCommand::from_bits(
+				self.access
+					.read(self.address, DeviceHeader::PCI_COMMAND_REGISTER.into()),
+			)
+			.unwrap()
+		}
+	}
+
 	/// Returns the bar at bar-register `slot`.
-	pub fn bar(&self, slot: u8) -> Option<Bar> {
+	pub fn get_bar(&self, slot: u8) -> Option<Bar> {
 		let header = PciHeader::new(self.address);
 		if let Some(endpoint) = EndpointHeader::from_header(header, &self.access) {
 			return endpoint.bar(slot, &self.access);
@@ -156,11 +194,57 @@ impl<T: ConfigRegionAccess> PciDevice<T> {
 		None
 	}
 
+	/// Configure the bar at register `slot`
+	#[allow(unused_variables)]
+	pub fn set_bar(&self, slot: u8, bar: Bar) {
+		let cmd = u16::from(DeviceHeader::PCI_BAR0_REGISTER) + u16::from(slot) * 4;
+		match bar {
+			Bar::Io { port } => unsafe {
+				self.access.write(self.address, cmd, port | 1);
+			},
+			Bar::Memory32 {
+				address,
+				size,
+				prefetchable,
+			} => {
+				if prefetchable {
+					unsafe {
+						self.access.write(self.address, cmd, address | 1 << 3);
+					}
+				} else {
+					unsafe {
+						self.access.write(self.address, cmd, address);
+					}
+				}
+			}
+			Bar::Memory64 {
+				address,
+				size,
+				prefetchable,
+			} => {
+				let high: u32 = (address >> 32).try_into().unwrap();
+				let low: u32 = (address & 0xFFFF_FFF0u64).try_into().unwrap();
+				if prefetchable {
+					unsafe {
+						self.access.write(self.address, cmd, low | 2 << 1 | 1 << 3);
+					}
+				} else {
+					unsafe {
+						self.access.write(self.address, cmd, low | 2 << 1);
+					}
+				}
+				unsafe {
+					self.access.write(self.address, cmd + 4, high);
+				}
+			}
+		}
+	}
+
 	/// Memory maps pci bar with specified index to identical location in virtual memory.
 	/// no_cache determines if we set the `Cache Disable` flag in the page-table-entry.
 	/// Returns (virtual-pointer, size) if successful, else None (if bar non-existent or IOSpace)
 	pub fn memory_map_bar(&self, index: u8, no_cache: bool) -> Option<(VirtAddr, usize)> {
-		let (address, size, prefetchable, width) = match self.bar(index) {
+		let (address, size, prefetchable, width) = match self.get_bar(index) {
 			Some(Bar::Io { .. }) => {
 				warn!("Cannot map IOBar!");
 				return None;
@@ -397,7 +481,6 @@ pub(crate) fn get_filesystem_driver() -> Option<&'static InterruptTicketMutex<Vi
 	}
 }
 
-#[cfg(not(target_arch = "aarch64"))]
 pub(crate) fn init_drivers() {
 	let mut nic_available = false;
 

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -312,7 +312,7 @@ impl<T: ConfigRegionAccess> PciDevice<T> {
 			let mut command = self
 				.access
 				.read(self.address, DeviceHeader::PCI_INTERRUPT_REGISTER.into());
-			command = command & 0xFFFF_0000u32;
+			command &= 0xFFFF_0000u32;
 			command |= u32::from(line);
 			command |= u32::from(pin) << 8;
 			self.access.write(
@@ -320,9 +320,6 @@ impl<T: ConfigRegionAccess> PciDevice<T> {
 				DeviceHeader::PCI_INTERRUPT_REGISTER.into(),
 				command,
 			);
-			let command = self
-				.access
-				.read(self.address, DeviceHeader::PCI_INTERRUPT_REGISTER.into());
 		}
 	}
 

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -49,7 +49,7 @@ pub(crate) mod constants {
 }
 
 bitflags! {
-	#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+	#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 	pub struct PciCommand: u32 {
 		/// Enable response in I/O space
 		const PCI_COMMAND_IO = 0x1;
@@ -69,9 +69,9 @@ bitflags! {
 		const PCI_COMMAND_WAIT = 0x80;
 		/// Enable SERR
 		const PCI_COMMAND_SERR = 0x100;
-		/// Enable back-to-back writes
+		///  Device is allowed to generate fast back-to-back transactions;
 		const PCI_COMMAND_FAST_BACK = 0x200;
-		/// INTx Emulation Disable
+		/// INTx# signal is disabled
 		const PCI_COMMAND_INTX_DISABLE = 0x400;
 	}
 }

--- a/src/drivers/virtio/env.rs
+++ b/src/drivers/virtio/env.rs
@@ -204,7 +204,7 @@ pub mod pci {
 		let mut mapped_bars: Vec<VirtioPciBar> = Vec::new();
 
 		for i in 0..MAX_BARS {
-			match device.bar(i.try_into().unwrap()) {
+			match device.get_bar(i.try_into().unwrap()) {
 				Some(Bar::Io { .. }) => {
 					warn!("Cannot map I/O BAR!");
 					continue;

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -587,7 +587,7 @@ impl ComCfgRaw {
 			error!("Common config of with id {} of device {:x}, does not fit into memory specified by bar {:x}!", 
                 cap.id,
                 cap.origin.dev_id,
-                 cap.bar.index
+                cap.bar.index
             );
 			return None;
 		}

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -8,6 +8,7 @@ use core::mem;
 use core::result::Result;
 
 use crate::arch::kernel::interrupts::*;
+use crate::arch::memory_barrier;
 use crate::arch::mm::PhysAddr;
 use crate::arch::pci::PciConfigRegion;
 use crate::drivers::error::DriverError;
@@ -463,6 +464,7 @@ impl ComCfg {
 
 	/// Resets the device status field to zero.
 	pub fn reset_dev(&mut self) {
+		memory_barrier();
 		self.com_cfg.device_status = 0;
 	}
 
@@ -470,18 +472,21 @@ impl ComCfg {
 	/// A driver MUST NOT initialize and use the device any further after this.
 	/// A driver MAY use the device again after a proper reset of the device.
 	pub fn set_failed(&mut self) {
+		memory_barrier();
 		self.com_cfg.device_status = u8::from(device::Status::FAILED);
 	}
 
 	/// Sets the ACKNOWLEDGE bit in the device status field. This indicates, the
 	/// OS has notived the device
 	pub fn ack_dev(&mut self) {
+		memory_barrier();
 		self.com_cfg.device_status |= u8::from(device::Status::ACKNOWLEDGE);
 	}
 
 	/// Sets the DRIVER bit in the device status field. This indicates, the OS
 	/// know how to run this device.
 	pub fn set_drv(&mut self) {
+		memory_barrier();
 		self.com_cfg.device_status |= u8::from(device::Status::DRIVER);
 	}
 
@@ -489,6 +494,7 @@ impl ComCfg {
 	///
 	/// Drivers MUST NOT accept new features after this step.
 	pub fn features_ok(&mut self) {
+		memory_barrier();
 		self.com_cfg.device_status |= u8::from(device::Status::FEATURES_OK);
 	}
 
@@ -499,6 +505,7 @@ impl ComCfg {
 	/// Re-reads device status to ensure the FEATURES_OK bit is still set:
 	/// otherwise, the device does not support our subset of features and the device is unusable.
 	pub fn check_features(&self) -> bool {
+		memory_barrier();
 		self.com_cfg.device_status & u8::from(device::Status::FEATURES_OK)
 			== u8::from(device::Status::FEATURES_OK)
 	}
@@ -507,6 +514,7 @@ impl ComCfg {
 	///
 	/// After this call, the device is "live"!
 	pub fn drv_ok(&mut self) {
+		memory_barrier();
 		self.com_cfg.device_status |= u8::from(device::Status::DRIVER_OK);
 	}
 
@@ -514,7 +522,9 @@ impl ComCfg {
 	pub fn dev_features(&mut self) -> u64 {
 		// Indicate device to show high 32 bits in device_feature field.
 		// See Virtio specification v1.1. - 4.1.4.3
+		memory_barrier();
 		self.com_cfg.device_feature_select = 1;
+		memory_barrier();
 
 		// read high 32 bits of device features
 		let mut dev_feat = u64::from(self.com_cfg.device_feature) << 32;
@@ -522,6 +532,7 @@ impl ComCfg {
 		// Indicate device to show low 32 bits in device_feature field.
 		// See Virtio specification v1.1. - 4.1.4.3
 		self.com_cfg.device_feature_select = 0;
+		memory_barrier();
 
 		// read low 32 bits of device features
 		dev_feat |= u64::from(self.com_cfg.device_feature);
@@ -536,7 +547,9 @@ impl ComCfg {
 
 		// Indicate to device that driver_features field shows low 32 bits.
 		// See Virtio specification v1.1. - 4.1.4.3
+		memory_barrier();
 		self.com_cfg.driver_feature_select = 0;
+		memory_barrier();
 
 		// write low 32 bits of device features
 		self.com_cfg.driver_feature = low;
@@ -544,6 +557,7 @@ impl ComCfg {
 		// Indicate to device that driver_features field shows high 32 bits.
 		// See Virtio specification v1.1. - 4.1.4.3
 		self.com_cfg.driver_feature_select = 1;
+		memory_barrier();
 
 		// write high 32 bits of device features
 		self.com_cfg.driver_feature = high;

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -1281,7 +1281,7 @@ pub(crate) fn init_device(
 		Ok(drv) => {
 			match &drv {
 				VirtioDriver::Network(_) => {
-					let irq = device.irq().unwrap();
+					let irq = device.get_irq().unwrap();
 					info!("Install virtio interrupt handler at line {}", irq);
 					// Install interrupt handler
 					irq_install_handler(irq, network_irqhandler);

--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -295,7 +295,6 @@ pub(crate) fn open(name: *const u8, flags: i32, mode: i32) -> Result<FileDescrip
 			Err(sysopen.ret)
 		}
 	} else {
-		#[cfg(target_arch = "x86_64")]
 		{
 			// mode is 0x777 (0b0111_0111_0111), when flags | O_CREAT, else 0
 			// flags is bitmask of O_DEC_* defined above.
@@ -316,10 +315,6 @@ pub(crate) fn open(name: *const u8, flags: i32, mode: i32) -> Result<FileDescrip
 			} else {
 				Err(-EINVAL)
 			}
-		}
-		#[cfg(not(target_arch = "x86_64"))]
-		{
-			Err(-ENOSYS)
 		}
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,6 @@ use arch::core_local::*;
 #[doc(hidden)]
 pub use env::is_uhyve as _is_uhyve;
 use mm::allocator::LockedAllocator;
-#[cfg(target_arch = "aarch64")]
-use qemu_exit::QEMUExit;
 
 pub(crate) use crate::arch::*;
 pub(crate) use crate::config::*;

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -453,6 +453,7 @@ impl PerCoreScheduler {
 
 	/// Save the FPU context for the current FPU owner and restore it for the current task,
 	/// which wants to use the FPU now.
+	#[cfg(target_arch = "x86_64")]
 	pub fn fpu_switch(&mut self) {
 		if !Rc::ptr_eq(&self.current_task, &self.fpu_owner) {
 			debug!(

--- a/src/syscalls/interfaces/mod.rs
+++ b/src/syscalls/interfaces/mod.rs
@@ -55,13 +55,6 @@ pub trait SyscallInterface: Send + Sync {
 		arch::processor::shutdown()
 	}
 
-	#[cfg(not(target_arch = "x86_64"))]
-	fn unlink(&self, _name: *const u8) -> i32 {
-		debug!("unlink is unimplemented, returning -ENOSYS");
-		-ENOSYS
-	}
-
-	#[cfg(target_arch = "x86_64")]
 	fn unlink(&self, name: *const u8) -> i32 {
 		let name = unsafe { CStr::from_ptr(name as _) }.to_str().unwrap();
 		debug!("unlink {}", name);


### PR DESCRIPTION
In case of aarch64, the PCI bar has to program during the initialization. The regions are part of the device trees.

This PR solves also #739 because it enable also the support for virtue-net-pci device for aarch64.

PCI details are available at https://wiki.osdev.org/PCI.