### PR TITLE
network drivers create directly TxToken / RxToken for smoltcp 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,9 +165,9 @@ jobs:
             -device vhost-user-fs-pci,queue-size=1024,chardev=char0,tag=root \
             -object memory-backend-file,id=mem,size=1G,mem-path=/dev/shm,share=on -numa node,memdev=mem \
             -initrd target/x86_64-unknown-hermit/release/rusty_demo
-      - name: Build httpd with DHCP support (debug)
+      - name: Build httpd with DHCP support (debug, rtl8139)
         run:
-          cargo build -Zbuild-std=std,panic_abort --target x86_64-unknown-hermit --package httpd --features ci,dhcpv4
+          cargo build -Zbuild-std=std,panic_abort --target x86_64-unknown-hermit --package httpd --features ci,dhcpv4,rtl8139
       - name: Test httpd with DHCP support (debug, rtl8139)
         run: |
           qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand \
@@ -179,6 +179,9 @@ jobs:
             sleep 5
             curl http://127.0.0.1:9975/help
             sleep 1
+      - name: Build httpd with DHCP support (debug, virtio-net)
+        run:
+            cargo build -Zbuild-std=std,panic_abort --target x86_64-unknown-hermit --package httpd --features ci,dhcpv4
       - name: Test httpd with DHCP support (debug, virtio-net)
         run: |
           qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand \
@@ -190,9 +193,9 @@ jobs:
             sleep 5
             curl http://127.0.0.1:9975/help
             sleep 1
-      - name: Build httpd with DHCP support (release)
+      - name: Build httpd with DHCP support (release, rtl8139)
         run:
-          cargo build -Zbuild-std=std,panic_abort --target x86_64-unknown-hermit --package httpd --release --features ci,dhcpv4
+          cargo build -Zbuild-std=std,panic_abort --target x86_64-unknown-hermit --package httpd --release --features ci,dhcpv4,rtl8139
       - name: Test httpd with DHCP support (release, rtl8139)
         run: |
           qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand \
@@ -204,6 +207,9 @@ jobs:
             sleep 5
             curl http://127.0.0.1:9975/help
             sleep 1
+      - name: Build httpd with DHCP support (release, virtio-net)
+        run:
+          cargo build -Zbuild-std=std,panic_abort --target x86_64-unknown-hermit --package httpd --release --features ci,dhcpv4
       - name: Test httpd with DHCP support (release, virtio-net)
         run: |
           qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ acpi = []
 smp = ["include-transformed"]
 fsgsbase = []
 trace = []
+rtl8139 = ["tcp", "pci"]
 tcp = [
     "smoltcp",
 ]

--- a/src/arch/aarch64/kernel/interrupts.rs
+++ b/src/arch/aarch64/kernel/interrupts.rs
@@ -24,6 +24,7 @@ const MAX_HANDLERS: usize = 256;
 /// The ID of the first Private Peripheral Interrupt.
 const PPI_START: u8 = 16;
 /// The ID of the first Shared Peripheral Interrupt.
+#[allow(dead_code)]
 const SPI_START: u8 = 32;
 /// Software-generated interrupt for rescheduling
 pub(crate) const SGI_RESCHED: u8 = 1;
@@ -93,6 +94,7 @@ pub fn disable() {
 	}
 }
 
