### PR TITLE
using Ethernet MTU instead IP MTU

### DIFF
--- a/src/drivers/net/rtl8139.rs
+++ b/src/drivers/net/rtl8139.rs
@@ -578,7 +578,7 @@ pub(crate) fn init_device(
 
 	Ok(RTL8139Driver {
 		iobase,
-		mtu: 1500,
+		mtu: 1514,
 		irq,
 		mac,
 		tx_in_use: [false; NO_TX_BUFFERS],

--- a/src/drivers/net/virtio_mmio.rs
+++ b/src/drivers/net/virtio_mmio.rs
@@ -123,12 +123,12 @@ impl VirtioNetDriver {
 		let notif_cfg = NotifCfg::new(registers);
 
 		let mtu = if let Some(my_mtu) = hermit_var!("HERMIT_MTU") {
-			u16::from_str(&my_mtu).unwrap()
+			u16::from_str(&my_mtu).unwrap() + 14
 		} else if dev_cfg.features.is_feature(Features::VIRTIO_NET_F_MTU) {
 			dev_cfg.raw.get_mtu()
 		} else {
 			// fallback to the default MTU
-			1500
+			1514
 		};
 
 		Ok(VirtioNetDriver {

--- a/src/drivers/net/virtio_net.rs
+++ b/src/drivers/net/virtio_net.rs
@@ -247,7 +247,7 @@ impl RxQueues {
 			//
 			let buff_def = [
 				Bytes::new(mem::size_of::<VirtioNetHdr>()).unwrap(),
-				Bytes::new((dev_cfg.raw.get_mtu() as usize) + ETH_HDR).unwrap(),
+				Bytes::new(dev_cfg.raw.get_mtu() as usize).unwrap(),
 			];
 			let spec = if dev_cfg
 				.features
@@ -256,10 +256,8 @@ impl RxQueues {
 				BuffSpec::Indirect(&buff_def)
 			} else {
 				BuffSpec::Single(
-					Bytes::new(
-						mem::size_of::<VirtioNetHdr>() + dev_cfg.raw.get_mtu() as usize + ETH_HDR,
-					)
-					.unwrap(),
+					Bytes::new(mem::size_of::<VirtioNetHdr>() + dev_cfg.raw.get_mtu() as usize)
+						.unwrap(),
 				)
 			};
 
@@ -430,10 +428,9 @@ impl TxQueues {
 				//      Header and data are added as ONE output descriptor to the transmitvq.
 				//      Hence we are interpreting this, as the fact, that send packets must be inside a single descriptor.
 				// As usize is currently safe as the minimal usize is defined as 16bit in rust.
-				let buff_def = Bytes::new(
-					mem::size_of::<VirtioNetHdr>() + (dev_cfg.raw.get_mtu() as usize) + ETH_HDR,
-				)
-				.unwrap();
+				let buff_def =
+					Bytes::new(mem::size_of::<VirtioNetHdr>() + dev_cfg.raw.get_mtu() as usize)
+						.unwrap();
 				let spec = BuffSpec::Single(buff_def);
 
 				let num_buff: u16 = vq.size().into();

--- a/src/drivers/net/virtio_pci.rs
+++ b/src/drivers/net/virtio_pci.rs
@@ -132,12 +132,12 @@ impl VirtioNetDriver {
 		};
 
 		let mtu = if let Some(my_mtu) = hermit_var!("HERMIT_MTU") {
-			u16::from_str(&my_mtu).unwrap()
+			u16::from_str(&my_mtu).unwrap() + 14
 		} else if dev_cfg.features.is_feature(Features::VIRTIO_NET_F_MTU) {
 			dev_cfg.raw.get_mtu()
 		} else {
 			// fallback to the default MTU
-			1500
+			1514
 		};
 
 		Ok(VirtioNetDriver {


### PR DESCRIPTION
smoltcp uses the Ethernet MTU as definition for the maximum transmission unit. Linux defines MTU as IP MTU. libhermit based on smoltcp and should uses the same definition. Consequently, the default MTU is 1514, which is the default IP MTU (1500) + size of the ethernet header.