### PR TITLE
fix mapping of 1GB pages

### DIFF
--- a/src/arch/aarch64/kernel/processor.rs
+++ b/src/arch/aarch64/kernel/processor.rs
@@ -152,6 +152,7 @@ pub fn get_timestamp() -> u64 {
 }
 
 #[inline]
+#[allow(dead_code)]
 pub fn supports_1gib_pages() -> bool {
 	false
 }

--- a/src/arch/aarch64/mm/paging.rs
+++ b/src/arch/aarch64/mm/paging.rs
@@ -611,13 +611,11 @@ pub fn map_heap<S: PageSize>(virt_addr: VirtAddr, count: usize) -> Result<(), us
 	};
 
 	let virt_addrs = (0..count).map(|n| virt_addr + n * S::SIZE as usize);
-	let mut map_counter: usize = 0;
 
-	for virt_addr in virt_addrs {
+	for (map_counter, virt_addr) in virt_addrs.enumerate() {
 		let phys_addr = physicalmem::allocate_aligned(S::SIZE as usize, S::SIZE as usize)
 			.map_err(|_| map_counter)?;
 		map::<S>(virt_addr, phys_addr, 1, flags);
-		map_counter += 1;
 	}
 
 	Ok(())

--- a/src/arch/aarch64/mm/paging.rs
+++ b/src/arch/aarch64/mm/paging.rs
@@ -601,7 +601,9 @@ pub fn map<S: PageSize>(
 	root_pagetable.map_pages(range, physical_address, flags);
 }
 
-pub fn map_heap<S: PageSize>(virt_addr: VirtAddr, count: usize) {
+/// Maps `count` pages at address `virt_addr`. If the allocation of a physical memory failed,
+/// the number of successfull mapped pages are returned as error value.
+pub fn map_heap<S: PageSize>(virt_addr: VirtAddr, count: usize) -> Result<(), usize> {
 	let flags = {
 		let mut flags = PageTableEntryFlags::empty();
 		flags.normal().writable().execute_disable();
@@ -609,11 +611,16 @@ pub fn map_heap<S: PageSize>(virt_addr: VirtAddr, count: usize) {
 	};
 
 	let virt_addrs = (0..count).map(|n| virt_addr + n * S::SIZE as usize);
+	let mut map_counter: usize = 0;
 
 	for virt_addr in virt_addrs {
-		let phys_addr = physicalmem::allocate_aligned(S::SIZE as usize, S::SIZE as usize).unwrap();
+		let phys_addr = physicalmem::allocate_aligned(S::SIZE as usize, S::SIZE as usize)
+			.map_err(|_| map_counter)?;
 		map::<S>(virt_addr, phys_addr, 1, flags);
+		map_counter += 1;
 	}
+
+	Ok(())
 }
 
 pub fn unmap<S: PageSize>(virtual_address: VirtAddr, count: usize) {

--- a/src/arch/x86_64/mm/paging.rs
+++ b/src/arch/x86_64/mm/paging.rs
@@ -152,13 +152,11 @@ where
 	};
 
 	let virt_addrs = (0..count).map(|n| virt_addr + n * S::SIZE as usize);
-	let mut map_counter: usize = 0;
 
-	for virt_addr in virt_addrs {
+	for (map_counter, virt_addr) in virt_addrs.enumerate() {
 		let phys_addr = physicalmem::allocate_aligned(S::SIZE as usize, S::SIZE as usize)
 			.map_err(|_| map_counter)?;
 		map::<S>(virt_addr, phys_addr, 1, flags);
-		map_counter += 1;
 	}
 
 	Ok(())

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -10,10 +10,10 @@ use hermit_sync::Lazy;
 use hermit_sync::OnceCell;
 
 #[cfg(target_arch = "x86_64")]
+use crate::arch::mm::paging::HugePageSize;
+#[cfg(target_arch = "x86_64")]
 use crate::arch::mm::paging::PageTableEntryFlagsExt;
-use crate::arch::mm::paging::{
-	BasePageSize, HugePageSize, LargePageSize, PageSize, PageTableEntryFlags,
-};
+use crate::arch::mm::paging::{BasePageSize, LargePageSize, PageSize, PageTableEntryFlags};
 use crate::arch::mm::physicalmem::total_memory_size;
 #[cfg(feature = "newlib")]
 use crate::arch::mm::virtualmem::kernel_heap_end;
@@ -82,6 +82,7 @@ pub(crate) fn init() {
 	let reserved_space = (npage_3tables + npage_2tables + npage_1tables)
 		* BasePageSize::SIZE as usize
 		+ LargePageSize::SIZE as usize;
+	#[cfg(target_arch = "x86_64")]
 	let has_1gib_pages = arch::processor::supports_1gib_pages();
 	let has_2mib_pages = arch::processor::supports_2mib_pages();
 


### PR DESCRIPTION
`map_heap` can be fail because due to fragmentation it isn't enough continuous memory for 1GB pages available. Consequently, `map_heap` returns as error value the number of sucessfully mapped pages. On success, all requested pages are mapped into the memory.