### PR TITLE
use write_unaligned to write data to the pci device

### DIFF
--- a/src/drivers/virtio/transport/mmio.rs
+++ b/src/drivers/virtio/transport/mmio.rs
@@ -290,9 +290,16 @@ impl NotifCtrl {
 	}
 
 	pub fn notify_dev(&self, notif_data: &[u8]) {
-		let data = u32::from_ne_bytes(notif_data.try_into().unwrap());
-		unsafe {
-			*self.notif_addr = data;
+		if self.f_notif_data {
+			unsafe {
+				(self.notif_addr as *mut u32)
+					.write_unaligned(u32::from_ne_bytes(notif_data.try_into().unwrap()));
+			}
+		} else {
+			unsafe {
+				(self.notif_addr as *mut u16)
+					.write_unaligned(u16::from_ne_bytes(notif_data[0..2].try_into().unwrap()));
+			}
 		}
 	}
 }

--- a/src/drivers/virtio/transport/mmio.rs
+++ b/src/drivers/virtio/transport/mmio.rs
@@ -4,6 +4,7 @@
 #![allow(dead_code)]
 
 use core::convert::TryInto;
+use core::intrinsics::unaligned_volatile_store;
 use core::ptr::{read_volatile, write_volatile};
 use core::result::Result;
 use core::sync::atomic::{fence, Ordering};
@@ -291,14 +292,22 @@ impl NotifCtrl {
 
 	pub fn notify_dev(&self, notif_data: &[u8]) {
 		if self.f_notif_data {
+			let ptr = self.notif_addr as *mut u32;
+
 			unsafe {
-				(self.notif_addr as *mut u32)
-					.write_unaligned(u32::from_ne_bytes(notif_data.try_into().unwrap()));
+				unaligned_volatile_store(
+					ptr,
+					u32::from_ne_bytes(notif_data[0..4].try_into().unwrap()),
+				);
 			}
 		} else {
+			let ptr = self.notif_addr as *mut u16;
+
 			unsafe {
-				(self.notif_addr as *mut u16)
-					.write_unaligned(u16::from_ne_bytes(notif_data[0..2].try_into().unwrap()));
+				unaligned_volatile_store(
+					ptr,
+					u16::from_ne_bytes(notif_data[0..2].try_into().unwrap()),
+				);
 			}
 		}
 	}

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -711,21 +711,13 @@ impl NotifCtrl {
 		// virtqueue index or the index and the next position inside the queue.
 		if self.f_notif_data {
 			unsafe {
-				let notif_area = core::slice::from_raw_parts_mut(self.notif_addr as *mut u8, 4);
-				let mut notif_data = notif_data.iter();
-
-				for byte in notif_area {
-					*byte = *notif_data.next().unwrap();
-				}
+				(self.notif_addr as *mut u32)
+					.write_unaligned(u32::from_ne_bytes(notif_data[0..4].try_into().unwrap()));
 			}
 		} else {
 			unsafe {
-				let notif_area = core::slice::from_raw_parts_mut(self.notif_addr as *mut u8, 2);
-				let mut notif_data = notif_data.iter();
-
-				for byte in notif_area {
-					*byte = *notif_data.next().unwrap();
-				}
+				(self.notif_addr as *mut u16)
+					.write_unaligned(u16::from_ne_bytes(notif_data[0..2].try_into().unwrap()));
 			}
 		}
 	}

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -4,6 +4,7 @@
 #![allow(dead_code)]
 
 use alloc::vec::Vec;
+use core::intrinsics::unaligned_volatile_store;
 use core::mem;
 use core::result::Result;
 
@@ -710,14 +711,22 @@ impl NotifCtrl {
 		// Depending in the feature negotiation, we write eitehr only the
 		// virtqueue index or the index and the next position inside the queue.
 		if self.f_notif_data {
+			let ptr = self.notif_addr as *mut u32;
+
 			unsafe {
-				(self.notif_addr as *mut u32)
-					.write_unaligned(u32::from_ne_bytes(notif_data[0..4].try_into().unwrap()));
+				unaligned_volatile_store(
+					ptr,
+					u32::from_ne_bytes(notif_data[0..4].try_into().unwrap()),
+				);
 			}
 		} else {
+			let ptr = self.notif_addr as *mut u16;
+
 			unsafe {
-				(self.notif_addr as *mut u16)
-					.write_unaligned(u16::from_ne_bytes(notif_data[0..2].try_into().unwrap()));
+				unaligned_volatile_store(
+					ptr,
+					u16::from_ne_bytes(notif_data[0..2].try_into().unwrap()),
+				);
 			}
 		}
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 #![cfg_attr(target_arch = "x86_64", feature(abi_x86_interrupt))]
 #![feature(allocator_api)]
 #![feature(asm_const)]
+#![feature(core_intrinsics)]
 #![feature(linked_list_cursors)]
 #![feature(maybe_uninit_slice)]
 #![feature(naked_functions)]


### PR DESCRIPTION
gurantees that the kernel 16-/32-bit registers to write the data to the device memory