+#[allow(dead_code)]
 pub(crate) fn irq_install_handler(irq_number: u8, handler: HandlerFunc) {
 	debug!("Install handler for interrupt {}", irq_number);
 	unsafe {
@@ -348,7 +350,8 @@ pub(crate) fn init() {
 static IRQ_NAMES: InterruptTicketMutex<HashMap<u8, &'static str, RandomState>> =
 	InterruptTicketMutex::new(HashMap::with_hasher(RandomState::with_seeds(0, 0, 0, 0)));
 
-pub fn add_irq_name(irq_number: u8, name: &'static str) {
+#[allow(dead_code)]
+pub(crate) fn add_irq_name(irq_number: u8, name: &'static str) {
 	debug!("Register name \"{}\"  for interrupt {}", name, irq_number);
 	IRQ_NAMES.lock().insert(SPI_START + irq_number, name);
 }
@@ -357,10 +360,10 @@ fn get_irq_name(irq_number: u8) -> Option<&'static str> {
 	IRQ_NAMES.lock().get(&irq_number).copied()
 }
 
-pub static IRQ_COUNTERS: InterruptSpinMutex<BTreeMap<CoreId, &IrqStatistics>> =
+pub(crate) static IRQ_COUNTERS: InterruptSpinMutex<BTreeMap<CoreId, &IrqStatistics>> =
 	InterruptSpinMutex::new(BTreeMap::new());
 
-pub struct IrqStatistics {
+pub(crate) struct IrqStatistics {
 	pub counters: [AtomicU64; 256],
 }
 
@@ -378,7 +381,7 @@ impl IrqStatistics {
 	}
 }
 
-pub fn print_statistics() {
+pub(crate) fn print_statistics() {
 	info!("Number of interrupts");
 	for (core_id, irg_statistics) in IRQ_COUNTERS.lock().iter() {
 		for (i, counter) in irg_statistics.counters.iter().enumerate() {

--- a/src/arch/aarch64/kernel/mmio.rs
+++ b/src/arch/aarch64/kernel/mmio.rs
@@ -1,7 +1,7 @@
 use hermit_sync::InterruptTicketMutex;
 
-use crate::drivers::net::NetworkInterface;
+use crate::drivers::net::virtio_net::VirtioNetDriver;
 
-pub fn get_network_driver() -> Option<&'static InterruptTicketMutex<dyn NetworkInterface>> {
+pub(crate) fn get_network_driver() -> Option<&'static InterruptTicketMutex<VirtioNetDriver>> {
 	None
 }

--- a/src/arch/aarch64/kernel/mod.rs
+++ b/src/arch/aarch64/kernel/mod.rs
@@ -1,6 +1,6 @@
 pub mod core_local;
 pub mod interrupts;
-#[cfg(not(feature = "pci"))]
+#[cfg(all(not(feature = "pci"), feature = "tcp"))]
 pub mod mmio;
 #[cfg(feature = "pci")]
 pub mod pci;

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -86,6 +86,6 @@ pub fn init_drivers() {
 	// Initialize PCI Drivers for x86_64
 	#[cfg(feature = "pci")]
 	crate::drivers::pci::init_drivers();
-	#[cfg(all(target_arch = "x86_64", not(feature = "pci")))]
+	#[cfg(all(target_arch = "x86_64", not(feature = "pci"), feature = "tcp"))]
 	crate::arch::x86_64::kernel::mmio::init_drivers();
 }

--- a/src/arch/x86_64/kernel/mmio.rs
+++ b/src/arch/x86_64/kernel/mmio.rs
@@ -9,7 +9,6 @@ use crate::arch::x86_64::mm::paging::{
 };
 use crate::arch::x86_64::mm::{paging, PhysAddr};
 use crate::drivers::net::virtio_net::VirtioNetDriver;
-use crate::drivers::net::NetworkInterface;
 use crate::drivers::virtio::transport::mmio as mmio_virtio;
 use crate::drivers::virtio::transport::mmio::{DevId, MmioRegisterLayout, VirtioDriver};
 
@@ -27,7 +26,7 @@ pub(crate) enum MmioDriver {
 
 impl MmioDriver {
 	#[allow(unreachable_patterns)]
-	fn get_network_driver(&self) -> Option<&InterruptTicketMutex<dyn NetworkInterface>> {
+	fn get_network_driver(&self) -> Option<&InterruptTicketMutex<VirtioNetDriver>> {
 		match self {
 			Self::VirtioNet(drv) => Some(drv),
 			_ => None,
@@ -122,11 +121,11 @@ pub(crate) fn register_driver(drv: MmioDriver) {
 	}
 }
 
-pub fn get_network_driver() -> Option<&'static InterruptTicketMutex<dyn NetworkInterface>> {
+pub(crate) fn get_network_driver() -> Option<&'static InterruptTicketMutex<VirtioNetDriver>> {
 	unsafe { MMIO_DRIVERS.iter().find_map(|drv| drv.get_network_driver()) }
 }
 
-pub fn init_drivers() {
+pub(crate) fn init_drivers() {
 	// virtio: MMIO Device Discovery
 	without_interrupts(|| {
 		if let Ok(mmio) = detect_network() {

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -17,7 +17,7 @@ pub mod apic;
 pub mod core_local;
 pub mod gdt;
 pub mod interrupts;
-#[cfg(not(feature = "pci"))]
+#[cfg(all(not(feature = "pci"), feature = "tcp"))]
 pub mod mmio;
 #[cfg(feature = "pci")]
 pub mod pci;

--- a/src/arch/x86_64/mm/physicalmem.rs
+++ b/src/arch/x86_64/mm/physicalmem.rs
@@ -174,6 +174,7 @@ pub fn deallocate(physical_address: PhysAddr, size: usize) {
 		.deallocate(physical_address.as_usize(), size);
 }
 
+#[allow(dead_code)]
 #[cfg(not(feature = "pci"))]
 pub fn reserve(physical_address: PhysAddr, size: usize) {
 	assert_eq!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,8 +4,10 @@ pub(crate) const DEFAULT_STACK_SIZE: usize = 65_536;
 
 pub(crate) const USER_STACK_SIZE: usize = 1_048_576;
 
+#[allow(dead_code)]
 #[cfg(feature = "pci")]
 pub(crate) const VIRTIO_MAX_QUEUE_SIZE: u16 = 2048;
+#[allow(dead_code)]
 #[cfg(not(feature = "pci"))]
 pub(crate) const VIRTIO_MAX_QUEUE_SIZE: u16 = 1024;
 

--- a/src/drivers/mmio.rs
+++ b/src/drivers/mmio.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "tcp")]
+pub(crate) use crate::arch::kernel::mmio::get_network_driver;

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -1,6 +1,9 @@
 //! A module containing hermit-rs driver, hermit-rs driver trait and driver specific errors.
 
 pub mod fs;
+#[cfg(not(feature = "pci"))]
+pub mod mmio;
+#[cfg(feature = "tcp")]
 pub mod net;
 #[cfg(feature = "pci")]
 pub mod pci;
@@ -12,14 +15,14 @@ pub mod virtio;
 pub mod error {
 	use core::fmt;
 
-	#[cfg(all(feature = "pci", not(target_arch = "aarch64")))]
+	#[cfg(feature = "rtl8139")]
 	use crate::drivers::net::rtl8139::RTL8139Error;
 	use crate::drivers::virtio::error::VirtioError;
 
 	#[derive(Debug)]
 	pub enum DriverError {
 		InitVirtioDevFail(VirtioError),
-		#[cfg(all(feature = "pci", not(target_arch = "aarch64")))]
+		#[cfg(feature = "rtl8139")]
 		InitRTL8139DevFail(RTL8139Error),
 	}
 
@@ -29,7 +32,7 @@ pub mod error {
 		}
 	}
 
-	#[cfg(all(feature = "pci", not(target_arch = "aarch64")))]
+	#[cfg(feature = "rtl8139")]
 	impl From<RTL8139Error> for DriverError {
 		fn from(err: RTL8139Error) -> Self {
 			DriverError::InitRTL8139DevFail(err)
@@ -42,7 +45,7 @@ pub mod error {
 				DriverError::InitVirtioDevFail(ref err) => {
 					write!(f, "Virtio driver failed: {err:?}")
 				}
-				#[cfg(all(feature = "pci", not(target_arch = "aarch64")))]
+				#[cfg(feature = "rtl8139")]
 				DriverError::InitRTL8139DevFail(ref err) => {
 					write!(f, "RTL8139 driver failed: {err:?}")
 				}

--- a/src/drivers/net/rtl8139.rs
+++ b/src/drivers/net/rtl8139.rs
@@ -14,8 +14,9 @@ use crate::arch::mm::paging::virt_to_phys;
 use crate::arch::mm::VirtAddr;
 use crate::arch::pci::PciConfigRegion;
 use crate::drivers::error::DriverError;
-use crate::drivers::net::{network_irqhandler, NetworkInterface};
+use crate::drivers::net::{network_irqhandler, NetworkDriver};
 use crate::drivers::pci::{PciCommand, PciDevice};
+use crate::executor::device::{RxToken, TxToken};
 
 /// size of the receive buffer
 const RX_BUF_LEN: usize = 8192;
@@ -210,10 +211,9 @@ pub(crate) struct RTL8139Driver {
 	rxbuffer: Box<[u8]>,
 	rxpos: usize,
 	txbuffer: Box<[u8]>,
-	polling_mode_counter: u32,
 }
 
-impl NetworkInterface for RTL8139Driver {
+impl NetworkDriver for RTL8139Driver {
 	/// Returns the MAC address of the network interface
 	fn get_mac_address(&self) -> [u8; 6] {
 		self.mac
@@ -224,37 +224,32 @@ impl NetworkInterface for RTL8139Driver {
 		self.mtu
 	}
 
-	fn get_tx_buffer(&mut self, len: usize) -> Result<(*mut u8, usize), ()> {
+	/// Send packet with the size `len`
+	fn send_packet<R, F>(&mut self, len: usize, f: F) -> R
+	where
+		F: FnOnce(&mut [u8]) -> R,
+	{
 		let id = self.tx_counter % NO_TX_BUFFERS;
 
 		if self.tx_in_use[id] || len > TX_BUF_LEN {
-			trace!("Unable to get TX buffer");
-			Err(())
+			panic!("Unable to get TX buffer");
 		} else {
 			self.tx_in_use[id] = true;
 			self.tx_counter += 1;
 
-			Ok((
-				self.txbuffer[id * TX_BUF_LEN..][..TX_BUF_LEN].as_mut_ptr(),
-				id,
-			))
+			let buffer = &mut self.txbuffer[id * TX_BUF_LEN..][..len];
+			let result = f(buffer);
+
+			// send the packet
+			unsafe {
+				outl(
+					self.iobase + TSD0 + (4 * id as u16),
+					len.try_into().unwrap(),
+				); //|0x3A0000);
+			}
+
+			result
 		}
-	}
-
-	fn free_tx_buffer(&self, _token: usize) {
-		// get_tx_buffer did not allocate
-	}
-
-	fn send_tx_buffer(&mut self, id: usize, len: usize) -> Result<(), ()> {
-		// send the packet
-		unsafe {
-			outl(
-				self.iobase + TSD0 + (4 * id as u16),
-				len.try_into().unwrap(),
-			); //|0x3A0000);
-		}
-
-		Ok(())
 	}
 
 	fn has_packet(&self) -> bool {
@@ -271,7 +266,8 @@ impl NetworkInterface for RTL8139Driver {
 		false
 	}
 
-	fn receive_rx_buffer(&mut self, buffer: &mut [u8]) -> Result<usize, ()> {
+	/// Get buffer with the received packet
+	fn receive_packet(&mut self) -> Option<(RxToken, TxToken)> {
 		let cmd = unsafe { inb(self.iobase + CR) };
 
 		if (cmd & CR_BUFE) != CR_BUFE {
@@ -284,48 +280,39 @@ impl NetworkInterface for RTL8139Driver {
 
 				// do we reach the end of the receive buffers?
 				// in this case, we conact the two slices to one vec
-				if pos + length as usize > RX_BUF_LEN {
-					buffer[..RX_BUF_LEN - pos].copy_from_slice(&self.rxbuffer[pos..RX_BUF_LEN]);
-					buffer[RX_BUF_LEN - pos..usize::from(length)].copy_from_slice(
-						&self.rxbuffer[0..usize::from(length) - (RX_BUF_LEN - pos)],
-					);
+				let vec_data = if pos + length as usize > RX_BUF_LEN {
+					let first = &self.rxbuffer[pos..RX_BUF_LEN];
+					let second = &self.rxbuffer[..length as usize - first.len()];
+					[first, second].concat()
 				} else {
-					buffer[..length.into()]
-						.copy_from_slice(&self.rxbuffer[pos..pos + usize::from(length)]);
+					(self.rxbuffer[pos..][..length.into()]).to_vec()
 				};
 
 				self.consume_current_buffer();
 
-				Ok(length.into())
+				Some((RxToken::new(vec_data), TxToken::new()))
 			} else {
-				error!(
+				warn!(
 					"RTL8192: invalid header {:#x}, rx_pos {}\n",
 					header, self.rxpos
 				);
 
-				Err(())
+				None
 			}
 		} else {
-			Err(())
+			None
 		}
 	}
 
 	fn set_polling_mode(&mut self, value: bool) {
 		if value {
-			if self.polling_mode_counter == 0 {
-				// disable interrupts from the NIC
-				unsafe {
-					outw(self.iobase + IMR, INT_MASK_NO_ROK);
-				}
+			unsafe {
+				outw(self.iobase + IMR, INT_MASK_NO_ROK);
 			}
-			self.polling_mode_counter += 1;
 		} else {
-			self.polling_mode_counter -= 1;
-			if self.polling_mode_counter == 0 {
-				// Enable all known interrupts by setting the interrupt mask.
-				unsafe {
-					outw(self.iobase + IMR, INT_MASK);
-				}
+			// Enable all known interrupts by setting the interrupt mask.
+			unsafe {
+				outw(self.iobase + IMR, INT_MASK);
 			}
 		}
 	}
@@ -599,6 +586,5 @@ pub(crate) fn init_device(
 		rxbuffer,
 		rxpos: 0,
 		txbuffer,
-		polling_mode_counter: 0,
 	})
 }

--- a/src/drivers/net/virtio_mmio.rs
+++ b/src/drivers/net/virtio_mmio.rs
@@ -150,7 +150,6 @@ impl VirtioNetDriver {
 			),
 			num_vqs: 0,
 			irq,
-			polling_mode_counter: 0,
 			mtu,
 		})
 	}

--- a/src/drivers/net/virtio_pci.rs
+++ b/src/drivers/net/virtio_pci.rs
@@ -160,7 +160,6 @@ impl VirtioNetDriver {
 			),
 			num_vqs: 0,
 			irq: device.get_irq().unwrap(),
-			polling_mode_counter: 0,
 			mtu,
 		})
 	}

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -13,10 +13,10 @@ use pci_types::{
 use crate::arch::mm::{PhysAddr, VirtAddr};
 use crate::arch::pci::PciConfigRegion;
 use crate::drivers::fs::virtio_fs::VirtioFsDriver;
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(feature = "rtl8139")]
 use crate::drivers::net::rtl8139::{self, RTL8139Driver};
+#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
 use crate::drivers::net::virtio_net::VirtioNetDriver;
-use crate::drivers::net::NetworkInterface;
 use crate::drivers::virtio::transport::pci as pci_virtio;
 use crate::drivers::virtio::transport::pci::VirtioDriver;
 
@@ -456,16 +456,24 @@ pub(crate) fn print_information() {
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum PciDriver {
 	VirtioFs(InterruptTicketMutex<VirtioFsDriver>),
+	#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
 	VirtioNet(InterruptTicketMutex<VirtioNetDriver>),
-	#[cfg(not(target_arch = "aarch64"))]
+	#[cfg(all(feature = "rtl8139", feature = "tcp"))]
 	RTL8139Net(InterruptTicketMutex<RTL8139Driver>),
 }
 
 impl PciDriver {
-	fn get_network_driver(&self) -> Option<&InterruptTicketMutex<dyn NetworkInterface>> {
+	#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
+	fn get_network_driver(&self) -> Option<&InterruptTicketMutex<VirtioNetDriver>> {
 		match self {
 			Self::VirtioNet(drv) => Some(drv),
-			#[cfg(not(target_arch = "aarch64"))]
+			_ => None,
+		}
+	}
+
+	#[cfg(all(feature = "rtl8139", feature = "tcp"))]
+	fn get_network_driver(&self) -> Option<&InterruptTicketMutex<RTL8139Driver>> {
+		match self {
 			Self::RTL8139Net(drv) => Some(drv),
 			_ => None,
 		}
@@ -474,6 +482,7 @@ impl PciDriver {
 	fn get_filesystem_driver(&self) -> Option<&InterruptTicketMutex<VirtioFsDriver>> {
 		match self {
 			Self::VirtioFs(drv) => Some(drv),
+			#[allow(unreachable_patterns)]
 			_ => None,
 		}
 	}
@@ -485,7 +494,13 @@ pub(crate) fn register_driver(drv: PciDriver) {
 	}
 }
 
-pub(crate) fn get_network_driver() -> Option<&'static InterruptTicketMutex<dyn NetworkInterface>> {
+#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
+pub(crate) fn get_network_driver() -> Option<&'static InterruptTicketMutex<VirtioNetDriver>> {
+	unsafe { PCI_DRIVERS.iter().find_map(|drv| drv.get_network_driver()) }
+}
+
+#[cfg(all(feature = "rtl8139", feature = "tcp"))]
+pub(crate) fn get_network_driver() -> Option<&'static InterruptTicketMutex<RTL8139Driver>> {
 	unsafe { PCI_DRIVERS.iter().find_map(|drv| drv.get_network_driver()) }
 }
 
@@ -498,8 +513,6 @@ pub(crate) fn get_filesystem_driver() -> Option<&'static InterruptTicketMutex<Vi
 }
 
 pub(crate) fn init_drivers() {
-	let mut nic_available = false;
-
 	// virtio: 4.1.2 PCI Device Discovery
 	without_interrupts(|| {
 		for adapter in unsafe {
@@ -514,8 +527,8 @@ pub(crate) fn init_drivers() {
 			);
 
 			match pci_virtio::init_device(adapter) {
+				#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
 				Ok(VirtioDriver::Network(drv)) => {
-					nic_available = true;
 					register_driver(PciDriver::VirtioNet(InterruptTicketMutex::new(drv)))
 				}
 				Ok(VirtioDriver::FileSystem(drv)) => {
@@ -525,24 +538,21 @@ pub(crate) fn init_drivers() {
 			}
 		}
 
-		// do we already found a network interface?
-		#[cfg(not(target_arch = "aarch64"))]
-		if !nic_available {
-			// Searching for Realtek RTL8139, which is supported by Qemu
-			for adapter in unsafe {
-				PCI_DEVICES.iter().filter(|x| {
-					let (vendor_id, device_id) = x.id();
-					vendor_id == 0x10ec && (0x8138..=0x8139).contains(&device_id)
-				})
-			} {
-				info!(
-					"Found Realtek network device with device id {:#x}",
-					adapter.device_id()
-				);
+		// Searching for Realtek RTL8139, which is supported by Qemu
+		#[cfg(feature = "rtl8139")]
+		for adapter in unsafe {
+			PCI_DEVICES.iter().filter(|x| {
+				let (vendor_id, device_id) = x.id();
+				vendor_id == 0x10ec && (0x8138..=0x8139).contains(&device_id)
+			})
+		} {
+			info!(
+				"Found Realtek network device with device id {:#x}",
+				adapter.device_id()
+			);
 
-				if let Ok(drv) = rtl8139::init_device(adapter) {
-					register_driver(PciDriver::RTL8139Net(InterruptTicketMutex::new(drv)))
-				}
+			if let Ok(drv) = rtl8139::init_device(adapter) {
+				register_driver(PciDriver::RTL8139Net(InterruptTicketMutex::new(drv)))
 			}
 		}
 	});

--- a/src/drivers/virtio/mod.rs
+++ b/src/drivers/virtio/mod.rs
@@ -10,15 +10,18 @@ pub mod error {
 
 	#[cfg(feature = "pci")]
 	pub use crate::drivers::fs::virtio_fs::error::VirtioFsError;
+	#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
 	pub use crate::drivers::net::virtio_net::error::VirtioNetError;
 	#[cfg(feature = "pci")]
 	use crate::drivers::pci::error::PciError;
 
+	#[allow(dead_code)]
 	#[derive(Debug)]
 	pub enum VirtioError {
 		#[cfg(feature = "pci")]
 		FromPci(PciError),
 		DevNotSupported(u16),
+		#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
 		NetDriver(VirtioNetError),
 		#[cfg(feature = "pci")]
 		FsDriver(VirtioFsError),
@@ -40,6 +43,7 @@ pub mod error {
                     PciError::NoVirtioCaps(id) => write!(f, "Driver failed to initialize device with id: {id:#x}. Reason: No Virtio capabilities were found."),
                 },
                 VirtioError::DevNotSupported(id) => write!(f, "Device with id {id:#x} not supported."),
+				#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
                 VirtioError::NetDriver(net_error) => match net_error {
                     VirtioNetError::General => write!(f, "Virtio network driver failed due to unknown reasons!"),
                     VirtioNetError::NoDevCfg(id) => write!(f, "Virtio network driver failed, for device {id:x}, due to a missing or malformed device config!"),

--- a/src/drivers/virtio/transport/mmio.rs
+++ b/src/drivers/virtio/transport/mmio.rs
@@ -10,10 +10,13 @@ use core::result::Result;
 use core::sync::atomic::{fence, Ordering};
 use core::u8;
 
+#[cfg(feature = "tcp")]
 use crate::arch::kernel::interrupts::*;
 use crate::arch::mm::PhysAddr;
 use crate::drivers::error::DriverError;
+#[cfg(feature = "tcp")]
 use crate::drivers::net::network_irqhandler;
+#[cfg(feature = "tcp")]
 use crate::drivers::net::virtio_net::VirtioNetDriver;
 use crate::drivers::virtio::device;
 use crate::drivers::virtio::error::VirtioError;
@@ -360,9 +363,11 @@ struct IsrStatusRaw {
 }
 
 pub(crate) enum VirtioDriver {
+	#[cfg(feature = "tcp")]
 	Network(VirtioNetDriver),
 }
 
+#[allow(unused_variables)]
 pub(crate) fn init_device(
 	registers: &'static mut MmioRegisterLayout,
 	irq_no: u8,
@@ -378,6 +383,7 @@ pub(crate) fn init_device(
 
 	// Verify the device-ID to find the network card
 	match registers.device_id {
+		#[cfg(feature = "tcp")]
 		DevId::VIRTIO_DEV_ID_NET => {
 			match VirtioNetDriver::init(dev_id, registers, irq_no) {
 				Ok(virt_net_drv) => {

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -8,13 +8,16 @@ use core::intrinsics::unaligned_volatile_store;
 use core::mem;
 use core::result::Result;
 
+#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
 use crate::arch::kernel::interrupts::*;
 use crate::arch::memory_barrier;
 use crate::arch::mm::PhysAddr;
 use crate::arch::pci::PciConfigRegion;
 use crate::drivers::error::DriverError;
 use crate::drivers::fs::virtio_fs::VirtioFsDriver;
+#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
 use crate::drivers::net::network_irqhandler;
+#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
 use crate::drivers::net::virtio_net::VirtioNetDriver;
 use crate::drivers::pci::error::PciError;
 use crate::drivers::pci::{DeviceHeader, Masks, PciDevice};
@@ -1249,6 +1252,7 @@ pub(crate) fn init_device(
 				VirtioError::DevNotSupported(device_id),
 			))
 		}
+		#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
 		DevId::VIRTIO_DEV_ID_NET => match VirtioNetDriver::init(device) {
 			Ok(virt_net_drv) => {
 				info!("Virtio network driver initialized.");
@@ -1295,6 +1299,7 @@ pub(crate) fn init_device(
 	match virt_drv {
 		Ok(drv) => {
 			match &drv {
+				#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
 				VirtioDriver::Network(_) => {
 					let irq = device.get_irq().unwrap();
 					info!("Install virtio interrupt handler at line {}", irq);
@@ -1312,6 +1317,7 @@ pub(crate) fn init_device(
 }
 
 pub(crate) enum VirtioDriver {
+	#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
 	Network(VirtioNetDriver),
 	FileSystem(VirtioFsDriver),
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -108,6 +108,7 @@ pub fn freq() -> Option<u16> {
 	CLI.get().unwrap().freq
 }
 
+#[allow(dead_code)]
 pub fn var(key: &str) -> Option<&String> {
 	CLI.get().unwrap().env_vars.get(key)
 }

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 #[cfg(feature = "tcp")]
-mod device;
+pub(crate) mod device;
 #[cfg(feature = "tcp")]
 pub(crate) mod network;
 pub(crate) mod task;

--- a/src/executor/network.rs
+++ b/src/executor/network.rs
@@ -6,7 +6,8 @@ use core::ops::DerefMut;
 use core::sync::atomic::{AtomicU16, Ordering};
 use core::task::{Context, Poll};
 
-use hermit_sync::InterruptTicketMutex;
+use crossbeam_utils::Backoff;
+use hermit_sync::{without_interrupts, InterruptTicketMutex};
 use smoltcp::iface::{SocketHandle, SocketSet};
 #[cfg(feature = "dhcpv4")]
 use smoltcp::socket::dhcpv4;
@@ -17,6 +18,11 @@ use smoltcp::wire::{IpCidr, Ipv4Address, Ipv4Cidr};
 
 use crate::arch::core_local::*;
 use crate::arch::{self, interrupts};
+#[cfg(not(feature = "pci"))]
+use crate::drivers::mmio::get_network_driver;
+use crate::drivers::net::NetworkDriver;
+#[cfg(feature = "pci")]
+use crate::drivers::pci::get_network_driver;
 use crate::executor::device::HermitNet;
 use crate::executor::{spawn, TaskNotify};
 
@@ -205,15 +211,6 @@ impl<'a> NetworkInterface<'a> {
 	}
 }
 
-/// set driver in polling mode
-#[inline]
-fn set_polling_mode(value: bool) {
-	#[cfg(feature = "pci")]
-	if let Some(driver) = crate::drivers::pci::get_network_driver() {
-		driver.lock().set_polling_mode(value)
-	}
-}
-
 #[inline]
 fn network_delay(timestamp: Instant) -> Option<Duration> {
 	crate::executor::network::NIC
@@ -237,12 +234,12 @@ pub(crate) fn block_on<F, T>(future: F, timeout: Option<Duration>) -> Result<T, 
 where
 	F: Future<Output = Result<T, i32>>,
 {
-	// Enter polling mode => no NIC interrupts
-	set_polling_mode(true);
+	// allow network interrupts
+	get_network_driver().unwrap().lock().set_polling_mode(true);
 
-	let mut counter: u16 = 0;
+	let backoff = Backoff::new();
 	let mut blocking_time = 1000;
-	let start = crate::executor::network::now();
+	let start = now();
 	let task_notify = Arc::new(TaskNotify::new());
 	let waker = task_notify.into();
 	let mut cx = Context::from_waker(&waker);
@@ -254,40 +251,38 @@ where
 		crate::executor::run();
 
 		if let Poll::Ready(t) = future.as_mut().poll(&mut cx) {
-			let wakeup_time = network_delay(crate::executor::network::now())
+			let network_timer = network_delay(crate::executor::network::now())
 				.map(|d| crate::arch::processor::get_timer_ticks() + d.total_micros());
-			core_scheduler().add_network_timer(wakeup_time);
+			core_scheduler().add_network_timer(network_timer);
 
 			// allow network interrupts
-			set_polling_mode(false);
+			get_network_driver().unwrap().lock().set_polling_mode(false);
 
 			return t;
 		}
 
 		if let Some(duration) = timeout {
 			if crate::executor::network::now() >= start + duration {
-				let wakeup_time = network_delay(crate::executor::network::now())
+				let network_timer = network_delay(crate::executor::network::now())
 					.map(|d| crate::arch::processor::get_timer_ticks() + d.total_micros());
-				core_scheduler().add_network_timer(wakeup_time);
+				core_scheduler().add_network_timer(network_timer);
 
 				// allow network interrupts
-				set_polling_mode(false);
+				get_network_driver().unwrap().lock().set_polling_mode(false);
 
 				return Err(-crate::errno::ETIME);
 			}
 		}
 
-		counter += 1;
-		// besure that we are not interrupted by a timer, which is able
-		// to call `reschedule`
+		// disable all interrupts
 		interrupts::disable();
 		let now = crate::executor::network::now();
 		let delay = network_delay(now).map(|d| d.total_micros());
-		if counter > 200 && delay.unwrap_or(10_000_000) > 100_000 {
+		if backoff.is_completed() && delay.unwrap_or(10_000_000) > 10_000 {
 			// add additional check before the task will block
 			if let Poll::Ready(t) = future.as_mut().poll(&mut cx) {
 				// allow network interrupts
-				set_polling_mode(false);
+				get_network_driver().unwrap().lock().set_polling_mode(false);
 				// enable interrupts
 				interrupts::enable();
 
@@ -311,7 +306,7 @@ where
 			core_scheduler.block_current_task(wakeup_time);
 
 			// allow network interrupts
-			set_polling_mode(false);
+			get_network_driver().unwrap().lock().set_polling_mode(false);
 
 			// enable interrupts
 			interrupts::enable();
@@ -319,14 +314,14 @@ where
 			// switch to another task
 			core_scheduler.reschedule();
 
-			// reset polling counter
-			counter = 0;
-
-			// Enter polling mode => no NIC interrupts
-			set_polling_mode(true);
+			// restore default values
+			get_network_driver().unwrap().lock().set_polling_mode(true);
+			backoff.reset();
 		} else {
 			// enable interrupts
 			interrupts::enable();
+
+			backoff.snooze();
 		}
 	}
 }
@@ -336,41 +331,36 @@ pub(crate) fn poll_on<F, T>(future: F, timeout: Option<Duration>) -> Result<T, i
 where
 	F: Future<Output = Result<T, i32>>,
 {
-	// Enter polling mode => no NIC interrupts
-	set_polling_mode(true);
+	// be sure that we are not interrupted by a timer, which is able
+	// to call `reschedule`
+	without_interrupts(|| {
+		let start = now();
+		let waker = core::task::Waker::noop();
+		let mut cx = Context::from_waker(&waker);
+		let mut future = future;
+		let mut future = unsafe { core::pin::Pin::new_unchecked(&mut future) };
 
-	let start = crate::executor::network::now();
-	let waker = core::task::Waker::noop();
-	let mut cx = Context::from_waker(&waker);
-	let mut future = future;
-	let mut future = unsafe { core::pin::Pin::new_unchecked(&mut future) };
+		loop {
+			// run background tasks
+			crate::executor::run();
 
-	loop {
-		// run background tasks
-		crate::executor::run();
-
-		if let Poll::Ready(t) = future.as_mut().poll(&mut cx) {
-			let wakeup_time = network_delay(crate::executor::network::now())
-				.map(|d| crate::arch::processor::get_timer_ticks() + d.total_micros());
-			core_scheduler().add_network_timer(wakeup_time);
-
-			// allow interrupts => NIC thread is able to run
-			set_polling_mode(false);
-
-			return t;
-		}
-
-		if let Some(duration) = timeout {
-			if crate::executor::network::now() >= start + duration {
-				let wakeup_time = network_delay(crate::executor::network::now())
+			if let Poll::Ready(t) = future.as_mut().poll(&mut cx) {
+				let wakeup_time = network_delay(now())
 					.map(|d| crate::arch::processor::get_timer_ticks() + d.total_micros());
 				core_scheduler().add_network_timer(wakeup_time);
 
-				// allow interrupts => NIC thread is able to run
-				set_polling_mode(false);
+				return t;
+			}
 
-				return Err(-crate::errno::ETIME);
+			if let Some(duration) = timeout {
+				if crate::executor::network::now() >= start + duration {
+					let wakeup_time = network_delay(now())
+						.map(|d| crate::arch::processor::get_timer_ticks() + d.total_micros());
+					core_scheduler().add_network_timer(wakeup_time);
+
+					return Err(-crate::errno::ETIME);
+				}
 			}
 		}
-	}
+	})
 }

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -67,58 +67,40 @@ impl<T> Socket<T> {
 	}
 
 	async fn async_read(&self, buffer: &mut [u8]) -> Result<isize, i32> {
-		let mut pos: usize = 0;
+		future::poll_fn(|cx| {
+			self.with(|socket| {
+				if socket.can_recv() {
+					return Poll::Ready(
+						socket
+							.recv(|data| {
+								let len = core::cmp::min(buffer.len(), data.len());
+								buffer[..len].copy_from_slice(&data[..len]);
+								(len, isize::try_from(len).unwrap())
+							})
+							.map_err(|_| -crate::errno::EIO),
+					);
+				}
 
-		while pos < buffer.len() {
-			let n = future::poll_fn(|cx| {
-				self.with(|socket| {
-					if socket.can_recv() {
-						return Poll::Ready(
-							socket
-								.recv(|data| {
-									let len = core::cmp::min(buffer.len() - pos, data.len());
-									buffer[pos..pos + len].copy_from_slice(&data[..len]);
-									(len, len)
-								})
-								.map_err(|_| -crate::errno::EIO),
-						);
-					}
-
-					if pos > 0 {
-						// we already send some data => return 0 as signal to stop the
-						// async write
-						return Poll::Ready(Ok(0));
-					}
-
-					match socket.state() {
-						tcp::State::FinWait1
-						| tcp::State::FinWait2
-						| tcp::State::Closed
-						| tcp::State::Closing
-						| tcp::State::CloseWait
-						| tcp::State::TimeWait => Poll::Ready(Err(-crate::errno::EIO)),
-						_ => {
-							if socket.can_recv() {
-								warn!("async_read: Unable to consume data");
-								Poll::Ready(Ok(0))
-							} else {
-								socket.register_recv_waker(cx.waker());
-								Poll::Pending
-							}
+				match socket.state() {
+					tcp::State::FinWait1
+					| tcp::State::FinWait2
+					| tcp::State::Closed
+					| tcp::State::Closing
+					| tcp::State::CloseWait
+					| tcp::State::TimeWait => Poll::Ready(Err(-crate::errno::EIO)),
+					_ => {
+						if socket.can_recv() {
+							warn!("async_read: Unable to consume data");
+							Poll::Ready(Ok(0))
+						} else {
+							socket.register_recv_waker(cx.waker());
+							Poll::Pending
 						}
 					}
-				})
+				}
 			})
-			.await?;
-
-			if n == 0 {
-				break;
-			}
-
-			pos += n;
-		}
-
-		Ok(pos.try_into().unwrap())
+		})
+		.await
 	}
 
 	async fn async_write(&self, buffer: &[u8]) -> Result<isize, i32> {

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -16,7 +16,8 @@ use crate::arch::interrupts;
 use crate::arch::switch::{switch_to_fpu_owner, switch_to_task};
 use crate::kernel::scheduler::TaskStacks;
 use crate::scheduler::task::*;
-pub mod task;
+
+pub(crate) mod task;
 
 static NO_TASKS: AtomicU32 = AtomicU32::new(0);
 /// Map between Core ID and per-core scheduler

--- a/src/scheduler/task.rs
+++ b/src/scheduler/task.rs
@@ -500,6 +500,8 @@ impl BlockedTaskQueue {
 				if let Some(node) = cursor.current() {
 					if node.wakeup_time.is_none() || wt < node.wakeup_time.unwrap() {
 						arch::set_oneshot_timer(wakeup_time);
+					} else {
+						arch::set_oneshot_timer(node.wakeup_time);
 					}
 				} else {
 					arch::set_oneshot_timer(wakeup_time);


### PR DESCRIPTION
For this purpose, it was necessary to avoid the creation of dynamic objects of the driver. This means that during compilation it must be defined which network interface is used. If the feature `rtl8139` is activated, the driver for Realtek 8139 will be used. Otherwise the Virtio network interface will be used.