### PR TITLE
add support of VIRTIO_NET_F_CSUM

### DIFF
--- a/src/drivers/net/mod.rs
+++ b/src/drivers/net/mod.rs
@@ -7,6 +7,8 @@ pub mod virtio_net;
 #[cfg(all(feature = "pci", not(feature = "rtl8139")))]
 pub mod virtio_pci;
 
+use smoltcp::phy::ChecksumCapabilities;
+
 #[cfg(target_arch = "x86_64")]
 use crate::arch::kernel::apic;
 #[allow(unused_imports)]
@@ -23,6 +25,10 @@ use crate::executor::device::{RxToken, TxToken};
 
 /// A trait for accessing the network interface
 pub(crate) trait NetworkDriver {
+	/// Returns smoltcp's checksum capabilities
+	fn get_checksums(&self) -> ChecksumCapabilities {
+		ChecksumCapabilities::default()
+	}
 	/// Returns the mac address of the device.
 	fn get_mac_address(&self) -> [u8; 6];
 	/// Returns the current MTU of the device.
@@ -39,10 +45,6 @@ pub(crate) trait NetworkDriver {
 	fn set_polling_mode(&mut self, value: bool);
 	/// Handle interrupt and check if a packet is available
 	fn handle_interrupt(&mut self) -> bool;
-	/// Returns true, if the device has to create checksums
-	fn with_checksums(&self) -> bool {
-		true
-	}
 }
 
 #[inline]

--- a/src/drivers/net/virtio_mmio.rs
+++ b/src/drivers/net/virtio_mmio.rs
@@ -10,6 +10,8 @@ use core::ptr::read_volatile;
 use core::str::FromStr;
 use core::sync::atomic::{fence, Ordering};
 
+use smoltcp::phy::ChecksumCapabilities;
+
 use crate::drivers::net::virtio_net::constants::{FeatureSet, Status};
 use crate::drivers::net::virtio_net::{CtrlQueue, NetDevCfg, RxQueues, TxQueues, VirtioNetDriver};
 use crate::drivers::virtio::error::{VirtioError, VirtioNetError};
@@ -149,6 +151,7 @@ impl VirtioNetDriver {
 			num_vqs: 0,
 			irq,
 			mtu,
+			checksums: ChecksumCapabilities::default(),
 		})
 	}
 

--- a/src/drivers/net/virtio_net.rs
+++ b/src/drivers/net/virtio_net.rs
@@ -11,6 +11,7 @@ use core::mem;
 use core::result::Result;
 
 use pci_types::InterruptLine;
+use smoltcp::phy::{Checksum, ChecksumCapabilities};
 use zerocopy::AsBytes;
 
 use self::constants::{FeatureSet, Features, NetHdrFlag, NetHdrGSO, Status, MAX_NUM_VQ};
