### PR TITLE
CI (ARM): Pin CPU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,16 +270,16 @@ jobs:
       - name: Test dev kernel
         run: |
           qemu-system-aarch64 -semihosting \
-            -kernel rusty-loader-aarch64 -machine virt,gic-version=max \
-            -m 512M -cpu max -smp 1 -display none -serial stdio \
+            -kernel rusty-loader-aarch64 -machine virt,gic-version=3 \
+            -m 512M -cpu cortex-a72 -smp 1 -display none -serial stdio \
             -device guest-loader,addr=0x48000000,initrd=target/aarch64-unknown-hermit/debug/rusty_demo
       - name: Build release profile
         run: cargo build -Zbuild-std=std,panic_abort --target aarch64-unknown-hermit --package rusty_demo --release --features pci-ids
       - name: Test release kernel
         run: |
           qemu-system-aarch64 -semihosting \
-            -kernel rusty-loader-aarch64 -machine virt,gic-version=max \
-            -m 512M -cpu max -smp 1 -display none -serial stdio \
+            -kernel rusty-loader-aarch64 -machine virt,gic-version=3 \
+            -m 512M -cpu cortex-a72 -smp 1 -display none -serial stdio \
             -device guest-loader,addr=0x48000000,initrd=target/aarch64-unknown-hermit/release/rusty_demo
       - name: Build httpd with DHCP support (debug)
         run:
@@ -287,8 +287,8 @@ jobs:
       - name: Test httpd with DHCP support (debug, virtio-net)
         run: |
           qemu-system-aarch64 -semihosting \
-            -kernel rusty-loader-aarch64 -machine virt,gic-version=max \
-            -m 512M -cpu max -smp 1 -display none -serial stdio \
+            -kernel rusty-loader-aarch64 -machine virt,gic-version=3 \
+            -m 512M -cpu cortex-a72 -smp 1 -display none -serial stdio \
             -device guest-loader,addr=0x48000000,initrd=target/aarch64-unknown-hermit/debug/httpd \
             -netdev user,id=u1,hostfwd=tcp::9975-:9975,net=192.168.76.0/24,dhcpstart=192.168.76.9 \
             -device virtio-net-pci,netdev=u1,disable-legacy=on &
@@ -301,8 +301,8 @@ jobs:
       - name: Test httpd with DHCP support (release, virtio-net)
         run: |
           qemu-system-aarch64 -semihosting \
-            -kernel rusty-loader-aarch64 -machine virt,gic-version=max \
-            -m 512M -cpu max -smp 1 -display none -serial stdio \
+            -kernel rusty-loader-aarch64 -machine virt,gic-version=3 \
+            -m 512M -cpu cortex-a72 -smp 1 -display none -serial stdio \
             -device guest-loader,addr=0x48000000,initrd=target/aarch64-unknown-hermit/release/httpd \
             -netdev user,id=u1,hostfwd=tcp::9975-:9975,net=192.168.76.0/24,dhcpstart=192.168.76.9 \
             -device virtio-net-pci,netdev=u1,disable-legacy=on &


### PR DESCRIPTION
If we don't pin this, we emulate different CPUs on different CPUs. For example, on M2 chips, rusty-loader won't work correctly.

See https://github.com/hermitcore/rusty-loader/pull/228.