### PR TITLE
using a futex to wakeup network tasks

### DIFF
--- a/src/executor/network.rs
+++ b/src/executor/network.rs
@@ -275,8 +275,6 @@ where
 			}
 		}
 
-		// disable all interrupts
-		interrupts::disable();
 		let delay = network_delay(now).map(|d| d.total_micros());
 		if backoff.is_completed() && delay.unwrap_or(10_000_000) > 10_000 {
 			let ticks = crate::arch::processor::get_timer_ticks();
@@ -288,9 +286,6 @@ where
 			// allow network interrupts
 			get_network_driver().unwrap().lock().set_polling_mode(false);
 
-			// enable interrupts
-			interrupts::enable();
-
 			// switch to another task
 			task_notify.wait(wakeup_time);
 
@@ -298,9 +293,6 @@ where
 			get_network_driver().unwrap().lock().set_polling_mode(true);
 			backoff.reset();
 		} else {
-			// enable interrupts
-			interrupts::enable();
-
 			backoff.snooze();
 		}
 	}

--- a/src/executor/network.rs
+++ b/src/executor/network.rs
@@ -17,7 +17,7 @@ use smoltcp::time::{Duration, Instant};
 use smoltcp::wire::{IpCidr, Ipv4Address, Ipv4Cidr};
 
 use crate::arch::core_local::*;
-use crate::arch::{self, interrupts};
+use crate::arch;
 #[cfg(not(feature = "pci"))]
 use crate::drivers::mmio::get_network_driver;
 use crate::drivers::net::NetworkDriver;

--- a/src/executor/network.rs
+++ b/src/executor/network.rs
@@ -16,8 +16,8 @@ use smoltcp::time::{Duration, Instant};
 #[cfg(feature = "dhcpv4")]
 use smoltcp::wire::{IpCidr, Ipv4Address, Ipv4Cidr};
 
-use crate::arch::core_local::*;
 use crate::arch;
+use crate::arch::core_local::*;
 #[cfg(not(feature = "pci"))]
 use crate::drivers::mmio::get_network_driver;
 use crate::drivers::net::NetworkDriver;

--- a/src/synch/futex.rs
+++ b/src/synch/futex.rs
@@ -89,6 +89,75 @@ pub fn futex_wait(address: &AtomicU32, expected: u32, timeout: Option<u64>, flag
 	}
 }
 
+/// If the value at address matches the expected value, park the current thread until it is either
+/// woken up with `futex_wake` (returns 0) or the specified timeout elapses (returns -ETIMEDOUT).
+/// In addition, the value `new_value` will stored at address.
+///
+/// The timeout is given in microseconds. If [`Flags::RELATIVE`] is given, it is interpreted as
+/// relative to the current time. Otherwise it is understood to be an absolute time
+/// (see `get_timer_ticks`).
+pub fn futex_wait_and_set(
+	address: &AtomicU32,
+	expected: u32,
+	timeout: Option<u64>,
+	flags: Flags,
+	new_val: u32,
+) -> i32 {
+	let mut parking_lot = PARKING_LOT.lock();
+	// Check the futex value after locking the parking lot so that all changes are observed.
+	if address.swap(new_val, SeqCst) != expected {
+		return -EAGAIN;
+	}
+
+	let wakeup_time = if flags.contains(Flags::RELATIVE) {
+		timeout.and_then(|t| get_timer_ticks().checked_add(t))
+	} else {
+		timeout
+	};
+
+	let scheduler = core_scheduler();
+	scheduler.block_current_task(wakeup_time);
+	let handle = scheduler.get_current_task_handle();
+	parking_lot.entry(addr(address)).or_default().push(handle);
+	drop(parking_lot);
+
+	loop {
+		scheduler.reschedule();
+
+		let mut parking_lot = PARKING_LOT.lock();
+		if matches!(wakeup_time, Some(t) if t <= get_timer_ticks()) {
+			let mut wakeup = true;
+			// Timeout occurred, try to remove ourselves from the waiting queue.
+			if let Entry::Occupied(mut queue) = parking_lot.entry(addr(address)) {
+				// If we are not in the waking queue, this must have been a wakeup.
+				wakeup = !queue.get_mut().remove(handle);
+				if queue.get().is_empty() {
+					queue.remove();
+				}
+			}
+
+			if wakeup {
+				return 0;
+			} else {
+				return -ETIMEDOUT;
+			}
+		} else {
+			// If we are not in the waking queue, this must have been a wakeup.
+			let wakeup = !matches!(parking_lot
+				.get(&addr(address)), Some(queue) if queue.contains(handle));
+
+			if wakeup {
+				return 0;
+			} else {
+				// A spurious wakeup occurred, sleep again.
+				// Tasks do not change core, so the handle in the parking lot is still current.
+				scheduler.block_current_task(wakeup_time);
+			}
+		}
+		drop(parking_lot);
+	}
+}
+
 /// Wake `count` threads waiting on the futex at address. Returns the number of threads
 /// woken up (saturates to `i32::MAX`). If `count` is `i32::MAX`, wake up all matching
 /// waiting threads. If `count` is negative, returns -EINVAL.


### PR DESCRIPTION
With the previous solution, the "wakeup" may occur before the task is blocked. So that this "wakeup" is not lost, futexes are used. If there is no blocking task available, the value of the futex is changed so that the next task is able to see that a wakeup was already arrived and the task does not have to block. 