@@ -522,6 +523,7 @@ pub(crate) struct VirtioNetDriver {
 	pub(super) num_vqs: u16,
 	pub(super) irq: InterruptLine,
 	pub(super) mtu: u16,
+	pub(super) checksums: ChecksumCapabilities,
 }
 
 impl NetworkDriver for VirtioNetDriver {
@@ -538,6 +540,10 @@ impl NetworkDriver for VirtioNetDriver {
 	/// Returns the current MTU of the device.
 	fn get_mtu(&self) -> u16 {
 		self.mtu
+	}
+
+	fn get_checksums(&self) -> ChecksumCapabilities {
+		self.checksums.clone()
 	}
 
 	fn has_packet(&self) -> bool {
@@ -573,7 +579,7 @@ impl NetworkDriver for VirtioNetDriver {
 
 			// If a checksum isn't necessary, we have inform the host within the header
 			// see Virtio specification 5.1.6.2
-			if !self.with_checksums() {
+			if !self.checksums.tcp.tx() || !self.checksums.udp.tx() {
 				let type_ = unsafe { u16::from_be(*(buff_ptr.offset(12) as *const u16)) };
 
 				match type_ {
@@ -708,15 +714,6 @@ impl NetworkDriver for VirtioNetDriver {
 
 		result
 	}
-
-	/// Returns `true` if the device supports the virtio feature
-	/// `VIRTIO_NET_F_GUEST_CSUM` and trust the incoming packages.
-	fn with_checksums(&self) -> bool {
-		!self
-			.dev_cfg
-			.features
-			.is_feature(Features::VIRTIO_NET_F_GUEST_CSUM)
-	}
 }
 
 // Backend-independent interface for Virtio network driver
@@ -836,8 +833,10 @@ impl VirtioNetDriver {
 		feats.push(Features::VIRTIO_NET_F_MTU);
 		// Packed Vq can be used
 		feats.push(Features::VIRTIO_F_RING_PACKED);
-		// Avoid the creation of checksums
+		// Guest avoids the creation of checksums
 		feats.push(Features::VIRTIO_NET_F_GUEST_CSUM);
+		// Host should the creation of checksums
+		feats.push(Features::VIRTIO_NET_F_CSUM);
 
 		// Currently the driver does NOT support the features below.
 		// In order to provide functionality for these, the driver
@@ -929,6 +928,34 @@ impl VirtioNetDriver {
 		// At this point the device is "live"
 		self.com_cfg.drv_ok();
 
+		if self
+			.dev_cfg
+			.features
+			.is_feature(Features::VIRTIO_NET_F_CSUM)
+			&& self
+				.dev_cfg
+				.features
+				.is_feature(Features::VIRTIO_NET_F_GUEST_CSUM)
+		{
+			self.checksums.udp = Checksum::None;
+			self.checksums.tcp = Checksum::None;
+		} else if self
+			.dev_cfg
+			.features
+			.is_feature(Features::VIRTIO_NET_F_CSUM)
+		{
+			self.checksums.udp = Checksum::Rx;
+			self.checksums.tcp = Checksum::Rx;
+		} else if self
+			.dev_cfg
+			.features
+			.is_feature(Features::VIRTIO_NET_F_GUEST_CSUM)
+		{
+			self.checksums.udp = Checksum::Tx;
+			self.checksums.tcp = Checksum::Tx;
+		}
+		info!("{:?}", self.checksums);
+
 		if self.dev_cfg.features.is_feature(Features::VIRTIO_NET_F_MTU) {
 			self.mtu = self.dev_cfg.raw.get_mtu();
 		}
@@ -1003,11 +1030,6 @@ impl VirtioNetDriver {
 			}
 
 			self.ctrl_vq.0.as_ref().unwrap().enable_notifs();
-		}
-
-		// If device does not take care of MAC address, the driver has to create one
-		if !self.dev_cfg.features.is_feature(Features::VIRTIO_NET_F_MAC) {
-			todo!("Driver created MAC address should be passed to device here.")
 		}
 
 		Ok(())

--- a/src/drivers/net/virtio_net.rs
+++ b/src/drivers/net/virtio_net.rs
@@ -835,7 +835,7 @@ impl VirtioNetDriver {
 		feats.push(Features::VIRTIO_F_RING_PACKED);
 		// Guest avoids the creation of checksums
 		feats.push(Features::VIRTIO_NET_F_GUEST_CSUM);
-		// Host should the creation of checksums
+		// Host should avoid the creation of checksums
 		feats.push(Features::VIRTIO_NET_F_CSUM);
 
 		// Currently the driver does NOT support the features below.

--- a/src/drivers/net/virtio_net.rs
+++ b/src/drivers/net/virtio_net.rs
@@ -937,6 +937,7 @@ impl VirtioNetDriver {
 				.features
 				.is_feature(Features::VIRTIO_NET_F_GUEST_CSUM)
 		{
+			self.checksums.ipv4 = Checksum::Tx;
 			self.checksums.udp = Checksum::None;
 			self.checksums.tcp = Checksum::None;
 		} else if self
@@ -951,6 +952,7 @@ impl VirtioNetDriver {
 			.features
 			.is_feature(Features::VIRTIO_NET_F_GUEST_CSUM)
 		{
+			self.checksums.ipv4 = Checksum::Tx;
 			self.checksums.udp = Checksum::Tx;
 			self.checksums.tcp = Checksum::Tx;
 		}

--- a/src/drivers/net/virtio_pci.rs
+++ b/src/drivers/net/virtio_pci.rs
@@ -8,6 +8,8 @@ use alloc::vec::Vec;
 use core::cell::RefCell;
 use core::str::FromStr;
 
+use smoltcp::phy::ChecksumCapabilities;
+
 use crate::arch::pci::PciConfigRegion;
 use crate::drivers::net::virtio_net::constants::FeatureSet;
 use crate::drivers::net::virtio_net::{CtrlQueue, NetDevCfg, RxQueues, TxQueues, VirtioNetDriver};
@@ -159,6 +161,7 @@ impl VirtioNetDriver {
 			num_vqs: 0,
 			irq: device.get_irq().unwrap(),
 			mtu,
+			checksums: ChecksumCapabilities::default(),
 		})
 	}
 


### PR DESCRIPTION
If the host is able to send packets with partial checksum, the driver will not check these checksums.