### PR TITLE
uses Ehernet MTU as definition of HERMIT_MTU

### DIFF
--- a/src/drivers/net/virtio_mmio.rs
+++ b/src/drivers/net/virtio_mmio.rs
@@ -125,7 +125,7 @@ impl VirtioNetDriver {
 		let notif_cfg = NotifCfg::new(registers);
 
 		let mtu = if let Some(my_mtu) = hermit_var!("HERMIT_MTU") {
-			u16::from_str(&my_mtu).unwrap() + 14
+			u16::from_str(&my_mtu).unwrap()
 		} else {
 			// fallback to the default MTU
 			1514

--- a/src/drivers/net/virtio_pci.rs
+++ b/src/drivers/net/virtio_pci.rs
@@ -134,7 +134,7 @@ impl VirtioNetDriver {
 		};
 
 		let mtu = if let Some(my_mtu) = hermit_var!("HERMIT_MTU") {
-			u16::from_str(&my_mtu).unwrap() + 14
+			u16::from_str(&my_mtu).unwrap()
 		} else {
 			// fallback to the default MTU
 			1514


### PR DESCRIPTION
Consequently, the same definition like smoltcp is used.